### PR TITLE
Proper capitalization of app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Group Folders
+# Group folders
 
 Admin configured folders shared by everyone in a group.
 
 ## Configure folders
 
-Folders can be configured from *Group Folders* in the admin settings.
+Folders can be configured from *Group folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more groups.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <info>
 	<id>groupfolders</id>
-	<name>Group Folders</name>
+	<name>Group folders</name>
 	<summary>Admin configured folders shared by everyone in a group</summary>
 	<description><![CDATA[Admin configured folders shared by everyone in a group.
 
-Folders can be configured from *Group Folders* in the admin settings.
+Folders can be configured from *Group folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more groups.]]></description>
 	<licence>AGPL</licence>

--- a/build/bundle.css
+++ b/build/bundle.css
@@ -11,7 +11,6 @@
 }
 .group-edit img {
   opacity: 0;
-  -webkit-transition: opactity 0.5s;
   transition: opactity 0.5s;
 }
 .group-edit tr:hover img {
@@ -59,7 +58,6 @@
 #groupfolders-react-root .icon {
   display: inline-block;
   opacity: 0.5;
-  -webkit-transition: opacity 0.5s;
   transition: opacity 0.5s;
 }
 

--- a/lib/Settings/Section.php
+++ b/lib/Settings/Section.php
@@ -53,7 +53,7 @@ class Section implements IIconSection {
 	 * @return string
 	 */
 	public function getName() {
-		return $this->l->t('Group Folders');
+		return $this->l->t('Group folders');
 	}
 
 	/**

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,7 +5,7 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 >
-	<testsuite name='Nextcloud - Group Folders App Tests'>
+	<testsuite name='Nextcloud - Group folders App Tests'>
 		<directory suffix='.php'>.</directory>
 	</testsuite>
 	<filter>
@@ -21,4 +21,3 @@
 		<log type="coverage-clover" target="./clover.xml"/>
 	</logging>
 </phpunit>
-


### PR DESCRIPTION
We only ever capitalize the first word, unless the others are brand names.

»Group folders« hence. Please review @icewind1991 @LukasReschke 