### PR TITLE
No need for babel-polyfill, since it is already included with 16

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -9,7 +9,6 @@ module.exports = {
 	mode: 'production',
 	entry: {
 		app: [
-			`babel-polyfill`,
 			`whatwg-fetch`,
 			'./js/index.tsx'
 		],


### PR DESCRIPTION
Otherwise there will be complaints about babel-polyfill being loaded twice.