### PR TITLE
Explicitly cast timestamp

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -199,7 +199,7 @@ class TrashBackend implements ITrashBackend {
 			$content = $trashFolder->getDirectoryListing();
 			foreach ($content as $item) {
 				$pathParts = pathinfo($item->getName());
-				$timestamp = substr($pathParts['extension'], 1);
+				$timestamp = (int)substr($pathParts['extension'], 1);
 				$name = $pathParts['filename'];
 				$key = $folderId . '/' . $name . '/' . $timestamp;
 				$originalLocation = isset($indexedRows[$key]) ? $indexedRows[$key]['original_location'] : '';


### PR DESCRIPTION
This avoids passing an empty string instead of an integer when used with S3 backend as primary storage.