### PR TITLE
Prepare release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-1.2.0
+## 3.0.1
+
+This release is aimed for Nextcloud 14/15 users who upgraded to 3.0.0 which was
+falsely marked as compatible for those Nextcloud releases.
+
+## 1.2.0
 
  - Allow changing the mount point of existing group folders
  - Add OCS api for managing folders

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
 webpack=node_modules/.bin/webpack
-version+=2.0.4
+version+=3.0.1
 
 jssources=$(wildcard js/*) $(wildcard js/*/*) $(wildcard css/*/*)  $(wildcard css/*)
 othersources=$(wildcard appinfo/*) $(wildcard css/*/*) $(wildcard controller/*/*) $(wildcard templates/*/*) $(wildcard log/*/*)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ Folders can be configured from *Group folders* in the admin settings.
 After a folder is created, the admin can give access to the folder to one or more groups, control their write/sharing permissions and assign a quota for the folder.
 
 Note: encrypting the contents of group folders is currently not supported.]]></description>
-	<version>2.0.4</version>
+	<version>3.0.1</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>
@@ -29,7 +29,7 @@ Note: encrypting the contents of group folders is currently not supported.]]></d
 	<screenshot>https://raw.githubusercontent.com/nextcloud/groupfolders/master/screenshots/permissions.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="14" max-version="16"/>
+		<nextcloud min-version="14" max-version="15"/>
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
This version will make sure users who upgraded to 3.0.0 which was falsely marked as 14/15 compatible will get a working version again. So 3.0.1 is basically 2.0.4 without 16 compatibility.