### PR TITLE
Make sure we always trim the first path separator

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -110,6 +110,7 @@ class ACLManager {
 	}
 
 	public function getACLPermissionsForPath(string $path): int {
+		$path = ltrim($path, '/');
 		$rules = $this->getRules($this->getParents($path));
 
 		return array_reduce($rules, function (int $permissions, array $rules) {
@@ -125,6 +126,7 @@ class ACLManager {
 	 * @return int
 	 */
 	public function getPermissionsForTree(string $path): int {
+		$path = ltrim($path, '/');
 		$rules = $this->ruleManager->getRulesForPrefix($this->user, $this->getRootStorageId(), $path);
 
 		return array_reduce($rules, function (int $permissions, array $rules) {

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -147,7 +147,6 @@ class ACLStorageWrapper extends Wrapper {
 	 * @return int
 	 */
 	private function canDeleteTree(string $path): int {
-		$path = ltrim($path, '/');
 		return $this->aclManager->getPermissionsForTree($path) & Constants::PERMISSION_DELETE;
 	}
 


### PR DESCRIPTION
Otherwise we end up with a rules cache with duplicate entries for the same path
that might not contain ACL rules

