### PR TITLE
Check if the parent folder is updatable when moving

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ Note: encrypting the contents of group folders is currently not supported.]]></d
 	<screenshot>https://raw.githubusercontent.com/nextcloud/groupfolders/master/screenshots/permissions.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="17" max-version="17" />
+		<nextcloud min-version="17" max-version="18" />
 	</dependencies>
 
 	<background-jobs>

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -88,8 +88,11 @@ class ACLStorageWrapper extends Wrapper {
 			}
 		}
 		$permissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		$checkParentPermissions = !$this->is_dir($path1) || $this->checkPermissions(dirname($path1), Constants::PERMISSION_UPDATE);
-		return $checkParentPermissions &&
+		$sourceParent = dirname($path1);
+		if ($sourceParent === '.') {
+			$sourceParent = '';
+		}
+		return $this->checkPermissions($sourceParent, Constants::PERMISSION_DELETE) &&
 			$this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ) &&
 			$this->checkPermissions($path2, $permissions) &&
 			parent::rename($path1, $path2);

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -88,7 +88,9 @@ class ACLStorageWrapper extends Wrapper {
 			}
 		}
 		$permissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ) and
+		$checkParentPermissions = !$this->is_dir($path1) or $this->checkPermissions(dirname($path1), Constants::PERMISSION_UPDATE);
+		return $checkParentPermissions and
+			$this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ) and
 			$this->checkPermissions($path2, $permissions) and
 			parent::rename($path1, $path2);
 	}

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -54,25 +54,25 @@ class ACLStorageWrapper extends Wrapper {
 	}
 
 	public function isReadable($path) {
-		return $this->checkPermissions($path, Constants::PERMISSION_READ) and parent::isReadable($path);
+		return $this->checkPermissions($path, Constants::PERMISSION_READ) && parent::isReadable($path);
 	}
 
 	public function isUpdatable($path) {
-		return $this->checkPermissions($path, Constants::PERMISSION_UPDATE) and parent::isUpdatable($path);
+		return $this->checkPermissions($path, Constants::PERMISSION_UPDATE) && parent::isUpdatable($path);
 	}
 
 	public function isCreatable($path) {
-		return $this->checkPermissions($path, Constants::PERMISSION_CREATE) and parent::isCreatable($path);
+		return $this->checkPermissions($path, Constants::PERMISSION_CREATE) && parent::isCreatable($path);
 	}
 
 	public function isDeletable($path) {
 		return $this->checkPermissions($path, Constants::PERMISSION_DELETE)
-			and $this->canDeleteTree($path)
-			and parent::isDeletable($path);
+			&& $this->canDeleteTree($path)
+			&& parent::isDeletable($path);
 	}
 
 	public function isSharable($path) {
-		return $this->checkPermissions($path, Constants::PERMISSION_SHARE) and parent::isSharable($path);
+		return $this->checkPermissions($path, Constants::PERMISSION_SHARE) && parent::isSharable($path);
 	}
 
 	public function getPermissions($path) {
@@ -84,14 +84,14 @@ class ACLStorageWrapper extends Wrapper {
 			$part = substr($path1, strlen($path2));
 			//This is a rename of the transfer file to the original file
 			if (strpos($part, '.ocTransferId') === 0) {
-				return $this->checkPermissions($path2, Constants::PERMISSION_CREATE) and parent::rename($path1, $path2);
+				return $this->checkPermissions($path2, Constants::PERMISSION_CREATE) && parent::rename($path1, $path2);
 			}
 		}
 		$permissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		$checkParentPermissions = !$this->is_dir($path1) or $this->checkPermissions(dirname($path1), Constants::PERMISSION_UPDATE);
-		return $checkParentPermissions and
-			$this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ) and
-			$this->checkPermissions($path2, $permissions) and
+		$checkParentPermissions = !$this->is_dir($path1) || $this->checkPermissions(dirname($path1), Constants::PERMISSION_UPDATE);
+		return $checkParentPermissions &&
+			$this->checkPermissions($path1, Constants::PERMISSION_UPDATE & Constants::PERMISSION_READ) &&
+			$this->checkPermissions($path2, $permissions) &&
 			parent::rename($path1, $path2);
 	}
 
@@ -115,30 +115,30 @@ class ACLStorageWrapper extends Wrapper {
 
 	public function copy($path1, $path2) {
 		$permissions = $this->file_exists($path2) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkPermissions($path2, $permissions) and
-			$this->checkPermissions($path1, Constants::PERMISSION_READ) and
+		return $this->checkPermissions($path2, $permissions) &&
+			$this->checkPermissions($path1, Constants::PERMISSION_READ) &&
 			parent::copy($path1, $path2);
 	}
 
 	public function touch($path, $mtime = null) {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
-		return $this->checkPermissions($path, $permissions) and parent::touch($path, $mtime);
+		return $this->checkPermissions($path, $permissions) && parent::touch($path, $mtime);
 	}
 
 	public function mkdir($path) {
-		return $this->checkPermissions($path, Constants::PERMISSION_CREATE) and parent::mkdir($path);
+		return $this->checkPermissions($path, Constants::PERMISSION_CREATE) && parent::mkdir($path);
 	}
 
 	public function rmdir($path) {
 		return $this->checkPermissions($path, Constants::PERMISSION_DELETE)
-			and $this->canDeleteTree($path)
-			and parent::rmdir($path);
+			&& $this->canDeleteTree($path)
+			&& parent::rmdir($path);
 	}
 
 	public function unlink($path) {
 		return $this->checkPermissions($path, Constants::PERMISSION_DELETE)
-			and $this->canDeleteTree($path)
-			and parent::unlink($path);
+			&& $this->canDeleteTree($path)
+			&& parent::unlink($path);
 	}
 
 	/**

--- a/tests/ACL/ACLStorageWrapperTest.php
+++ b/tests/ACL/ACLStorageWrapperTest.php
@@ -85,4 +85,18 @@ class ACLStorageWrapperTest extends TestCase {
 		sort($expected);
 		$this->assertEquals($expected, $result);
 	}
+
+	public function testMove() {
+		$this->source->mkdir('foo');
+		$this->source->touch('file1');
+
+		$this->aclPermissions[''] = Constants::PERMISSION_READ;
+		$this->aclPermissions['foo'] = Constants::PERMISSION_ALL;
+
+		$this->assertFalse($this->storage->rename('file1', 'foo/file1'));
+
+		$this->aclPermissions[''] = Constants::PERMISSION_READ + Constants::PERMISSION_DELETE;
+
+		$this->assertTrue($this->storage->rename('file1', 'foo/file1'));
+	}
 }


### PR DESCRIPTION
When moving folders we should also check if the parent folder is actually updatable. Otherwise users could mess with the folder structure.

Try moving FolderA into FolderB with the following ACL applied:
- Groupfolder/  READ 
- Groupfolder/FolderA/  READ WRITE UPDATE DELETE
- Groupfolder/FolderB/  READ WRITE UPDATE DELETE

