### PR TITLE
Return proper owner for storage

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -24,6 +24,7 @@ namespace OCA\GroupFolders\Mount;
 
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\IUserSession;
 
 class GroupFolderStorage extends Quota {
 	/** @var int */
@@ -32,12 +33,16 @@ class GroupFolderStorage extends Quota {
 	/** @var ICacheEntry */
 	private $rootEntry;
 
+	/** @var IUserSession */
+	private $userSession;
+
 	public $cache;
 
 	public function __construct($parameters) {
 		parent::__construct($parameters);
 		$this->folderId = $parameters['folder_id'];
 		$this->rootEntry = $parameters['rootCacheEntry'];
+		$this->userSession = $parameters['userSession'];
 	}
 
 	public function getFolderId() {
@@ -45,7 +50,8 @@ class GroupFolderStorage extends Quota {
 	}
 
 	public function getOwner($path) {
-		return \OC_User::getUser();
+		$user = $this->userSession->getUser();
+		return $user !== null ? $user->getUID() : false;
 	}
 
 	public function instanceOfStorage($class) {

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -44,6 +44,10 @@ class GroupFolderStorage extends Quota {
 		return $this->folderId;
 	}
 
+	public function getOwner($path) {
+		return \OC_User::getUser();
+	}
+
 	public function instanceOfStorage($class) {
 		// "implement" the interface without adding a hard dependency on nc15
 		if ($class === 'OCP\Files\Storage\IDisableEncryptionStorage') {

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -165,7 +165,8 @@ class MountProvider implements IMountProvider {
 			'storage' => $baseStorage,
 			'quota' => $quota,
 			'folder_id' => $id,
-			'rootCacheEntry' => $cacheEntry
+			'rootCacheEntry' => $cacheEntry,
+			'userSession' => $this->userSession
 		]);
 		$maskedStore = new PermissionsMask([
 			'storage' => $quotaStorage,


### PR DESCRIPTION
When sharing a file from a groupfolder with the ocs api without an active session the trash and version backend are registered before the current user session has been initialized though the login. This leads to https://github.com/nextcloud/server/blob/4560bf939b32c4e07550bc1280827dcebc4eada1/lib/private/Files/Storage/Common.php#L406-L410 being called and caching false as the owner for the group folder storage.

Now when sharing a file it is assumed that there is always an owner (which will be fixed with https://github.com/nextcloud/server/pull/17489) but I assume it would be safer to make sure the current user is always assumed as the owner in case it is checked in other places as well.

Fixes https://github.com/nextcloud/groupfolders/issues/271