### PR TITLE
Show inherited acls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -140,21 +140,20 @@ client.addFileInfoParser(function(response) {
 		data.aclCanManage = !!aclCanManage;
 	}
 
-	var acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST];
-	var inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST];
+	var acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST] || [];
+	var inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST] || [];
 
-	if (!_.isUndefined(acls)) {
-		data.acl = parseAclList(acls);
-		data.inheritedAcls = parseAclList(inheritedAcls);
+	data.acl = parseAclList(acls);
+	data.inheritedAcls = parseAclList(inheritedAcls);
 
-		data.acl.map((acl) => {
-			let inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
-			if (inheritedAcl) {
-				acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
-			}
-			return acl;
-		})
-	}
+	data.acl.map((acl) => {
+		let inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
+		if (inheritedAcl) {
+			acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
+		}
+		return acl;
+	})
+
 	return data;
 });
 patchClientForNestedPropPatch(client);
@@ -167,14 +166,35 @@ class AclDavService {
 			} ).then((status, fileInfo) => {
 				if (fileInfo) {
 					let acls = []
+					let existingMappings = {};
 					for ( let i in fileInfo.acl ) {
-						let acl = new Rule()
+						let acl = new Rule();
 						acl.fromValues(
 							fileInfo.acl[i].mappingType,
 							fileInfo.acl[i].mappingId,
 							fileInfo.acl[i].mappingDisplayName,
 							fileInfo.acl[i].mask,
 							fileInfo.acl[i].permissions,
+						)
+						acls.push(acl);
+
+						if (existingMappings[fileInfo.acl[i].mappingType] == null) {
+							existingMappings[fileInfo.acl[i].mappingType] = new Set();
+						}
+						existingMappings[fileInfo.acl[i].mappingType].add(fileInfo.acl[i].mappingId);
+					}
+					for ( let i in fileInfo.inheritedAcls ) {
+						if (existingMappings[fileInfo.inheritedAcls[i].mappingType] != null && existingMappings[fileInfo.inheritedAcls[i].mappingType].has(fileInfo.inheritedAcls[i].mappingId)) {
+							continue;
+						}
+
+						let acl = new Rule();
+						acl.fromValues(
+							fileInfo.inheritedAcls[i].mappingType,
+							fileInfo.inheritedAcls[i].mappingId,
+							fileInfo.inheritedAcls[i].mappingDisplayName,
+							fileInfo.inheritedAcls[i].mask,
+							fileInfo.inheritedAcls[i].permissions,
 						)
 						acls.push(acl);
 					}

--- a/src/client.js
+++ b/src/client.js
@@ -165,8 +165,8 @@ class AclDavService {
 			properties: [ACL_PROPERTIES.PROPERTY_ACL_LIST, ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST, ACL_PROPERTIES.GROUP_FOLDER_ID, ACL_PROPERTIES.PROPERTY_ACL_ENABLED, ACL_PROPERTIES.PROPERTY_ACL_CAN_MANAGE]
 			} ).then((status, fileInfo) => {
 				if (fileInfo) {
-					let acls = []
-					let existingMappings = {};
+					let aclsById = {};
+					let inheritedAclsById = {};
 					for ( let i in fileInfo.acl ) {
 						let acl = new Rule();
 						acl.fromValues(
@@ -176,18 +176,9 @@ class AclDavService {
 							fileInfo.acl[i].mask,
 							fileInfo.acl[i].permissions,
 						)
-						acls.push(acl);
-
-						if (existingMappings[fileInfo.acl[i].mappingType] == null) {
-							existingMappings[fileInfo.acl[i].mappingType] = new Set();
-						}
-						existingMappings[fileInfo.acl[i].mappingType].add(fileInfo.acl[i].mappingId);
+						aclsById[acl.getUniqueMappingIdentifier()] = acl;
 					}
 					for ( let i in fileInfo.inheritedAcls ) {
-						if (existingMappings[fileInfo.inheritedAcls[i].mappingType] != null && existingMappings[fileInfo.inheritedAcls[i].mappingType].has(fileInfo.inheritedAcls[i].mappingId)) {
-							continue;
-						}
-
 						let acl = new Rule();
 						acl.fromValues(
 							fileInfo.inheritedAcls[i].mappingType,
@@ -195,11 +186,17 @@ class AclDavService {
 							fileInfo.inheritedAcls[i].mappingDisplayName,
 							fileInfo.inheritedAcls[i].mask,
 							fileInfo.inheritedAcls[i].permissions,
-						)
-						acls.push(acl);
+							true
+						);
+						let id = acl.getUniqueMappingIdentifier();
+						inheritedAclsById[id] = acl;
+						if (aclsById[id] == null) {
+							aclsById[id] = acl;
+						}
 					}
 					return {
-						acls,
+						acls: Object.values(aclsById),
+						inheritedAclsById,
 						aclEnabled: fileInfo.aclEnabled,
 						aclCanManage: fileInfo.aclCanManage,
 						groupFolderId: fileInfo.groupFolderId

--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -27,8 +27,8 @@
 	<div v-else style="position: relative;" v-click-outside="popoverClose">
 		<button :disabled="disabled" @click="open = true" v-if="state === STATES.INHERIT_DENY" class="icon-deny inherited" v-tooltip="t('groupfolders', 'Denied (Inherited permission)')"></button>
 		<button :disabled="disabled" @click="open = true" v-else-if="state === STATES.INHERIT_ALLOW" class="icon-checkmark inherited" v-tooltip="t('groupfolders', 'Allowed (Inherited permission)')"></button>
-		<button :disabled="disabled" @click="open = true" v-else-if="state === STATES.SELF_DENY" class="icon-deny" v-tooltip="t('groupfolders', 'Denied')"></button>
-		<button :disabled="disabled" @click="open = true" v-else-if="state === STATES.SELF_ALLOW" class="icon-checkmark" v-tooltip="t('groupfolders', 'Allowed')"></button>
+		<button :disabled="disabled" @click="open = true" v-else-if="state === STATES.SELF_DENY" v-bind:class="'icon-deny' + (inherited ? ' inherited' : '')" v-tooltip="t('groupfolders', 'Denied')"></button>
+		<button :disabled="disabled" @click="open = true" v-else-if="state === STATES.SELF_ALLOW" v-bind:class="'icon-checkmark' + (inherited ? ' inherited' : '')" v-tooltip="t('groupfolders', 'Allowed')"></button>
 		<div class="popovermenu" :class="{open: open}"><PopoverMenu :menu="menu"></PopoverMenu></div>
 	</div>
 </template>
@@ -47,6 +47,10 @@
 		name: 'AclStateButton',
 		components: {PopoverMenu},
 		props: {
+			inherited: {
+				type: Boolean,
+				default: false
+			},
 			state: {
 				type: Number,
 				default: STATES.INHERIT_DENY

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -72,22 +72,27 @@
 				</td>
 				<td class="state-column">
 					<AclStateButton :state="getState(OC.PERMISSION_READ, item.permissions, item.mask)"
+									:inherited="item.inherited"
 									@update="changePermission(item, OC.PERMISSION_READ, $event)" :disabled="loading"/>
 				</td>
 				<td class="state-column">
 					<AclStateButton :state="getState(OC.PERMISSION_UPDATE, item.permissions, item.mask)"
+									:inherited="item.inherited"
 									@update="changePermission(item, OC.PERMISSION_UPDATE, $event)" :disabled="loading"/>
 				</td>
 				<td class="state-column" v-if="model.type === 'dir'">
 					<AclStateButton :state="getState(OC.PERMISSION_CREATE, item.permissions, item.mask)"
+									:inherited="item.inherited"
 									@update="changePermission(item, OC.PERMISSION_CREATE, $event)" :disabled="loading"/>
 				</td>
 				<td class="state-column">
 					<AclStateButton :state="getState(OC.PERMISSION_DELETE, item.permissions, item.mask)"
+									:inherited="item.inherited"
 									@update="changePermission(item, OC.PERMISSION_DELETE, $event)" :disabled="loading"/>
 				</td>
 				<td class="state-column">
 					<AclStateButton :state="getState(OC.PERMISSION_SHARE, item.permissions, item.mask)"
+									:inherited="item.inherited"
 									@update="changePermission(item, OC.PERMISSION_SHARE, $event)" :disabled="loading"/>
 				</td>
 				<td class="state-column"><a v-if="item.inherited === false" class="icon-close" v-tooltip="t('groupfolders', 'Remove access rule')"

--- a/src/model/Rule.js
+++ b/src/model/Rule.js
@@ -35,12 +35,13 @@ export default class Rule {
 		this.permissions = props[PROPERTIES.PROPERTY_ACL_PERMISSIONS];
 	}
 
-	fromValues(mappingType, mappingId, mappingDisplayName, mask = 0, permissions = 31) {
+	fromValues(mappingType, mappingId, mappingDisplayName, mask = 0, permissions = 31, inherited = false) {
 		this.mappingType = mappingType;
 		this.mappingId = mappingId;
 		this.mappingDisplayName = mappingDisplayName;
 		this.mask = mask;
 		this.permissions = permissions;
+		this.inherited = inherited;
 	}
 
 	getProperties() {
@@ -56,4 +57,13 @@ export default class Rule {
 		return this.mappingType + ':' + this.mappingId;
 	}
 
+	clone() {
+		let rule = new Rule();
+		Object.getOwnPropertyNames(this)
+			.forEach(prop => {
+				rule[prop] = this[prop];
+			})
+
+		return rule;
+	}
 }


### PR DESCRIPTION
This pr adds inherited advanced rules into the sidebar together with rules for current file. This allows seeing all advanced rules for the file with possibility of changing any rule (rule for current file will be changed in case inherited rule is shown).

~~When rule is removed in the ui, it is removed from the list and if it was inherited, it will be shown there again after reopening (maybe this should be changed somehow?).~~