### PR TITLE
Fix: Trying to access array offset on value of type int 

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -61,7 +61,7 @@ class VersionsBackend implements IVersionBackend {
 			try {
 				$folderId = $mount->getFolderId();
 				/** @var Folder $versionsFolder */
-				$versionsFolder = $this->getVersionsFolder($mount->getFolderId())->get($file->getId());
+				$versionsFolder = $this->getVersionsFolder($mount->getFolderId())->get((string)$file->getId());
 				return array_map(function (File $versionFile) use ($file, $user, $folderId) {
 					return new GroupVersion(
 						(int)$versionFile->getName(),


### PR DESCRIPTION
at lib/private/Files/Node/Node.php#327. As reported at https://github.com/nextcloud/server/issues/19010 and similar to https://github.com/nextcloud/text/pull/608/commits/92df34121d057c95c246275b4fe46675eeaa3257. 

get() expects $path to be a string hence the file id is int or null.

