### PR TITLE
Fix argument null fatal in case of empty array

### DIFF
--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -81,7 +81,7 @@ class RuleManager {
 				$result[$row['fileid']][] = $rule;
 			}
 		}
-		return $result;
+		return $this->filterRules($result);
 	}
 
 	/**
@@ -163,7 +163,7 @@ class RuleManager {
 				}
 			}
 		}
-		return $result;
+		return $this->filterRules($result);
 	}
 
 	private function getId(int $storageId, string $path): int {
@@ -197,6 +197,18 @@ class RuleManager {
 		return $this->rulesByPath($rows);
 	}
 
+	/**
+	 * Ensures paths with no rules are not returned.
+	 *
+	 * @param (Rule[])[] $rules
+	 * @return (Rule[])[]
+	 */
+	private function filterRules(array $rules): array {
+		return array_filter($rules, function($path) {
+			return !empty($path);
+		});
+	}
+
 	private function rulesByPath(array $rows, array $result = []): array {
 		foreach ($rows as $row) {
 			if (!isset($result[$row['path']])) {
@@ -207,7 +219,8 @@ class RuleManager {
 				$result[$row['path']][] = $rule;
 			}
 		}
-		return $result;
+
+		return $this->filterRules($result);
 	}
 
 	/**


### PR DESCRIPTION
I found a lot of `TypeError: Argument 2 passed to OCA\\GroupFolders\\ACL\\ACLManager::OCA\\GroupFolders\\ACL\\{closure}() must be of the type array, null given` with `{"file":"/opt/nextcloud-18.0.3/apps/groupfolders/lib/ACL/ACLManager.php","line":122,"function":"array_reduce"}` in my server logs.

I have investigated the issue and found out that the `array_reduce` function of PHP automagically converts an empty array to null.

Example:

```
array_reduce([
    []
], function(array $rules) {
    var_dump($rules);
    return 0;
}) ;
```

Results in:

```
Uncaught TypeError: Argument 1 passed to {closure}() must be of the type array, null given in [...][...]:5
```

And this case is currently not handled in the `ACLManager`. If there are folders passed with no rules, it crashes.