### PR TITLE
ACL: Increase performance by selecting on indexed column

### DIFF
--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -93,11 +93,15 @@ class RuleManager {
 	public function getRulesForFilesByPath(IUser $user, int $storageId, array $filePaths): array {
 		$userMappings = $this->userMappingManager->getMappingsForUser($user);
 
+		$hashes = array_map(function (string $path) {
+			return md5($path);
+		}, $filePaths);
+
 		$query = $this->connection->getQueryBuilder();
 		$query->select(['f.fileid', 'mapping_type', 'mapping_id', 'mask', 'a.permissions', 'path'])
 			->from('group_folders_acl', 'a')
 			->innerJoin('a', 'filecache', 'f', $query->expr()->eq('f.fileid', 'a.fileid'))
-			->where($query->expr()->in('path', $query->createNamedParameter($filePaths, IQueryBuilder::PARAM_STR_ARRAY)))
+			->where($query->expr()->in('path_hash', $query->createNamedParameter($hashes, IQueryBuilder::PARAM_STR_ARRAY)))
 			->andWhere($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->orX(...array_map(function (IUserMapping $userMapping) use ($query) {
 				return $query->expr()->andX(


### PR DESCRIPTION
In all other methods of `RuleManager` we already filter by `path_hash` instead of `path` because `path_hash`, together with `storage_id` has a unique index, but `path` has no index at all.

I noticed this on our installation which makes heavy use of group folders, containing ACL on a specific user group that is used in hundreds of group folders. This characteristic seems to accelerate the problem as well.

Explaining the original select results in following execution plan:

```
+------+-------------+-------+--------+--------------------------------------------------------------------------------------+---------------------------+---------+----------------+-------+------------------------------------+
| id   | select_type | table | type   | possible_keys                                                                        | key                       | key_len | ref            | rows  | Extra                              |
+------+-------------+-------+--------+--------------------------------------------------------------------------------------+---------------------------+---------+----------------+-------+------------------------------------+
|    1 | SIMPLE      | a     | ref    | groups_folder_acl_unique,groups_folder_acl_file,groups_folder_acl_mapping            | groups_folder_acl_mapping | 66      | const          | 12329 | Using index condition; Using where |
|    1 | SIMPLE      | f     | eq_ref | PRIMARY,fs_storage_path_hash,fs_storage_mimetype,fs_storage_mimepart,fs_storage_size | PRIMARY                   | 8       | wolke.a.fileid |     1 | Using where                        |
+------+-------------+-------+--------+--------------------------------------------------------------------------------------+---------------------------+---------+----------------+-------+------------------------------------+
```

Explaining the adjusted query results in this execution plan:

```
+------+-------------+-------+-------+--------------------------------------------------------------------------------------+--------------------------+---------+-------------+------+------------------------------------+
| id   | select_type | table | type  | possible_keys                                                                        | key                      | key_len | ref         | rows | Extra                              |
+------+-------------+-------+-------+--------------------------------------------------------------------------------------+--------------------------+---------+-------------+------+------------------------------------+
|    1 | SIMPLE      | f     | const | PRIMARY,fs_storage_path_hash,fs_storage_mimetype,fs_storage_mimepart,fs_storage_size | fs_storage_path_hash     | 138     | const,const |    1 |                                    |
|    1 | SIMPLE      | a     | ref   | groups_folder_acl_unique,groups_folder_acl_file,groups_folder_acl_mapping            | groups_folder_acl_unique | 74      | const,const |    3 | Using index condition; Using where |
+------+-------------+-------+-------+--------------------------------------------------------------------------------------+--------------------------+---------+-------------+------+------------------------------------+
```

As we can see, in the adjusted query MySQL can make use of the `fs_storage_path_hash` index, and in my case needs to scan 12.326 less rows.

I have benchmarked this on our production system with a sample of 10.000 queries:

| Metric  | Before         | After          |
|---------|----------------|----------------|
| min     | 1 ms           | 1 ms           |
| max     | 258 ms         | 28 ms          |
| average | 85,66633367 ms | 2,911088911 ms |