### PR TITLE
Bump version requirement

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ Note: encrypting the contents of group folders is currently not supported.]]></d
 	<screenshot>https://raw.githubusercontent.com/nextcloud/groupfolders/master/screenshots/permissions.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="18" max-version="19" />
+		<nextcloud min-version="18" max-version="20" />
 	</dependencies>
 
 	<background-jobs>


### PR DESCRIPTION
Allows running the app on master of server,
but shouldn't be published to the appstore like this