### PR TITLE
Provide a default scanner

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -22,6 +22,7 @@
 namespace OCA\GroupFolders\Mount;
 
 
+use OC\Files\Cache\Scanner;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\IUser;
@@ -79,5 +80,15 @@ class GroupFolderStorage extends Quota {
 
 		$this->cache = new RootEntryCache(parent::getCache($path, $storage), $this->rootEntry);
 		return $this->cache;
+	}
+
+	public function getScanner($path = '', $storage = null) {
+		if (!$storage) {
+			$storage = $this;
+		}
+		if (!isset($storage->scanner)) {
+			$storage->scanner = new Scanner($storage);
+		}
+		return $storage->scanner;
 	}
 }


### PR DESCRIPTION
Else we fall back to getting the scanner from the root storage. Which
will fail if you try to upload something due to the LocalRootScanner.

Now it just uses the default one again and all is right with the world.

@icewind1991 please check

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>