### PR TITLE
Properly encode group names as url parameter

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,12 +34,14 @@ return ['routes' => [
 	[
 		'name' => 'Folder#removeGroup',
 		'url' => '/folders/{id}/groups/{group}',
-		'verb' => 'DELETE'
+		'verb' => 'DELETE',
+		'requirements' => ['group' => '.+']
 	],
 	[
 		'name' => 'Folder#setPermissions',
 		'url' => '/folders/{id}/groups/{group}',
-		'verb' => 'POST'
+		'verb' => 'POST',
+		'requirements' => ['group' => '.+']
 	],
 	[
 		'name' => 'Folder#setManageACL',


### PR DESCRIPTION
Steps to reproduce:

- Add a group named "A/group" or "A group ; , / ? : @ & = + $" to a groupfolder
- Try to update the permissions for that group