### PR TITLE
Always delete expired versions regardless of the filecache permissions

### DIFF
--- a/lib/Versions/GroupVersionsExpireManager.php
+++ b/lib/Versions/GroupVersionsExpireManager.php
@@ -23,6 +23,7 @@ namespace OCA\GroupFolders\Versions;
 
 
 use OC\Files\FileInfo;
+use OC\Files\View;
 use OC\Hooks\BasicEmitter;
 use OC\User\User;
 use OCA\GroupFolders\Folder\FolderManager;
@@ -59,6 +60,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 	}
 
 	public function expireFolder($folder) {
+		$view = new View('/__groupfolders/versions/' . $folder['id']);
 		$files = $this->versionsBackend->getAllVersionedFiles($folder);
 		$dummyUser = new User('', null, $this->dispatcher);
 		foreach ($files as $fileId => $file) {
@@ -68,7 +70,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 				foreach ($expireVersions as $version) {
 					/** @var GroupVersion $version */
 					$this->emit(self::class, 'deleteVersion', [$version]);
-					$version->getVersionFile()->delete();
+					$view->unlink('/' . $fileId . '/' . $version->getVersionFile()->getName());
 				}
 			} else {
 				// source file no longer exists


### PR DESCRIPTION
If a version is created by a user which doesn't have delete permission the filecache entry for the version file has no delete permission set since the cache entry is copied over from the original file. https://github.com/nextcloud/groupfolders/blob/279eb30c27b16cfcfc89271da80a8d20b1664b9a/lib/Versions/VersionsBackend.php#L130

This PR makes sure that version expiry is always able to delete expired versions.

Fixes https://github.com/nextcloud/groupfolders/issues/861
Fixes https://github.com/nextcloud/groupfolders/issues/536
Fixes https://github.com/nextcloud/groupfolders/issues/673
Fixes https://github.com/nextcloud/groupfolders/issues/936