### PR TITLE
Expire group folders trashbin

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -76,7 +76,8 @@ class Application extends App {
 				$c->query(TrashManager::class),
 				$c->query('GroupAppFolder'),
 				$c->query(MountProvider::class),
-				$c->query(ACLManagerFactory::class)
+				$c->query(ACLManagerFactory::class),
+				$c->query(VersionsBackend::class)
 			);
 		});
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -92,7 +92,8 @@ class Application extends App {
 		$container->registerService(ExpireGroupVersions::class, function (IAppContainer $c) {
 			if (interface_exists('OCA\Files_Versions\Versions\IVersionBackend')) {
 				return new ExpireGroupVersions(
-					$c->query(GroupVersionsExpireManager::class)
+					$c->query(GroupVersionsExpireManager::class),
+					$c->get(TrashBackend::class)
 				);
 			} else {
 				return new ExpireGroupVersionsPlaceholder();

--- a/lib/Command/ExpireGroupVersions.php
+++ b/lib/Command/ExpireGroupVersions.php
@@ -23,7 +23,9 @@ namespace OCA\GroupFolders\Command;
 
 
 use OC\Core\Command\Base;
+use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Versions\Versions\IVersion;
+use OCA\GroupFolders\Trash\TrashBackend;
 use OCA\GroupFolders\Versions\GroupVersionsExpireManager;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -31,15 +33,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ExpireGroupVersions extends Base {
 	private $expireManager;
 
-	public function __construct(GroupVersionsExpireManager $expireManager) {
+	private $trashBackend;
+
+	public function __construct(GroupVersionsExpireManager $expireManager, TrashBackend $trashBackend) {
 		parent::__construct();
 		$this->expireManager = $expireManager;
+		$this->trashBackend = $trashBackend;
 	}
 
 	protected function configure() {
 		$this
 			->setName('groupfolders:expire')
-			->setDescription('Trigger expiry of versions for files stored in group folders');
+			->setDescription('Trigger expiry of versions and trashbin for files stored in group folders');
 		parent::configure();
 	}
 
@@ -56,6 +61,10 @@ class ExpireGroupVersions extends Base {
 		$this->expireManager->listen(GroupVersionsExpireManager::class, 'deleteFile', function($id) use ($output) {
 			$output->writeln("<info>Cleaning up versions for no longer existing file with id $id</info>");
 		});
+
+
+		list($count, $size) = $this->trashBackend->expire(\OC::$server->get(Expiration::class));
+		$output->writeln("<info>Removed $count expired trashbin items</info>");
 
 		$this->expireManager->expireAll();
 	}

--- a/lib/Trash/TrashManager.php
+++ b/lib/Trash/TrashManager.php
@@ -34,8 +34,9 @@ class TrashManager {
 
 	public function listTrashForFolders(array $folderIds): array {
 		$query = $this->connection->getQueryBuilder();
-		$query->select(['trash_id', 'name', 'deleted_time', 'original_location', 'folder_id'])
+		$query->select(['trash_id', 'name', 'deleted_time', 'original_location', 'folder_id', 'file_id'])
 			->from('group_folders_trash')
+			->orderBy('deleted_time')
 			->where($query->expr()->in('folder_id', $query->createNamedParameter($folderIds, IQueryBuilder::PARAM_INT_ARRAY)));
 		return $query->execute()->fetchAll();
 	}


### PR DESCRIPTION
This is a first attempt to make group folder trash items expire properly, since until now the trash is just growing forever. 

Fixes https://github.com/nextcloud/groupfolders/issues/930

@icewind1991 In a later step, I'd like to extend `OCA\Files_Trashbin\Trash\ITrashBackend` with an expire method in the server, so that we can basically move the regular trashbin retention from the old static functions to the regular files trash backend as well. With this we can then pick up the retention policy globally and apply it to each trash backend. Any concerns regarding that?

Missing pieces for the groupfolder only implementation:
- [ ] Also take expiration based on available space into account
- [ ] Provide occ command and background job
