### PR TITLE
Properly cast file and groupfolder ids to strings when using them in paths

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -92,9 +92,9 @@ class VersionsBackend implements IVersionBackend {
 
 			try {
 				/** @var Folder $versionFolder */
-				$versionFolder = $versionsFolder->get($file->getId());
+				$versionFolder = $versionsFolder->get((string)$file->getId());
 			} catch (NotFoundException $e) {
-				$versionFolder = $versionsFolder->newFolder($file->getId());
+				$versionFolder = $versionsFolder->newFolder((string)$file->getId());
 			}
 
 			$versionMount = $versionFolder->getMountPoint();
@@ -140,7 +140,7 @@ class VersionsBackend implements IVersionBackend {
 		if ($mount instanceof GroupMountPoint) {
 			try {
 				/** @var Folder $versionsFolder */
-				$versionsFolder = $this->getVersionsFolder($mount->getFolderId())->get($sourceFile->getId());
+				$versionsFolder = $this->getVersionsFolder($mount->getFolderId())->get((string)$sourceFile->getId());
 				return $versionsFolder->get((string)$revision);
 			} catch (NotFoundException $e) {
 				return null;
@@ -196,7 +196,7 @@ class VersionsBackend implements IVersionBackend {
 		} catch (NotFoundException $e) {
 			/** @var Folder $trashRoot */
 			$trashRoot = $this->appFolder->nodeExists('versions') ? $this->appFolder->get('versions') : $this->appFolder->newFolder('versions');
-			return $trashRoot->newFolder($folderId);
+			return $trashRoot->newFolder((string)$folderId);
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/1023