### PR TITLE
Make sure to only move in cache if it was not already done by the storage

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -178,7 +178,9 @@ class TrashBackend implements ITrashBackend {
 			$targetInternalPath = $trashFolder->getInternalPath() . '/' . $trashName;
 			if ($trashStorage->moveFromStorage($unJailedStorage, $unJailedInternalPath, $targetInternalPath)) {
 				$this->trashManager->addTrashItem($folderId, $name, $time, $internalPath, $fileEntry->getId());
-				$trashStorage->getCache()->moveFromCache($unJailedStorage->getCache(), $unJailedInternalPath, $targetInternalPath);
+				if ($trashStorage->getCache()->getId($targetInternalPath) !== $fileEntry->getId()) {
+					$trashStorage->getCache()->moveFromCache($unJailedStorage->getCache(), $unJailedInternalPath, $targetInternalPath);
+				}
 			} else {
 				throw new \Exception("Failed to move groupfolder item to trash");
 			}


### PR DESCRIPTION
- S3 primary storage
- try to delete a file from a group folder

Before:
The deletion showed an error since the moveFromCache was already performed in https://github.com/nextcloud/server/blob/bb06b6cce46df881d84f34adfd5b1c3f315bd718/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L362 and therefore the second move failed with the error from #831 

After:
The cache move attempt is only happening if the paths have not been updated already