### PR TITLE
Fix occ when files_trashbin is disabled

### DIFF
--- a/lib/Command/Trashbin/Cleanup.php
+++ b/lib/Command/Trashbin/Cleanup.php
@@ -46,10 +46,12 @@ class Cleanup extends Base {
 	 */
 	private $folderManager;
 
-	public function __construct(TrashBackend $trashBackend, FolderManager $folderManager, IRootFolder $rootFolder) {
+	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder) {
 		parent::__construct();
-		$this->trashBackend = $trashBackend;
-		$this->folderManager = $folderManager;
+		if (\OC::$server->getAppManager()->isEnabledForUser('files_trashbin')) {
+			$this->trashBackend = \OC::$server->get(TrashBackend::class);
+			$this->folderManager = $folderManager;
+		}
 	}
 
 	protected function configure() {
@@ -62,6 +64,10 @@ class Cleanup extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
+		if (!$this->trashBackend) {
+			$output->writeln('<error>files_trashbin is disabled: group folders trashbin is not available</error>');
+			return -1;
+		}
 		$helper = $this->getHelper('question');
 
 		$folders = $this->folderManager->getAllFolders();


### PR DESCRIPTION
Otherwise loading the ITrashManager interface fails when injecting the TrashBackend. I'm open to more elegant suggestions on how to solve this, though there doesn't seem to be a way to register occ commands programmatically or I couldn't find it.