### PR TITLE
[stable18] Fix backport of #1070

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -178,8 +178,8 @@ class AclDavService {
 		}).then((status, fileInfo) => {
 			if (fileInfo) {
 				let acls = []
-				for ( let i in fileInfo.acl ) {
-					let acl = new Rule()
+				for ( const i in fileInfo.acl ) {
+					const acl = new Rule()
 					acl.fromValues(
 						fileInfo.acl[i].mappingType,
 						fileInfo.acl[i].mappingId,

--- a/src/client.js
+++ b/src/client.js
@@ -144,21 +144,21 @@ const FilesPlugin = {
 				data.aclCanManage = !!aclCanManage
 			}
 
-			const acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST] || [];
-			const inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST] || [];
+			const acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST] || []
+			const inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST] || []
 
-			data.acl = parseAclList(acls);
-			data.inheritedAcls = parseAclList(inheritedAcls);
+			data.acl = parseAclList(acls)
+			data.inheritedAcls = parseAclList(inheritedAcls)
 
 			data.acl.map((acl) => {
 				const inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
 				if (inheritedAcl) {
 					acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
 				}
-				return acl;
+				return acl
 			})
-			return data;
-		});
+			return data
+		})
 
 		patchClientForNestedPropPatch(client)
 	},
@@ -187,7 +187,7 @@ class AclDavService {
 						fileInfo.acl[i].mask,
 						fileInfo.acl[i].permissions,
 					)
-					acls.push(acl);
+					acls.push(acl)
 				}
 				return {
 					acls,
@@ -197,8 +197,8 @@ class AclDavService {
 				}
 			}
 			// TODO parse inherited permissions here
-			return null;
-		});
+			return null
+		})
 	}
 
 	propPatch(model, acls) {

--- a/src/client.js
+++ b/src/client.js
@@ -178,7 +178,7 @@ class AclDavService {
 		}).then((status, fileInfo) => {
 			if (fileInfo) {
 				let acls = []
-				for ( const i in fileInfo.acl ) {
+				for (const i in fileInfo.acl) {
 					const acl = new Rule()
 					acl.fromValues(
 						fileInfo.acl[i].mappingType,

--- a/src/client.js
+++ b/src/client.js
@@ -138,46 +138,29 @@ const FilesPlugin = {
 			if (typeof aclEnabled !== 'undefined') {
 				data.aclEnabled = !!aclEnabled
 			}
-			list.push(acl);
-		}
-		return list;
-	}
-
-	client = window.OCA.Files.App.fileList.filesClient;
-	client.addFileInfoParser(function(response) {
-		var data = {};
-		var props = response.propStat[0].properties;
-		var groupFolderId = props[ACL_PROPERTIES.GROUP_FOLDER_ID];
-		if (typeof groupFolderId !== 'undefined') {
-			data.groupFolderId = groupFolderId;
-		}
-		var aclEnabled = props[ACL_PROPERTIES.PROPERTY_ACL_ENABLED];
-		if (typeof aclEnabled !== 'undefined') {
-			data.aclEnabled = !!aclEnabled;
-		}
 
 			const aclCanManage = props[ACL_PROPERTIES.PROPERTY_ACL_CAN_MANAGE]
 			if (typeof aclCanManage !== 'undefined') {
 				data.aclCanManage = !!aclCanManage
 			}
 
-		var acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST];
-		var inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST];
+			const acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST];
+			const inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST];
 
-		if (!_.isUndefined(acls)) {
-			data.acl = parseAclList(acls);
-			data.inheritedAcls = parseAclList(inheritedAcls);
+			if (!_.isUndefined(acls)) {
+				data.acl = parseAclList(acls);
+				data.inheritedAcls = parseAclList(inheritedAcls);
 
-			data.acl.map((acl) => {
-				let inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
-				if (inheritedAcl) {
-					acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
-				}
-				return acl;
-			})
-		}
-		return data;
-	});
+				data.acl.map((acl) => {
+					const inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
+					if (inheritedAcl) {
+						acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
+					}
+					return acl;
+				})
+			}
+			return data;
+		});
 
 		patchClientForNestedPropPatch(client)
 	},

--- a/src/client.js
+++ b/src/client.js
@@ -144,21 +144,19 @@ const FilesPlugin = {
 				data.aclCanManage = !!aclCanManage
 			}
 
-			const acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST];
-			const inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST];
+			const acls = props[ACL_PROPERTIES.PROPERTY_ACL_LIST] || [];
+			const inheritedAcls = props[ACL_PROPERTIES.PROPERTY_INHERITED_ACL_LIST] || [];
 
-			if (!_.isUndefined(acls)) {
-				data.acl = parseAclList(acls);
-				data.inheritedAcls = parseAclList(inheritedAcls);
+			data.acl = parseAclList(acls);
+			data.inheritedAcls = parseAclList(inheritedAcls);
 
-				data.acl.map((acl) => {
-					const inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
-					if (inheritedAcl) {
-						acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
-					}
-					return acl;
-				})
-			}
+			data.acl.map((acl) => {
+				const inheritedAcl = data.inheritedAcls.find((inheritedAclRule) => inheritedAclRule.mappingType === acl.mappingType && inheritedAclRule.mappingId === acl.mappingId)
+				if (inheritedAcl) {
+					acl.permissions = (acl.permissions & acl.mask) | (inheritedAcl.permissions & ~acl.mask)
+				}
+				return acl;
+			})
 			return data;
 		});
 


### PR DESCRIPTION
Follow up to #1088

See https://github.com/nextcloud/groupfolders/pull/1070/files#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0L125 and https://github.com/nextcloud/groupfolders/pull/1088/files#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0L125

Besides the fix itself (it failed to build) I have also applied other style changes to align _stable18_ with _master_ to ease future backports.

This should be applied to _stable19_ too; let's see if the backportbot can also do forwardports ;-)