### PR TITLE
Bug fix in user list selection

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -275,7 +275,7 @@ class FolderManager {
 		});
 	}
 
-	public function searchUsers($id, $search = '', $limit = 10, $offset = 0): array {
+	public function searchUsers($id, $search = '', $limit = 100, $offset = 0): array {
 		$groups = $this->getGroups($id);
 		$users = [[]];
 		foreach ($groups as $groupArray) {


### PR DESCRIPTION
The default limit in userSearch sets a maximum hard limit of 10 users (+ groups) in the drop-down list of known users when adding new GF permissions to a directory entry.
I changed the value to 100 which seems a more reasonable limit for larger instances..
Tested on NC 19 with GF 7.1.1.

