### PR TITLE
Fix dev build with updated webpack-cli (#1216)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build/main.js: node_modules $(jssources)
 
 .PHONY: watch
 watch: node_modules
-	node node_modules/.bin/webpack-dev-server --watch --hot --inline --port 3000 --public localcloud.icewind.me:444 --config webpack.dev.config.js
+	$(webpack) serve --hot --port 3000 --public localcloud.icewind.me:444 --config webpack.dev.config.js
 
 release: appstore create-tag
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -65,6 +65,7 @@ module.exports = {
 		]
 	},
 	devServer: {
-		contentBase: path.resolve(__dirname, './src')
+		contentBase: path.resolve(__dirname, './src'),
+		watchContentBase: true
 	},
 };


### PR DESCRIPTION
See https://github.com/webpack/webpack-dev-server/issues/2029.
Fixes #1216.

Fixes: 1953a63 (Bump webpack-cli from 3.3.12 to 4.1.0)
Signed-off-by: Frieder Schrempf <dev@fris.de>