### PR TITLE
Fix file drop shared folders

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -52,7 +52,7 @@ class ACLCacheWrapper extends CacheWrapper {
 		if (isset($entry['permissions'])) {
 			$entry['scan_permissions'] = $entry['permissions'];
 			$entry['permissions'] &= $this->getACLPermissionsForPath($entry['path']);
-			if (!($entry['permissions'] & Constants::PERMISSION_READ)) {
+			if (!$entry['permissions']) {
 				return false;
 			}
 		}


### PR DESCRIPTION
Fixes #923

When ACL is enabled [the READ permission is required to get any other permission on the group folder (or its contents)](https://github.com/nextcloud/groupfolders/blob/c859ff92d4d7d451666fb4ab2cb0457345a1cb56/lib/ACL/ACLStorageWrapper.php#L40-L54). However, the `ACLCacheWrapper` verified not only that the READ permission was enabled for the folder/file, but also that it was being requested. Due to this it was not possible to publicly upload a file to a file drop shared folder inside a group folder, as in that case only SHARE + CREATE permissions are requested.

**Reviewers:** note that I know nothing about group folders, caches or storages, so please review carefully :-)

## How to test

- Open the settings for group folders
- Create a group folder for a group of the current user
- Enable ACL
- Open the Files app
- Enter in the group folder
- Create a new folder
- Share the new folder by link
- Set the link share to "File drop (upload only)"
- Copy the link
- In a private window, open the link
- Upload a file

### Result with this pull request

The file is uploaded.

### Result without this pull request

The file fails to upload. The web console shows an internal error in the upload request (Nextcloud logs show [`Call to a member function getType() on boolean`](https://github.com/nextcloud/server/blob/d89a75be0b01f0423a7c1ad2d58aac73c3cc1f3a/apps/dav/lib/Connector/Sabre/ServerFactory.php#L162), maybe a check for `rootInfo` should be added there too to handle such errors more gracefully?).
