### PR TITLE
Fix #801 Folder icon in shared group folder

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -37,6 +37,11 @@ __webpack_public_path__ = OC.linkTo('groupfolders', 'build/');
 })(OC, OCA);
 
 window.addEventListener('DOMContentLoaded', () => {
+	if (OCA.Theming) {
+		OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);
+	} else {
+		OC.MimeType._mimeTypeIcons['dir-group'] = OC.imagePath('groupfolders', 'folder-group');
+	}
 	import(/* webpackChunkName: "sharing" */'./SharingSidebarApp').then((Module) => {
 		OCA.Sharing.ShareTabSections.registerSection((el, fileInfo) => {
 			if (fileInfo.mountType !== 'group') {

--- a/src/files.js
+++ b/src/files.js
@@ -24,18 +24,6 @@ import './client'
 __webpack_nonce__ = btoa(OC.requestToken);
 __webpack_public_path__ = OC.linkTo('groupfolders', 'build/');
 
-(function(OC, OCA) {
-	OC.Plugins.register('OCA.Files.App', {
-		attach: () => {
-			if (OCA.Theming) {
-				OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);
-			} else {
-				OC.MimeType._mimeTypeIcons['dir-group'] = OC.imagePath('groupfolders', 'folder-group');
-			}
-		}
-	});
-})(OC, OCA);
-
 window.addEventListener('DOMContentLoaded', () => {
 	if (OCA.Theming) {
 		OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);


### PR DESCRIPTION
Always set icon for group folder via ContentLoaded event to have it also in a shared folder.