### PR TITLE
check folder permissions when restoring a trashbin item

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -565,4 +565,23 @@ class FolderManager {
 
 		return array_values($mergedFolders);
 	}
+
+	/**
+	 * @param IUser $user
+	 * @param int $folderId
+	 * @return int
+	 */
+	public function getFolderPermissionsForUser(IUser $user, int $folderId): int {
+		$groups = $this->groupManager->getUserGroupIds($user);
+		$folders = $this->getFoldersForGroups($groups);
+
+		$permissions = 0;
+		foreach ($folders as $folder) {
+			if ($folderId === (int)$folder['folder_id']) {
+				$permissions |= $folder['permissions'];
+			}
+		}
+
+		return $permissions;
+	}
 }

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -96,12 +96,16 @@ class TrashBackend implements ITrashBackend {
 
 	public function restoreItem(ITrashItem $item) {
 		$user = $item->getUser();
-		list(, $folderId) = explode('/', $item->getTrashPath());
+		[, $folderId] = explode('/', $item->getTrashPath());
 		$node = $this->getNodeForTrashItem($user, $item);
 		if ($node === null) {
 			throw new NotFoundException();
 		}
-		if (!$this->userHasAccessToPath($item->getUser(), $folderId . '/' . $item->getOriginalLocation(), Constants::PERMISSION_UPDATE)) {
+		if (!$this->userHasACLAccessToPath($item->getUser(), $folderId . '/' . $item->getOriginalLocation(), Constants::PERMISSION_UPDATE)) {
+			throw new NotPermittedException();
+		}
+		$folderPermissions = $this->folderManager->getFolderPermissionsForUser($item->getUser(), (int)$folderId);
+		if (($folderPermissions & Constants::PERMISSION_UPDATE) !== Constants::PERMISSION_UPDATE) {
 			throw new NotPermittedException();
 		}
 

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -291,4 +291,36 @@ class FolderManagerTest extends TestCase {
 			]
 		], $folders);
 	}
+
+	public function testGetFolderPermissionsForUserMerge() {
+		$db = $this->createMock(IDBConnection::class);
+		/** @var FolderManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+		$manager = $this->getMockBuilder(FolderManager::class)
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader])
+			->setMethods(['getFoldersForGroups'])
+			->getMock();
+
+		$folder1 = [
+			'folder_id' => 1,
+			'mount_point' => 'foo',
+			'permissions' => 3,
+			'quota' => 1000
+		];
+		$folder2 = [
+			'folder_id' => 1,
+			'mount_point' => 'foo',
+			'permissions' => 8,
+			'quota' => 1000
+		];
+
+		$manager->expects($this->any())
+			->method('getFoldersForGroups')
+			->willReturn([$folder1, $folder2]);
+
+		$permissions = $manager->getFolderPermissionsForUser($this->getUser(['g1', 'g2', 'g3']), 1);
+		$this->assertEquals(11, $permissions);
+
+		$permissions = $manager->getFolderPermissionsForUser($this->getUser(['g1', 'g2', 'g3']), 2);
+		$this->assertEquals(0, $permissions);
+	}
 }


### PR DESCRIPTION
not just the acl permissions

To test:

- Setup two users `userA` and `userB`, and two groups `groupB` and `groupA`, adding the user to the respective group
- Setup a group folder, giving `groupA` full permissions, and `groupB` read only permissions (using folder permissions, not ACL)
- As `userA` upload some stuff and delete it
- As `userB` try to restore the deleted stuff