### PR TITLE
Fix #801 Folder icon in shared group folder

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\GroupFolders\AppInfo;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
 use OCA\GroupFolders\ACL\RuleManager;
 use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
@@ -57,6 +58,8 @@ class Application extends App implements IBootstrap {
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalScriptsListener::class);
+		$context->registerEventListener(BeforeTemplateRenderedEvent::class, LoadAdditionalScriptsListener::class);
+
 		$context->registerServiceAlias('GroupAppFolder', LazyFolder::class);
 
 		$context->registerService(MountProvider::class, function (IAppContainer $c) {

--- a/src/files.js
+++ b/src/files.js
@@ -37,6 +37,11 @@ __webpack_public_path__ = OC.linkTo('groupfolders', 'js/');
 })(OC, OCA);
 
 window.addEventListener('DOMContentLoaded', () => {
+	if (OCA.Theming) {
+		OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);
+	} else {
+		OC.MimeType._mimeTypeIcons['dir-group'] = OC.imagePath('groupfolders', 'folder-group');
+	}
 	import(/* webpackChunkName: "sharing" */'./SharingSidebarApp').then((Module) => {
 		OCA.Sharing.ShareTabSections.registerSection((el, fileInfo) => {
 			if (fileInfo.mountType !== 'group') {

--- a/src/files.js
+++ b/src/files.js
@@ -30,6 +30,10 @@ window.addEventListener('DOMContentLoaded', () => {
 	} else {
 		OC.MimeType._mimeTypeIcons['dir-group'] = OC.imagePath('groupfolders', 'folder-group');
 	}
+
+	if (!OCA?.Sharing?.ShareTabSections) {
+		return
+	}
 	import(/* webpackChunkName: "sharing" */'./SharingSidebarApp').then((Module) => {
 		OCA.Sharing.ShareTabSections.registerSection((el, fileInfo) => {
 			if (fileInfo.mountType !== 'group') {

--- a/src/files.js
+++ b/src/files.js
@@ -24,18 +24,6 @@ import './client'
 __webpack_nonce__ = btoa(OC.requestToken);
 __webpack_public_path__ = OC.linkTo('groupfolders', 'js/');
 
-(function(OC, OCA) {
-	OC.Plugins.register('OCA.Files.App', {
-		attach: () => {
-			if (OCA.Theming) {
-				OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);
-			} else {
-				OC.MimeType._mimeTypeIcons['dir-group'] = OC.imagePath('groupfolders', 'folder-group');
-			}
-		}
-	});
-})(OC, OCA);
-
 window.addEventListener('DOMContentLoaded', () => {
 	if (OCA.Theming) {
 		OC.MimeType._mimeTypeIcons['dir-group'] = OC.generateUrl('/apps/theming/img/groupfolders/folder-group.svg?v=' + OCA.Theming.cacheBuster);

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.3.1@2feba22a005a18bf31d4c7b9bdb9252c73897476">
+<files psalm-version="4.x-dev@">
   <file src="lib/ACL/ACLManager.php">
     <MissingDependency occurrences="2">
       <code>$rootFolder</code>
@@ -22,6 +22,9 @@
       <code>\OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</code>
       <code>\OCA\GroupFolders\BackgroundJob\ExpireGroupVersionsPlaceholder</code>
     </MissingDependency>
+    <UndefinedClass occurrences="1">
+      <code>BeforeTemplateRenderedEvent</code>
+    </UndefinedClass>
   </file>
   <file src="lib/CacheListener.php">
     <MissingDependency occurrences="1">


### PR DESCRIPTION
Always set icon for group folder via ContentLoaded event to have it also in a shared folder.

Based on #1235 but added a commit in order to make sure that the files app integration is properly loaded on public pages with the new events to embed scripts.