### PR TITLE
Add tooltip for user/group name in sidebar ACL list

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -67,8 +67,7 @@
 					<avatar :user="item.mappingId" :size="24"></avatar>
 				</td>
 				<td class="username">
-					{{ item.mappingDisplayName }}
-					<span v-if="item.mappingType === 'group'"> {{ t('groupfolders', '(Group)') }}</span>
+					{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}
 				</td>
 				<td class="state-column">
 					<AclStateButton :state="getState(OC.PERMISSION_READ, item.permissions, item.mask)"
@@ -111,13 +110,11 @@
 					 track-by="unique">
 			<template slot="singleLabel" slot-scope="props">
 				<avatar :user="props.option.id" :isNoUser="props.option.type !== 'user'"/>
-				{{ props.option.displayname }}
-				<span v-if="props.option.type === 'group'">{{ t('groupfolders', '(Group)') }}</span>
+				{{ getFullDisplayName(props.option.displayname, props.option.type) }}
 			</template>
 			<template slot="option" slot-scope="props">
 				<avatar :user="props.option.id" :isNoUser="props.option.type !== 'user'"/>
-				{{ props.option.displayname }}
-				<span v-if="props.option.type === 'group'">{{ t('groupfolders', '(Group)') }}</span>
+				{{ getFullDisplayName(props.option.displayname, props.option.type) }}
 			</template>
 		</multiselect>
 	</div>
@@ -189,6 +186,13 @@
 			}
 		},
 		methods: {
+			getFullDisplayName (displayName, type) {
+				if (type === 'group') {
+					return t('groupfolders', '{displayName} (Group)', { displayName: displayName })
+				}
+
+				return displayName
+			},
 			searchMappings (query) {
 				axios.get(OC.generateUrl(`apps/groupfolders/folders/${this.groupFolderId}/search`) + '?format=json&search=' + query).then((result) => {
 					let groups = result.data.ocs.data.groups.map((group) => {

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -66,7 +66,7 @@
 				<td>
 					<avatar :user="item.mappingId" :size="24"></avatar>
 				</td>
-				<td class="username">
+				<td class="username" v-tooltip="getFullDisplayName(item.mappingDisplayName, item.mappingType)">
 					{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}
 				</td>
 				<td class="state-column">


### PR DESCRIPTION
The available space in the table may not be enough to show the full name, so in some cases it was not possible to distinguish between two different names.

![Files-Sidebar-Sharing-Group-ACL-Tooltip](https://user-images.githubusercontent.com/26858233/109529477-129f5300-7ab6-11eb-992a-cf83cf973ca2.png)

Besides that the display name is no longer concatenated but internationalized as a whole to ensure that it can be properly translated (which, unfortunately, will temporary cause the UI string to be shown in English until the new string is translated :shrug:).
