### PR TITLE
Fix deletion failing even if there's an entry in the folder listing

### DIFF
--- a/lib/Command/Group.php
+++ b/lib/Command/Group.php
@@ -69,23 +69,21 @@ class Group extends Base {
 		if ($folder) {
 			$groupString = $input->getArgument('group');
 			$group = $this->groupManager->get($groupString);
-			if ($group) {
-				if ($input->getOption('delete')) {
-					$this->folderManager->removeApplicableGroup($folderId, $groupString);
+			if ($input->getOption('delete')) {
+				$this->folderManager->removeApplicableGroup($folderId, $groupString);
+				return 0;
+			} elseif ($group) {
+				$permissionsString = $input->getArgument('permissions');
+				$permissions = $this->getNewPermissions($permissionsString);
+				if ($permissions) {
+					if (!isset($folder['groups'][$groupString])) {
+						$this->folderManager->addApplicableGroup($folderId, $groupString);
+					}
+					$this->folderManager->setGroupPermissions($folderId, $groupString, $permissions);
 					return 0;
 				} else {
-					$permissionsString = $input->getArgument('permissions');
-					$permissions = $this->getNewPermissions($permissionsString);
-					if ($permissions) {
-						if (!isset($folder['groups'][$groupString])) {
-							$this->folderManager->addApplicableGroup($folderId, $groupString);
-						}
-						$this->folderManager->setGroupPermissions($folderId, $groupString, $permissions);
-						return 0;
-					} else {
-						$output->writeln('<error>Unable to parse permissions input: ' . implode(' ', $permissionsString) . '</error>');
-						return -1;
-					}
+					$output->writeln('<error>Unable to parse permissions input: ' . implode(' ', $permissionsString) . '</error>');
+					return -1;
 				}
 			} else {
 				$output->writeln('<error>group not found: ' . $groupString . '</error>');


### PR DESCRIPTION
If you disable the app, delete a group and then re-enable the app, the group folders database and the group list will have diverged. That would be easy to fix via occ if it didn't check whether the group existed before deleting.

Since deleting a non-existent group doesn't break anything, I'd like to remove the check.

This is the same way it already works in the Frontend and OCS.

Please note: The diff here on github looks like I changed a lot but it's mostly just indentation.