### PR TITLE
Fix "contenthash" not included in chunk filename

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -18,6 +18,7 @@ module.exports = {
 	output: {
 		path: path.join(__dirname, "js"),
 		filename: "[name].js",
+		chunkFilename: '[name].js?v=[contenthash]',
 		publicPath: '/',
 		jsonpFunction: 'webpackJsonpGroupFolder'
 	},

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -19,6 +19,7 @@ module.exports = {
 	output: {
 		path: path.join(__dirname, "js"),
 		filename: "[name].js",
+		chunkFilename: '[name].js?v=[contenthash]',
 		libraryTarget: 'umd',
 		publicPath: '/',
 		jsonpFunction: 'webpackJsonpGroupFolder'


### PR DESCRIPTION
The "contenthash" is needed to make the browser aware of changes in the chunk and thus fetch it again instead of using its cached version.

All credits go to @juliushaertl :-)

Not sure if this should be backported or not, so I just leave up to you calling the backportbot ;-)