### PR TITLE
fix ACL error: user can not manage acl even assigned in setting

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -275,7 +275,7 @@ class FolderManager {
 			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('user')))
 			->andWhere($query->expr()->eq('mapping_id', $query->createNamedParameter($userId)));
-		if ($query->execute()->rowCount() === 1) {
+		if (count($query->execute()->fetchAll()) === 1) {
 			return true;
 		}
 


### PR DESCRIPTION
In the lib/Folder/FolderManager.php#278, the condition "$query->execute()->rowCount()" will always return 0, which is not correct.
So, even admin assign the ACL for a user in group, the user still can not manage ACL.
Using "count($query->execute()->fetchAll())" can fix the problem.