### PR TITLE
load all acl rules for a folder/search result in one go

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
  *
@@ -24,6 +26,8 @@ namespace OCA\GroupFolders\ACL;
 use OC\Files\Cache\Wrapper\CacheWrapper;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Search\ISearchQuery;
 
 class ACLCacheWrapper extends CacheWrapper {
 	private $aclManager;
@@ -61,7 +65,36 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	public function getFolderContentsById($fileId) {
 		$results = $this->getCache()->getFolderContentsById($fileId);
+		$this->preloadEntries($results);
 		$entries = array_map([$this, 'formatCacheEntry'], $results);
 		return array_filter(array_filter($entries));
+	}
+
+	public function search($pattern) {
+		$results = $this->getCache()->search($pattern);
+		$this->preloadEntries($results);
+		return array_map([$this, 'formatCacheEntry'], $results);
+	}
+
+	public function searchByMime($mimetype) {
+		$results = $this->getCache()->searchByMime($mimetype);
+		$this->preloadEntries($results);
+		return array_map([$this, 'formatCacheEntry'], $results);
+	}
+
+	public function searchQuery(ISearchQuery $query) {
+		$results = $this->getCache()->searchQuery($query);
+		$this->preloadEntries($results);
+		return array_map([$this, 'formatCacheEntry'], $results);
+	}
+
+	/**
+	 * @param ICacheEntry[] $entries
+	 */
+	private function preloadEntries(array $entries) {
+		$paths = array_map(function (ICacheEntry $entry) {
+			return $entry->getPath();
+		}, $entries);
+		$this->aclManager->preloadPaths($paths);
 	}
 }

--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2019 Robin Appelman <robin@icewind.nl>
  *
@@ -106,6 +108,14 @@ class ACLManager {
 		}
 
 		return $paths;
+	}
+
+	public function preloadPaths(array $paths) {
+		$allPaths = [];
+		foreach ($paths as $path) {
+			$allPaths = array_unique(array_merge($allPaths, $this->getParents($path)));
+		}
+		$this->getRules($allPaths);
 	}
 
 	public function getACLPermissionsForPath(string $path): int {


### PR DESCRIPTION
this greatly speeds up handling of large folders and search results

Signed-off-by: Robin Appelman <robin@icewind.nl>