### PR TITLE
preventDefault on folder create submit event

### DIFF
--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {ChangeEvent, Component} from 'react';
+import {ChangeEvent, Component, FormEvent} from 'react';
 
 import {Api, Folder, Group, ManageRuleProps, OCSGroup, OCSUser} from './Api';
 import {FolderGroups} from './FolderGroups';
@@ -57,7 +57,8 @@ export class App extends Component<{}, AppState> implements OC.Plugin<OC.Search.
 		OC.Plugins.register('OCA.Search.Core', this);
 	}
 
-	createRow = () => {
+	createRow = (event: FormEvent) => {
+		event.preventDefault();
 		const mountPoint = this.state.newMountPoint;
 		if (!mountPoint) {
 			return;


### PR DESCRIPTION
Currently when navigating to the group folders settings and pressing create, it will triger the form submit navigation to `settings/admins/groupfolders#?`.
Once you're at the url with `#` the form submit will no longer triger a page nagivation.

Signed-off-by: Robin Appelman <robin@icewind.nl>