### PR TITLE
Fixed searching for groups in the sharing sideview

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -255,13 +255,15 @@ class FolderManager {
 
 	private function getGroups($id): array {
 		$groups = $this->getAllApplicable()[$id] ?? [];
-		return array_map(function ($gid) {
-			$group = $this->groupManager->get($gid);
+		$groups = array_map(function ($gid) {
+			return $this->groupManager->get($gid);
+		}, array_keys($groups));
+		return array_map(function ($group) {
 			return [
 				'gid' => $group->getGID(),
 				'displayname' => $group->getDisplayName()
 			];
-		}, array_keys($groups));
+		}, array_filter($groups));
 	}
 
 	public function canManageACL($folderId, $userId): bool {

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -195,7 +195,7 @@
 			},
 			searchMappings (query) {
 				axios.get(OC.generateUrl(`apps/groupfolders/folders/${this.groupFolderId}/search`) + '?format=json&search=' + query).then((result) => {
-					let groups = result.data.ocs.data.groups.map((group) => {
+					let groups = Object.values(result.data.ocs.data.groups).map((group) => {
 						return {
 							unique: 'group:' + group.gid,
 							type: 'group',

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -122,7 +122,7 @@ export class Api {
 		return $.getJSON(this.getUrl(`folders/${folderId}/search?format=json&search=${search}`))
 			.then((data: OCSResult<{ groups: OCSGroup[]; users: OCSUser[]; }>) => {
 				return {
-					groups: data.ocs.data.groups.map((item) => {
+					groups: Object.values(data.ocs.data.groups).map((item) => {
 						return {
 							type: 'group',
 							id: item.gid,


### PR DESCRIPTION
The result of FolderManager::getGroups and ::searchGroups are indexed
arrays. Thus, the data returned by the .../search?... route
are JSON Objects and not arrays.