### PR TITLE
Revert "fix ACL error: user can not manage acl even assigned in setting"

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -275,7 +275,7 @@ class FolderManager {
 			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('user')))
 			->andWhere($query->expr()->eq('mapping_id', $query->createNamedParameter($userId)));
-		if (count($query->execute()->fetchAll()) === 1) {
+		if ($query->execute()->rowCount() === 1) {
 			return true;
 		}
 


### PR DESCRIPTION
Reverts nextcloud/groupfolders#1364 as it was merged without reviews and I don't see the need to fetch all rows just for checking existance the execute and rowCount should work fine. 

I've put branch protections for master/stable in place now as they seemed to be missing on the groupfolders repo.

@Nienzu Maybe you can reopen https://github.com/nextcloud/groupfolders/pull/1364 once the merge has been reverted and describe your setup a bit more in detail, especially what DB you are using, because I cannot reproduce the original issue with the code.