### PR TITLE
Only return user result once

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -154,7 +154,7 @@ class FolderManager {
 		$folderMap = [];
 		foreach ($rows as $row) {
 			$id = (int)$row['folder_id'];
-			
+
 			if (!isset($folderMap[$id])) {
 				$folderMap[$id] = [$row];
 			} else {
@@ -307,20 +307,22 @@ class FolderManager {
 
 	public function searchUsers($id, $search = '', $limit = 10, $offset = 0): array {
 		$groups = $this->getGroups($id);
-		$users = [[]];
+		$users = [];
 		foreach ($groups as $groupArray) {
 			$group = $this->groupManager->get($groupArray['gid']);
 			if ($group) {
 				$foundUsers = $this->groupManager->displayNamesInGroup($group->getGID(), $search, $limit, $offset);
-				$users[] = array_map(function ($uid, $displayname) {
-					return [
-						'uid' => $uid,
-						'displayname' => $displayname
-					];
-				}, array_keys($foundUsers), $foundUsers);
+				foreach ($foundUsers as $uid => $displayName) {
+					if (!isset($users[$uid])) {
+						$users[$uid] = [
+							'uid' => $uid,
+							'displayname' => $displayName
+						];
+					}
+				}
 			}
 		}
-		return array_merge(...$users);
+		return array_values($users);
 	}
 
 	/**


### PR DESCRIPTION
- Have two groups with the same user being member of
- Search for the user in the ACL list

Before:
- See duplicate entries for the user

After:
- Each user result is only displayed once