### PR TITLE
Mock database dependency as it is being pulled in by the CacheWrapper

### DIFF
--- a/tests/ACL/ACLCacheWrapperTest.php
+++ b/tests/ACL/ACLCacheWrapperTest.php
@@ -26,6 +26,7 @@ use OCA\GroupFolders\ACL\ACLCacheWrapper;
 use OCA\GroupFolders\ACL\ACLManager;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
+use OCP\IDBConnection;
 use Test\TestCase;
 
 class ACLCacheWrapperTest extends TestCase {
@@ -39,6 +40,10 @@ class ACLCacheWrapperTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+
+		\OC::$server->registerService(IDBConnection::class, function () {
+			return $this->createMock(IDBConnection::class);
+		});
 
 		$this->aclManager = $this->createMock(ACLManager::class);
 		$this->aclManager->method('getACLPermissionsForPath')


### PR DESCRIPTION
Test failed after https://github.com/nextcloud/server/pull/26874 was merged since the CacheWrapper now has a dependency on the database connection which is being pulled in through the server container.

Fixes #1537 