### PR TITLE
Avoid double encoding the group name in the ACL options

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -237,7 +237,7 @@ export default {
 		},
 		getFullDisplayName(displayName, type) {
 			if (type === 'group') {
-				return t('groupfolders', '{displayName} (Group)', { displayName })
+				return `${displayName} (${t('groupfolders', 'Group')})`
 			}
 
 			return displayName


### PR DESCRIPTION
Steps to reproduce:
- Create a group named "A&B"
- Setup ACL on a groupfolder
- Search for the group in the sharing sidebar ACL UI
- Set a custom ACL rule

Before:
- The ampersand was encoded twice

After:
- The group name is displayed properly