### PR TITLE
[stable20] Avoid double encoding the group name in the ACL options

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -203,7 +203,7 @@
 			},
 			getFullDisplayName (displayName, type) {
 				if (type === 'group') {
-					return t('groupfolders', '{displayName} (Group)', { displayName: displayName })
+					return `${displayName} (${t('groupfolders', 'Group')})`
 				}
 
 				return displayName


### PR DESCRIPTION
Backport of #1601