### PR TITLE
[Backport stable21]: Correctly calculate directory sizes when using an object store primary storage

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -23,6 +23,8 @@ namespace OCA\GroupFolders\Mount;
 
 
 use OC\Files\Cache\Scanner;
+use OC\Files\ObjectStore\NoopScanner;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\IUser;
@@ -86,7 +88,9 @@ class GroupFolderStorage extends Quota {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($storage->scanner)) {
+		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
+			$storage->scanner = new NoopScanner($storage);
+		} else if (!isset($storage->scanner)) {
 			$storage->scanner = new Scanner($storage);
 		}
 		return $storage->scanner;


### PR DESCRIPTION
…y storage

A object store storage should use an NoopScanner since it is not
possible to scan the directory structure of an object store. This makes
sure that the group folder mount point doesn't override the NoopScanner
that the object store storage use.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>