### PR TITLE
Fix fetching groups

### DIFF
--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -45,19 +45,8 @@ export class Api {
 	}
 
 	listGroups(): Thenable<Group[]> {
-		const version = parseInt(OC.config.version, 10);
-		if (version >= 14) {
-			return $.getJSON(OC.linkToOCS('cloud', 1) + 'groups/details')
-				.then((data: OCSResult<{ groups: Group[]; }>) => data.ocs.data.groups);
-		} else {
-			return $.getJSON(OC.linkToOCS('cloud', 1) + 'groups')
-				.then((data: OCSResult<{ groups: string[]; }>) => data.ocs.data.groups.map(group => {
-					return {
-						id: group,
-						displayname: group
-					};
-				}));
-		}
+		return $.getJSON(OC.linkToOCS('cloud', 1) + '/groups/details')
+			.then((data: OCSResult<{ groups: Group[]; }>) => data.ocs.data.groups);
 	}
 
 	createFolder(mountPoint: string): Thenable<number> {


### PR DESCRIPTION
Before the api call was made to /ocs/v2.php/cloudgroups/details
and this is now changed to /ocs/v2.php/cloud/groups/details. This also
remove the compatibility with nextcloud <= 14

Signed-off-by: Carl Schwan <carl@carlschwan.eu>