### PR TITLE
Makefile should use npm to compile javascript and not directly call webpack.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ node_modules: package.json
 	npm install --deps
 
 build/main.js: node_modules $(jssources)
-	NODE_ENV=production $(webpack) --config webpack.js
+	npm run build
 
 .PHONY: watch
 watch: node_modules


### PR DESCRIPTION
By using 'npm run build' instead of calling webpack directly, webpack
gets some additional npm environment variables. Some of these environment
variables are used by @nextcloud/webpack-vue-config (npm_package_name and npm_package_version).

With some build environment webpacks fails miserabily when npm_package_name is not defined, and
the following error message shows up:

>Building undefined undefined
>
>[webpack-cli] Failed to load '/var/www/nextcloud/apps/groupfolders/webpack.js' config
>[webpack-cli] TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined

The "Building undefined undefined" string comes from @nextcloud/webpack-vue-config's
webpack.js file.

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>