### PR TITLE
Load groupfolders-files.js instead of files.json

### DIFF
--- a/lib/Listeners/LoadAdditionalScriptsListener.php
+++ b/lib/Listeners/LoadAdditionalScriptsListener.php
@@ -31,6 +31,6 @@ use OCP\EventDispatcher\IEventListener;
 
 class LoadAdditionalScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
-		\OCP\Util::addScript('groupfolders', 'files');
+		\OCP\Util::addScript('groupfolders', 'groupfolders-files');
 	}
 }


### PR DESCRIPTION
It seems that webpack now generates groupfolders-files.js instead of
files.js so the previous generated link was 404 and the group folder
icons was wrong.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>