### PR TITLE
Make advanced permissions to inherit per user/group

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once configured, the folders will show up in the home folder for each user in th
 
 _Advanced Permissions_ allows entitled users to configure permissions inside groupfolders on a per file and folder basis.
 
-Permissions are configured by setting one or more of "Read", "Write", "Create", "Delete" or "Share" permissions to "allow" or "deny". Any permission not explicitly set will inherit the permissions from the parent folder. If multiple configured advanced permissions for a single file or folder apply for a single user (such as when a user belongs to multiple groups), the "allow" permission will overwrite any "deny" permission. Denied permissions configured for the group folder itself cannot be overwritten to "allow" permissions by the advanced permission rules.
+Permissions are configured by setting one or more of "Read", "Write", "Create", "Delete" or "Share" permissions to "allow" or "deny". Any permission not explicitly set for a user/group will inherit the user/group's permissions from the parent folder. If multiple configured advanced permissions for a single file or folder apply for a single user (such as when a user belongs to multiple groups), the "allow" permission will overwrite any "deny" permission. Denied permissions configured for the group folder itself cannot be overwritten to "allow" permissions by the advanced permission rules.
 
 ![advanced permissions](screenshots/acl.png)
 

--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -117,28 +117,4 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 			(int)$elements[self::PERMISSIONS]
 		);
 	}
-
-	/**
-	 * merge multiple rules that apply on the same file where allow overwrites deny
-	 *
-	 * @param array $rules
-	 * @return Rule
-	 */
-	public static function mergeRules(array $rules): Rule {
-		// or'ing the masks to get a new mask that masks all set permissions
-		$mask = array_reduce($rules, function (int $mask, Rule $rule) {
-			return $mask | $rule->getMask();
-		}, 0);
-		// or'ing the permissions combines them with allow overwriting deny
-		$permissions = array_reduce($rules, function (int $permissions, Rule $rule) {
-			return $permissions | $rule->getPermissions();
-		}, 0);
-
-		return new Rule(
-			new UserMapping('dummy', ''),
-			-1,
-			$mask,
-			$permissions
-		);
-	}
 }

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -24,7 +24,7 @@ namespace OCA\groupfolders\tests\ACL;
 use OCA\GroupFolders\ACL\ACLManager;
 use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\ACL\RuleManager;
-use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
+use OCA\GroupFolders\ACL\UserMapping\UserMapping;
 use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -38,7 +38,7 @@ class ACLManagerTest extends TestCase {
 	private $user;
 	/** @var ACLManager */
 	private $aclManager;
-	/** @var IUserMapping */
+	/** @var UserMapping */
 	private $dummyMapping;
 	/** @var Rule[] */
 	private $rules = [];
@@ -57,7 +57,7 @@ class ACLManagerTest extends TestCase {
 		$this->aclManager = new ACLManager($this->ruleManager, $this->user, function () use ($rootFolder) {
 			return $rootFolder;
 		});
-		$this->dummyMapping = $this->createMock(IUserMapping::class);
+		$this->dummyMapping = $this->createMock(UserMapping::class);
 
 		$this->ruleManager->method('getRulesForFilesByPath')
 			->willReturnCallback(function (IUser $user, int $storageId, array $paths) {
@@ -88,5 +88,25 @@ class ACLManagerTest extends TestCase {
 		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE - Constants::PERMISSION_UPDATE, $this->aclManager->getACLPermissionsForPath('foo'));
 		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE, $this->aclManager->getACLPermissionsForPath('foo/bar'));
 		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath('foo/bar/sub'));
+	}
+
+	public function testGetACLPermissionsForPathWithMultipleMappings() {
+		$anoterMapping = new UserMapping('group', 'test');
+		$this->rules = [
+			'foo' => [
+				new Rule($this->dummyMapping, 10, Constants::PERMISSION_ALL, Constants::PERMISSION_READ), // read only for dummyMapping
+				new Rule($anoterMapping, 10, 0, 0) // allow all for anotherMapping
+			],
+			'foo/bar' => [
+				new Rule($this->dummyMapping, 10, Constants::PERMISSION_UPDATE, Constants::PERMISSION_UPDATE), // add write for dummyMapping
+				new Rule($anoterMapping, 10, Constants::PERMISSION_UPDATE, 0) // deny write for anotherMapping
+			],
+			'foo/bar/sub' => [
+				new Rule($this->dummyMapping, 10, Constants::PERMISSION_ALL, 0) // deny all for dummyMapping
+			]
+		];
+		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath('foo'));
+		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath('foo/bar'));
+		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE, $this->aclManager->getACLPermissionsForPath('foo/bar/sub'));
 	}
 }

--- a/tests/ACL/RuleTest.php
+++ b/tests/ACL/RuleTest.php
@@ -43,39 +43,4 @@ class RuleTest extends TestCase {
 		$rule = new Rule($this->createMock(IUserMapping::class), 0, $mask, $permissions);
 		$this->assertEquals($expected, $rule->applyPermissions($input));
 	}
-
-	public function mergeRulesProvider() {
-		return [
-			[[
-				[0b00001111, 0b00000011],
-				[0b00001111, 0b00000011],
-			], 0b00001111, 0b00000011],
-			[[
-				[0b00001111, 0b00000000],
-				[0b00001111, 0b00000011],
-			], 0b00001111, 0b00000011],
-			[[
-				[0b00000011, 0b00000011],
-				[0b00001100, 0b00000000],
-			], 0b00001111, 0b00000011],
-			[[
-				[0b00001100, 0b00000000],
-				[0b00000011, 0b00000011],
-				[0b00001111, 0b00000100],
-			], 0b00001111, 0b00000111],
-		];
-	}
-
-	/**
-	 * @dataProvider mergeRulesProvider
-	 */
-	public function testMergeRules($inputs, $expectedMask, $expectedPermissions) {
-		$inputRules = array_map(function (array $input) {
-			return new Rule($this->createMock(IUserMapping::class), 0, $input[0], $input[1]);
-		}, $inputs);
-
-		$result = Rule::mergeRules($inputRules);
-		$this->assertEquals($expectedMask, $result->getMask());
-		$this->assertEquals($expectedPermissions, $result->getPermissions());
-	}
 }


### PR DESCRIPTION
I think that, in following case the member of `manager` and `test` should have write permission to `foo/bar/`.

| Folder path|Advanced permissions|
|---|:---|
| `foo/` | Allow all for `manager` group |
| `foo/bar/` | Deny write for `member` group |

But writing to `foo/bar` by the member is denied, because currently advanced permissions is calculated by the following steps:

1. Merge all user/group's permissions together with the rules that "allow" overwrites "deny", per depth of path
1. Merge permissions of all depth of path together with the rules that child's permissions overwrite parent folder's one.

Fix it by calculate permissions by following steps:

1. Merge permissions of all depth of path together with the rules that child's permissions overwrite parent folder's one, per user/group.
1. Merge all user/group's permissions together with the rules that "allow" overwrites "deny"

Close #1212