### PR TITLE
Fix rollback of file version

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -123,7 +123,7 @@ class VersionsBackend implements IVersionBackend {
 			$versionInternalPath = $version->getVersionFile()->getInternalPath();
 
 			$targetMount->getStorage()->copyFromStorage($versionMount->getStorage(), $versionInternalPath, $targetInternalPath);
-			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $versionInternalPath);
+			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $targetInternalPath);
 		}
 	}
 

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -123,7 +123,7 @@ class VersionsBackend implements IVersionBackend {
 			$versionInternalPath = $version->getVersionFile()->getInternalPath();
 
 			$targetMount->getStorage()->copyFromStorage($versionMount->getStorage(), $versionInternalPath, $targetInternalPath);
-			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $targetInternalPath);
+			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $targetMount->getSourcePath() . '/' . $targetInternalPath);
 		}
 	}
 


### PR DESCRIPTION
## Error

After the rollback, the `filecache` entry for the file does not contain the correct size which breaks the download.

## Current behaviour when a file `A` is rolled-back from `A.version1`

1. A new version is created
    - file `A` is copied to version `A.version2`
    - file cache `A` is copied to version cache `A.version2`

2. Version1 is restored
    - version `A.version1` is copied to file `A`
    - file cache `A.version1` is copied to version cache `A.version1` (which does nothing)

## Proposed change

The PR changes the last step to: file cache `A.version1` is copied to version cache `A`
