### PR TITLE
Use already cached parents when fetching ACL

### DIFF
--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -61,9 +61,13 @@ class ACLManagerTest extends TestCase {
 
 		$this->ruleManager->method('getRulesForFilesByPath')
 			->willReturnCallback(function (IUser $user, int $storageId, array $paths) {
-				return array_filter($this->rules, function (string $path) use ($paths) {
+				// fill with empty in case no rule was found
+				$rules = array_fill_keys($paths, []);
+				$actualRules = array_filter($this->rules, function (string $path) use ($paths) {
 					return array_search($path, $paths) !== false;
 				}, ARRAY_FILTER_USE_KEY);
+
+				return array_merge($rules, $actualRules);
 			});
 	}
 


### PR DESCRIPTION
When fetching ACL rules, don't refetch the rules from already cached
parents. This fixes performance issues with large folders.

Fixes https://github.com/nextcloud/groupfolders/issues/1693

Improves performance with 1100 entries from 20 seconds to 4 seconds.

- [x] BUG: because the cache is capped, the logic breaks after cached entries are getting removed by the cap (when testing I increased the capped cache's max)