### PR TITLE
[stable22] Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ node_modules: package.json
 	npm install --deps
 
 build/main.js: node_modules $(jssources)
-	NODE_ENV=production $(webpack) --config webpack.js
+	npm run build
 
 .PHONY: watch
 watch: node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "groupfolders",
       "dependencies": {
         "@nextcloud/axios": "^1.6.0",
         "@nextcloud/router": "^2.0.0",


### PR DESCRIPTION
run 'npm run build' instead of webpack

Fix #1711 

Signed-off-by: Carl Schwan <carl@carlschwan.eu>