### PR TITLE
Fix tooltips not shown

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script>
-import { PopoverMenu } from '@nextcloud/vue'
+import { PopoverMenu, Tooltip } from '@nextcloud/vue'
 
 const STATES = {
 	INHERIT_DENY: 0,
@@ -63,6 +63,9 @@ const STATES = {
 
 export default {
 	name: 'AclStateButton',
+	directives: {
+		tooltip: Tooltip,
+	},
 	components: { PopoverMenu },
 	props: {
 		inherited: {

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -153,7 +153,7 @@
 import Vue from 'vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { Avatar, Multiselect } from '@nextcloud/vue'
+import { Avatar, Multiselect, Tooltip } from '@nextcloud/vue'
 import AclStateButton from './AclStateButton'
 import Rule from './../model/Rule'
 import BinaryTools from './../BinaryTools'
@@ -163,6 +163,9 @@ let searchRequestCancelSource = null
 
 export default {
 	name: 'SharingSidebarView',
+	directives: {
+		tooltip: Tooltip,
+	},
 	components: {
 		Avatar, Multiselect, AclStateButton,
 	},


### PR DESCRIPTION
It seems that `v-tooltip` worked even if the directive was not explicitly declared when using `nextcloud-vue`, but [with the move to `@nextcloud/vue` in groupfolders 10.0.0](https://github.com/nextcloud/groupfolders/commit/f9222ef0c05fef33b8cce1b641537fdea5ce5020) and later this is now needed.
