### PR TITLE
Fix wrong object passed to the mount provider in VersionsBackend::getAllVersionedFiles

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -28,6 +28,7 @@ use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCP\Constants;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
@@ -62,7 +63,7 @@ class FolderManager {
 	/**
 	 * @return (array|bool|int|mixed)[][]
 	 *
-	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|mixed, quota: mixed, size: int, acl: bool}>
+	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int, acl: bool}>
 	 * @throws Exception
 	 */
 	public function getAllFolders(): array {
@@ -116,7 +117,7 @@ class FolderManager {
 	/**
 	 * @return (array|bool|int|mixed)[][]
 	 *
-	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|mixed, quota: mixed, size: int|mixed, acl: bool, manage: mixed}>
+	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int|mixed, acl: bool, manage: mixed}>
 	 * @throws Exception
 	 */
 	public function getAllFoldersWithSize(int $rootStorageId): array {
@@ -354,7 +355,7 @@ class FolderManager {
 	/**
 	 * @param string $groupId
 	 * @param int $rootStorageId
-	 * @return array[]
+	 * @return list<array{folder_id: int, mount_point: string, permissions: int, quota: int, acl: bool, rootCacheEntry: ?ICacheEntry}>
 	 * @throws Exception
 	 */
 	public function getFoldersForGroup(string $groupId, int $rootStorageId = 0): array {
@@ -406,7 +407,7 @@ class FolderManager {
 	/**
 	 * @param string[] $groupIds
 	 * @param int $rootStorageId
-	 * @return array[]
+	 * @return list<array{folder_id: int, mount_point: string, permissions: int, quota: int, acl: bool, rootCacheEntry: ?ICacheEntry}>
 	 * @throws Exception
 	 */
 	public function getFoldersForGroups(array $groupIds, int $rootStorageId = 0): array {

--- a/lib/Versions/GroupVersionsExpireManager.php
+++ b/lib/Versions/GroupVersionsExpireManager.php
@@ -50,7 +50,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 		$this->dispatcher = $dispatcher;
 	}
 
-	public function expireAll() {
+	public function expireAll(): void {
 		$folders = $this->folderManager->getAllFolders();
 		foreach ($folders as $folder) {
 			$this->emit(self::class, 'enterFolder', [$folder]);
@@ -58,7 +58,10 @@ class GroupVersionsExpireManager extends BasicEmitter {
 		}
 	}
 
-	public function expireFolder($folder) {
+	/**
+	 * @param array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int, acl: bool} $folder
+	 */
+	public function expireFolder(array $folder): void {
 		$view = new View('/__groupfolders/versions/' . $folder['id']);
 		$files = $this->versionsBackend->getAllVersionedFiles($folder);
 		$dummyUser = new User('', null, $this->dispatcher);

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -33,6 +33,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
+use OCP\Constant;
 
 class VersionsBackend implements IVersionBackend {
 	/** @var Folder */
@@ -151,12 +152,12 @@ class VersionsBackend implements IVersionBackend {
 	}
 
 	/**
-	 * @param array $folder
+	 * @param array{id: int, mount_point: mixed, groups: array<empty, empty>|mixed, quota: mixed, size: int, acl: bool} $folder
 	 * @return (FileInfo|null)[] [$fileId => FileInfo|null]
 	 */
 	public function getAllVersionedFiles(array $folder) {
 		$versionsFolder = $this->getVersionsFolder($folder['id']);
-		$mount = $this->mountProvider->getMount($folder['id'], '/dummyuser/files/' . $folder['mount_point'], $folder['groups'], $folder['quota']);
+		$mount = $this->mountProvider->getMount($folder['id'], '/dummyuser/files/' . $folder['mount_point'], Constant::PERMISSION_ALL, $folder['quota']);
 		try {
 			$contents = $versionsFolder->getDirectoryListing();
 		} catch (NotFoundException $e) {


### PR DESCRIPTION
`$folder['groups']` is an array from groupId to permission. The mount
    provider only wants the permission, so since we want to get all the
    versionned files, just use 31 instead.
    
Before php8, this code was working since using & for an int and an array
    gave an int. In php8, this now thrown an error.
    
This also include more type hinting that helped me figure out that was
    wrong.
    
Fix #1725