### PR TITLE
Enfore the usage of int for quota

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -63,7 +63,7 @@ class FolderManager {
 	/**
 	 * @return (array|bool|int|mixed)[][]
 	 *
-	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int, acl: bool}>
+	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: int, size: int, acl: bool}>
 	 * @throws Exception
 	 */
 	public function getAllFolders(): array {
@@ -83,7 +83,7 @@ class FolderManager {
 				'id' => $id,
 				'mount_point' => $row['mount_point'],
 				'groups' => $applicableMap[$id] ?? [],
-				'quota' => $row['quota'],
+				'quota' => (int)$row['quota'],
 				'size' => 0,
 				'acl' => (bool)$row['acl']
 			];
@@ -117,7 +117,7 @@ class FolderManager {
 	/**
 	 * @return (array|bool|int|mixed)[][]
 	 *
-	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int|mixed, acl: bool, manage: mixed}>
+	 * @psalm-return array<int, array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: int, size: int|mixed, acl: bool, manage: mixed}>
 	 * @throws Exception
 	 */
 	public function getAllFoldersWithSize(int $rootStorageId): array {
@@ -141,7 +141,7 @@ class FolderManager {
 				'id' => $id,
 				'mount_point' => $row['mount_point'],
 				'groups' => $applicableMap[$id] ?? [],
-				'quota' => $row['quota'],
+				'quota' => (int)$row['quota'],
 				'size' => $row['size'] ? $row['size'] : 0,
 				'acl' => (bool)$row['acl'],
 				'manage' => $this->getManageAcl($mappings)
@@ -207,7 +207,7 @@ class FolderManager {
 	/**
 	 * @return (array|bool|int|mixed)[]|false
 	 *
-	 * @psalm-return array{id: mixed, mount_point: mixed, groups: array<empty, empty>|mixed, quota: mixed, size: int|mixed, acl: bool}|false
+	 * @psalm-return array{id: mixed, mount_point: mixed, groups: array<empty, empty>|mixed, quota: int, size: int|mixed, acl: bool}|false
 	 * @throws Exception
 	 */
 	public function getFolder(int $id, int $rootStorageId) {
@@ -228,7 +228,7 @@ class FolderManager {
 			'id' => $id,
 			'mount_point' => $row['mount_point'],
 			'groups' => $applicableMap[$id] ?? [],
-			'quota' => $row['quota'],
+			'quota' => (int)$row['quota'],
 			'size' => $row['size'] ? $row['size'] : 0,
 			'acl' => (bool)$row['acl']
 		] : false;

--- a/lib/Versions/GroupVersionsExpireManager.php
+++ b/lib/Versions/GroupVersionsExpireManager.php
@@ -59,7 +59,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 	}
 
 	/**
-	 * @param array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: mixed, size: int, acl: bool} $folder
+	 * @param array{id: int, mount_point: mixed, groups: array<empty, empty>|array<array-key, int>, quota: int, size: int, acl: bool} $folder
 	 */
 	public function expireFolder(array $folder): void {
 		$view = new View('/__groupfolders/versions/' . $folder['id']);


### PR DESCRIPTION
The Doctrine DBAL returns a string for a bigint. This causes problems
since most of the code expects an int (QuotaStorage and MountProvider::getMount).

In particular the BackgroundJob for version expiration got broken
because of that.

The only disadvantage is that it will theorically breaks on 32bits
system but since we don't support that and some part of the code were
already expecing an int. This probably won't change anything.

@PhMetzger

Signed-off-by: Carl Schwan <carl@carlschwan.eu>