### PR TITLE
Cast argument from string to int

### DIFF
--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -55,7 +55,7 @@ class Scan extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$folderId = $input->getArgument('folder_id');
+		$folderId = (int)$input->getArgument('folder_id');
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			$mount = $this->mountProvider->getMount($folder['id'], '/' . $folder['mount_point'], Constants::PERMISSION_ALL, $folder['quota']);


### PR DESCRIPTION
The function expects an int but is given a string.

Is this a safe way to cast a string in php?