### PR TITLE
Unify folder retrival in commands

### DIFF
--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -22,6 +22,7 @@
 namespace OCA\GroupFolders\Command;
 
 use OC\Core\Command\Base;
+use OCA\GroupFolders\Command\FolderCommand;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
 use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\ACL\RuleManager;
@@ -37,7 +38,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ACL extends Base {
+class ACL extends FolderCommand {
 	const PERMISSIONS_MAP = [
 		'read' => Constants::PERMISSION_READ,
 		'write' => Constants::PERMISSION_UPDATE,
@@ -46,10 +47,7 @@ class ACL extends Base {
 		'share' => Constants::PERMISSION_SHARE,
 	];
 
-	private $folderManager;
-	private $rootFolder;
 	private $ruleManager;
-	private $mountProvider;
 	private $aclManagerFactory;
 	private $userManager;
 
@@ -61,11 +59,8 @@ class ACL extends Base {
 		ACLManagerFactory $aclManagerFactory,
 		IUserManager $userManager
 	) {
-		parent::__construct();
-		$this->folderManager = $folderManager;
-		$this->rootFolder = $rootFolder;
+		parent::__construct($folderManager, $rootFolder, $mountProvider);
 		$this->ruleManager = $ruleManager;
-		$this->mountProvider = $mountProvider;
 		$this->aclManagerFactory = $aclManagerFactory;
 		$this->userManager = $userManager;
 	}
@@ -88,122 +83,114 @@ class ACL extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$folderId = (int)$input->getArgument('folder_id');
-		if ((string)$folderId !== $input->getArgument('folder_id')) {
-			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
-			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
-			return;
+		$folder = $this->getFolder($input, $output);
+		if ($folder === false) {
+			return -1;
 		}
-		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
-		if ($folder) {
-			if ($input->getOption('enable')) {
-				$this->folderManager->setFolderACL($folderId, true);
-			} elseif ($input->getOption('disable')) {
-				$this->folderManager->setFolderACL($folderId, false);
-			} elseif ($input->getOption('test')) {
-				if ($input->getOption('user') && ($input->getArgument('path'))) {
-					$mappingId = $input->getOption('user');
-					$user = $this->userManager->get($mappingId);
-					if (!$user) {
-						$output->writeln('<error>User not found: ' . $mappingId . '</error>');
-						return -1;
-					}
-					$jailPath = $this->mountProvider->getJailPath((int)$folder['id']);
-					$path = $input->getArgument('path');
-					$aclManager = $this->aclManagerFactory->getACLManager($user);
-					$permissions = $aclManager->getACLPermissionsForPath($jailPath . rtrim('/' . $path, '/'));
-					$permissionString = $this->formatRulePermissions(Constants::PERMISSION_ALL, $permissions);
-					$output->writeln($permissionString);
-					return;
-				} else {
-					$output->writeln('<error>--user and <path> options needs to be set for permissions testing</error>');
-					return -3;
-				}
-			} elseif (!$folder['acl']) {
-				$output->writeln('<error>Advanced permissions not enabled for folder: ' . $folderId . '</error>');
-				return -2;
-			} elseif (
-				!$input->getArgument('path') &&
-				!$input->getArgument('permissions') &&
-				!$input->getOption('user') &&
-				!$input->getOption('group')
-			) {
-				$this->printPermissions($input, $output, $folder);
-			} elseif ($input->getOption('manage-add') && ($input->getOption('user') || $input->getOption('group'))) {
-				$mappingType = $input->getOption('user') ? 'user' : 'group';
-				$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
-				$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, true);
-			} elseif ($input->getOption('manage-remove') && ($input->getOption('user') || $input->getOption('group'))) {
-				$mappingType = $input->getOption('user') ? 'user' : 'group';
-				$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
-				$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, false);
-			} elseif (!$input->getArgument('path')) {
-				$output->writeln('<error><path> argument has to be set when not using --enable or --disable</error>');
-				return -3;
-			} elseif (!$input->getArgument('permissions')) {
-				$output->writeln('<error><permissions> argument has to be set when not using --enable or --disable</error>');
-				return -3;
-			} elseif ($input->getOption('user') && $input->getOption('group')) {
-				$output->writeln('<error>--user and --group can not be used at the same time</error>');
-				return -3;
-			} elseif (!$input->getOption('user') && !$input->getOption('group')) {
-				$output->writeln('<error>either --user or --group has to be used when not using --enable or --disable</error>');
-				return -3;
-			} else {
-				$mappingType = $input->getOption('user') ? 'user' : 'group';
-				$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
-				$path = $input->getArgument('path');
-				$path = trim($path, '/');
-				$permissionStrings = $input->getArgument('permissions');
-
-				$mount = $this->mountProvider->getMount(
-					$folder['id'],
-					'/dummy/files/' . $folder['mount_point'],
-					$folder['permissions'],
-					$folder['quota'],
-					$folder['rootCacheEntry'],
-					null,
-					$folder['acl']
-				);
-				$id = $mount->getStorage()->getCache()->getId($path);
-				if ($id === -1) {
-					$output->writeln('<error>Path not found in folder: ' . $path . '</error>');
+		if ($input->getOption('enable')) {
+			$this->folderManager->setFolderACL($folderId, true);
+		} elseif ($input->getOption('disable')) {
+			$this->folderManager->setFolderACL($folderId, false);
+		} elseif ($input->getOption('test')) {
+			if ($input->getOption('user') && ($input->getArgument('path'))) {
+				$mappingId = $input->getOption('user');
+				$user = $this->userManager->get($mappingId);
+				if (!$user) {
+					$output->writeln('<error>User not found: ' . $mappingId . '</error>');
 					return -1;
 				}
-
-				if ($permissionStrings === ['clear']) {
-					$this->ruleManager->deleteRule(new Rule(
-						new UserMapping($mappingType, $mappingId),
-						$id,
-						0,
-						0
-					));
-				} else {
-					foreach ($permissionStrings as $permission) {
-						if ($permission[0] !== '+' && $permission[0] !== '-') {
-							$output->writeln('<error>incorrect format for permissions "' . $permission . '"</error>');
-							return -3;
-						}
-						$name = substr($permission, 1);
-						if (!isset(self::PERMISSIONS_MAP[$name])) {
-							$output->writeln('<error>incorrect format for permissions2 "' . $permission . '"</error>');
-							return -3;
-						}
-					}
-
-					[$mask, $permissions] = $this->parsePermissions($permissionStrings);
-
-					$this->ruleManager->saveRule(new Rule(
-						new UserMapping($mappingType, $mappingId),
-						$id,
-						$mask,
-						$permissions
-					));
-				}
+				$jailPath = $this->mountProvider->getJailPath((int)$folder['id']);
+				$path = $input->getArgument('path');
+				$aclManager = $this->aclManagerFactory->getACLManager($user);
+				$permissions = $aclManager->getACLPermissionsForPath($jailPath . rtrim('/' . $path, '/'));
+				$permissionString = $this->formatRulePermissions(Constants::PERMISSION_ALL, $permissions);
+				$output->writeln($permissionString);
+				return;
+			} else {
+				$output->writeln('<error>--user and <path> options needs to be set for permissions testing</error>');
+				return -3;
 			}
+		} elseif (!$folder['acl']) {
+			$output->writeln('<error>Advanced permissions not enabled for folder: ' . $folderId . '</error>');
+			return -2;
+		} elseif (
+			!$input->getArgument('path') &&
+			!$input->getArgument('permissions') &&
+			!$input->getOption('user') &&
+			!$input->getOption('group')
+		) {
+			$this->printPermissions($input, $output, $folder);
+		} elseif ($input->getOption('manage-add') && ($input->getOption('user') || $input->getOption('group'))) {
+			$mappingType = $input->getOption('user') ? 'user' : 'group';
+			$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
+			$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, true);
+		} elseif ($input->getOption('manage-remove') && ($input->getOption('user') || $input->getOption('group'))) {
+			$mappingType = $input->getOption('user') ? 'user' : 'group';
+			$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
+			$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, false);
+		} elseif (!$input->getArgument('path')) {
+			$output->writeln('<error><path> argument has to be set when not using --enable or --disable</error>');
+			return -3;
+		} elseif (!$input->getArgument('permissions')) {
+			$output->writeln('<error><permissions> argument has to be set when not using --enable or --disable</error>');
+			return -3;
+		} elseif ($input->getOption('user') && $input->getOption('group')) {
+			$output->writeln('<error>--user and --group can not be used at the same time</error>');
+			return -3;
+		} elseif (!$input->getOption('user') && !$input->getOption('group')) {
+			$output->writeln('<error>either --user or --group has to be used when not using --enable or --disable</error>');
+			return -3;
 		} else {
-			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
-			return -1;
+			$mappingType = $input->getOption('user') ? 'user' : 'group';
+			$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
+			$path = $input->getArgument('path');
+			$path = trim($path, '/');
+			$permissionStrings = $input->getArgument('permissions');
+
+			$mount = $this->mountProvider->getMount(
+				$folder['id'],
+				'/dummy/files/' . $folder['mount_point'],
+				$folder['permissions'],
+				$folder['quota'],
+				$folder['rootCacheEntry'],
+				null,
+				$folder['acl']
+			);
+			$id = $mount->getStorage()->getCache()->getId($path);
+			if ($id === -1) {
+				$output->writeln('<error>Path not found in folder: ' . $path . '</error>');
+				return -1;
+			}
+
+			if ($permissionStrings === ['clear']) {
+				$this->ruleManager->deleteRule(new Rule(
+					new UserMapping($mappingType, $mappingId),
+					$id,
+					0,
+					0
+				));
+			} else {
+				foreach ($permissionStrings as $permission) {
+					if ($permission[0] !== '+' && $permission[0] !== '-') {
+						$output->writeln('<error>incorrect format for permissions "' . $permission . '"</error>');
+						return -3;
+					}
+					$name = substr($permission, 1);
+					if (!isset(self::PERMISSIONS_MAP[$name])) {
+						$output->writeln('<error>incorrect format for permissions2 "' . $permission . '"</error>');
+						return -3;
+					}
+				}
+
+				[$mask, $permissions] = $this->parsePermissions($permissionStrings);
+
+				$this->ruleManager->saveRule(new Rule(
+					new UserMapping($mappingType, $mappingId),
+					$id,
+					$mask,
+					$permissions
+				));
+			}
 		}
 		return 0;
 	}

--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -89,6 +89,11 @@ class ACL extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return;
+		}
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			if ($input->getOption('enable')) {

--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -88,9 +88,9 @@ class ACL extends FolderCommand {
 			return -1;
 		}
 		if ($input->getOption('enable')) {
-			$this->folderManager->setFolderACL($folderId, true);
+			$this->folderManager->setFolderACL($folder['id'], true);
 		} elseif ($input->getOption('disable')) {
-			$this->folderManager->setFolderACL($folderId, false);
+			$this->folderManager->setFolderACL($folder['id'], false);
 		} elseif ($input->getOption('test')) {
 			if ($input->getOption('user') && ($input->getArgument('path'))) {
 				$mappingId = $input->getOption('user');
@@ -105,13 +105,13 @@ class ACL extends FolderCommand {
 				$permissions = $aclManager->getACLPermissionsForPath($jailPath . rtrim('/' . $path, '/'));
 				$permissionString = $this->formatRulePermissions(Constants::PERMISSION_ALL, $permissions);
 				$output->writeln($permissionString);
-				return;
+				return 0;
 			} else {
 				$output->writeln('<error>--user and <path> options needs to be set for permissions testing</error>');
 				return -3;
 			}
 		} elseif (!$folder['acl']) {
-			$output->writeln('<error>Advanced permissions not enabled for folder: ' . $folderId . '</error>');
+			$output->writeln('<error>Advanced permissions not enabled for folder: ' . $folder['id'] . '</error>');
 			return -2;
 		} elseif (
 			!$input->getArgument('path') &&
@@ -123,11 +123,11 @@ class ACL extends FolderCommand {
 		} elseif ($input->getOption('manage-add') && ($input->getOption('user') || $input->getOption('group'))) {
 			$mappingType = $input->getOption('user') ? 'user' : 'group';
 			$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
-			$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, true);
+			$this->folderManager->setManageACL($folder['id'], $mappingType, $mappingId, true);
 		} elseif ($input->getOption('manage-remove') && ($input->getOption('user') || $input->getOption('group'))) {
 			$mappingType = $input->getOption('user') ? 'user' : 'group';
 			$mappingId = $input->getOption('user') ? $input->getOption('user') : $input->getOption('group');
-			$this->folderManager->setManageACL($folderId, $mappingType, $mappingId, false);
+			$this->folderManager->setManageACL($folder['id'], $mappingType, $mappingId, false);
 		} elseif (!$input->getArgument('path')) {
 			$output->writeln('<error><path> argument has to be set when not using --enable or --disable</error>');
 			return -3;
@@ -169,28 +169,28 @@ class ACL extends FolderCommand {
 					0,
 					0
 				));
-			} else {
-				foreach ($permissionStrings as $permission) {
-					if ($permission[0] !== '+' && $permission[0] !== '-') {
-						$output->writeln('<error>incorrect format for permissions "' . $permission . '"</error>');
-						return -3;
-					}
-					$name = substr($permission, 1);
-					if (!isset(self::PERMISSIONS_MAP[$name])) {
-						$output->writeln('<error>incorrect format for permissions2 "' . $permission . '"</error>');
-						return -3;
-					}
-				}
-
-				[$mask, $permissions] = $this->parsePermissions($permissionStrings);
-
-				$this->ruleManager->saveRule(new Rule(
-					new UserMapping($mappingType, $mappingId),
-					$id,
-					$mask,
-					$permissions
-				));
+				return 0;
 			}
+			foreach ($permissionStrings as $permission) {
+				if ($permission[0] !== '+' && $permission[0] !== '-') {
+					$output->writeln('<error>incorrect format for permissions "' . $permission . '"</error>');
+					return -3;
+				}
+				$name = substr($permission, 1);
+				if (!isset(self::PERMISSIONS_MAP[$name])) {
+					$output->writeln('<error>incorrect format for permissions2 "' . $permission . '"</error>');
+					return -3;
+				}
+			}
+
+			[$mask, $permissions] = $this->parsePermissions($permissionStrings);
+
+			$this->ruleManager->saveRule(new Rule(
+				new UserMapping($mappingType, $mappingId),
+				$id,
+				$mask,
+				$permissions
+			));
 		}
 		return 0;
 	}

--- a/lib/Command/Create.php
+++ b/lib/Command/Create.php
@@ -29,13 +29,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Create extends Base {
+	/** @var FolderManager $folderManager */
 	private $folderManager;
-	private $rootFolder;
 
-	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder) {
+	public function __construct(FolderManager $folderManager) {
 		parent::__construct();
 		$this->folderManager = $folderManager;
-		$this->rootFolder = $rootFolder;
 	}
 
 	protected function configure() {

--- a/lib/Command/Delete.php
+++ b/lib/Command/Delete.php
@@ -54,10 +54,15 @@ class Delete extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return;
+		}
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			$helper = $this->getHelper('question');
-			$question = new ConfirmationQuestion('Are you sure you want to delete the group folder' . $folder['mount_point'] . ' and all files within, this cannot be undone (y/N).', false);
+			$question = new ConfirmationQuestion('Are you sure you want to delete the group folder ' . $folder['mount_point'] . ' and all files within, this cannot be undone (y/N).', false);
 			if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
 				$folder = $this->mountProvider->getFolder($folderId);
 				$this->folderManager->removeFolder($folderId);

--- a/lib/Command/Delete.php
+++ b/lib/Command/Delete.php
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class FolderCommand extends Base {
+class Delete extends FolderCommand {
 	protected function configure() {
 		$this
 			->setName('groupfolders:delete')
@@ -47,9 +47,9 @@ class FolderCommand extends Base {
 		$helper = $this->getHelper('question');
 		$question = new ConfirmationQuestion('Are you sure you want to delete the group folder ' . $folder['mount_point'] . ' and all files within, this cannot be undone (y/N).', false);
 		if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
-			$folder = $this->mountProvider->getFolder($folderId);
-			$this->folderManager->removeFolder($folderId);
-			$folder->delete();
+			$folderMount = $this->mountProvider->getFolder($folder['id']);
+			$this->folderManager->removeFolder($folder['id']);
+			$folderMount->delete();
 		}
 		return 0;
 	}

--- a/lib/Command/FolderCommand.php
+++ b/lib/Command/FolderCommand.php
@@ -26,18 +26,17 @@ use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Mount\MountProvider;
 use OCP\Files\IRootFolder;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Base command for commands asking the user for a folder id.
  */
 abstract class FolderCommand extends Base {
-	/** @var FolderManager */
+	/** @var FolderManager $folderManager */
 	protected $folderManager;
-	/** @var IRootFolder */
+	/** @var IRootFolder $rootFolder */
 	protected $rootFolder;
-	/** @var MountProvider */
+	/** @var MountProvider $mountProvider */
 	protected $mountProvider;
 
 	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder, MountProvider $mountProvider) {
@@ -62,5 +61,6 @@ abstract class FolderCommand extends Base {
 			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
 			return false;
 		}
+		return $folder;
 	}
 }

--- a/lib/Command/FolderCommand.php
+++ b/lib/Command/FolderCommand.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Command;
+
+use OC\Core\Command\Base;
+use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\MountProvider;
+use OCP\Files\IRootFolder;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Base command for commands asking the user for a folder id.
+ */
+abstract class FolderCommand extends Base {
+	/** @var FolderManager */
+	protected $folderManager;
+	/** @var IRootFolder */
+	protected $rootFolder;
+	/** @var MountProvider */
+	protected $mountProvider;
+
+	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder, MountProvider $mountProvider) {
+		parent::__construct();
+		$this->folderManager = $folderManager;
+		$this->rootFolder = $rootFolder;
+		$this->mountProvider = $mountProvider;
+	}
+
+	/**
+	 * @psalm-return array{id: mixed, mount_point: mixed, groups: array<empty, empty>|mixed, quota: int, size: int|mixed, acl: bool}|false
+	 */
+	protected function getFolder(InputInterface $input, OutputInterface $output) {
+		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return false;
+		}
+		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
+		if ($folder === false) {
+			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
+			return false;
+		}
+	}
+}

--- a/lib/Command/Group.php
+++ b/lib/Command/Group.php
@@ -65,6 +65,11 @@ class Group extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return;
+		}
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			$groupString = $input->getArgument('group');

--- a/lib/Command/Group.php
+++ b/lib/Command/Group.php
@@ -23,6 +23,7 @@ namespace OCA\GroupFolders\Command;
 
 use OC\Core\Command\Base;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\MountProvider;
 use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\IGroupManager;
@@ -31,23 +32,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Group extends Base {
+class Group extends FolderCommand {
 	const PERMISSION_VALUES = [
 		'read' => Constants::PERMISSION_READ,
 		'write' => Constants::PERMISSION_UPDATE | Constants::PERMISSION_CREATE,
 		'share' => Constants::PERMISSION_SHARE,
 		'delete' => Constants::PERMISSION_DELETE,
 	];
-
-
-	private $folderManager;
-	private $rootFolder;
+	/** @var IGroupManager $groupManager */
 	private $groupManager;
 
-	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder, IGroupManager $groupManager) {
-		parent::__construct();
-		$this->folderManager = $folderManager;
-		$this->rootFolder = $rootFolder;
+	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder, IGroupManager $groupManager, MountProvider $mountProvider) {
+		parent::__construct($folderManager, $rootFolder, $mountProvider);
 		$this->groupManager = $groupManager;
 	}
 
@@ -64,40 +60,30 @@ class Group extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$folderId = (int)$input->getArgument('folder_id');
-		if ((string)$folderId !== $input->getArgument('folder_id')) {
-			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
-			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
-			return;
-		}
-		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
-		if ($folder) {
-			$groupString = $input->getArgument('group');
-			$group = $this->groupManager->get($groupString);
-			if ($input->getOption('delete')) {
-				$this->folderManager->removeApplicableGroup($folderId, $groupString);
-				return 0;
-			} elseif ($group) {
-				$permissionsString = $input->getArgument('permissions');
-				$permissions = $this->getNewPermissions($permissionsString);
-				if ($permissions) {
-					if (!isset($folder['groups'][$groupString])) {
-						$this->folderManager->addApplicableGroup($folderId, $groupString);
-					}
-					$this->folderManager->setGroupPermissions($folderId, $groupString, $permissions);
-					return 0;
-				} else {
-					$output->writeln('<error>Unable to parse permissions input: ' . implode(' ', $permissionsString) . '</error>');
-					return -1;
-				}
-			} else {
-				$output->writeln('<error>group not found: ' . $groupString . '</error>');
-				return -1;
-			}
-		} else {
-			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
+		$folder = $this->getFolder($input, $output);
+		if ($folder === false) {
 			return -1;
 		}
+		$groupString = $input->getArgument('group');
+		$group = $this->groupManager->get($groupString);
+		if ($input->getOption('delete')) {
+			$this->folderManager->removeApplicableGroup($folder['id'], $groupString);
+			return 0;
+		} elseif ($group) {
+			$permissionsString = $input->getArgument('permissions');
+			$permissions = $this->getNewPermissions($permissionsString);
+			if ($permissions) {
+				if (!isset($folder['groups'][$groupString])) {
+					$this->folderManager->addApplicableGroup($folder['id'], $groupString);
+				}
+				$this->folderManager->setGroupPermissions($folder['id'], $groupString, $permissions);
+				return 0;
+			}
+			$output->writeln('<error>Unable to parse permissions input: ' . implode(' ', $permissionsString) . '</error>');
+			return -1;
+		}
+		$output->writeln('<error>group not found: ' . $groupString . '</error>');
+		return -1;
 	}
 
 	private function getNewPermissions(array $input) {

--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -50,6 +50,11 @@ class Quota extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return;
+		}
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			$quotaString = strtolower($input->getArgument('quota'));

--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -22,6 +22,7 @@
 namespace OCA\GroupFolders\Command;
 
 use OC\Core\Command\Base;
+use OCA\GroupFolders\Command\FolderCommand;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
@@ -29,16 +30,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Quota extends Base {
-	private $folderManager;
-	private $rootFolder;
-
-	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder) {
-		parent::__construct();
-		$this->folderManager = $folderManager;
-		$this->rootFolder = $rootFolder;
-	}
-
+class Quota extends FolderCommand {
 	protected function configure() {
 		$this
 			->setName('groupfolders:quota')
@@ -49,26 +41,17 @@ class Quota extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$folderId = (int)$input->getArgument('folder_id');
-		if ((string)$folderId !== $input->getArgument('folder_id')) {
-			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
-			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
-			return;
-		}
-		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
-		if ($folder) {
-			$quotaString = strtolower($input->getArgument('quota'));
-			$quota = ($quotaString === 'unlimited') ? FileInfo::SPACE_UNLIMITED : \OCP\Util::computerFileSize($quotaString);
-			if ($quota) {
-				$this->folderManager->setFolderQuota($folderId, $quota);
-				return 0;
-			} else {
-				$output->writeln('<error>Unable to parse quota input: ' . $quotaString . '</error>');
-				return -1;
-			}
-		} else {
-			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
+		$folder = $this->getFolder($input, $output);
+		if ($folder === false) {
 			return -1;
 		}
+		$quotaString = strtolower($input->getArgument('quota'));
+		$quota = ($quotaString === 'unlimited') ? FileInfo::SPACE_UNLIMITED : \OCP\Util::computerFileSize($quotaString);
+		if ($quota) {
+			$this->folderManager->setFolderQuota($folderId, $quota);
+			return 0;
+		}
+		$output->writeln('<error>Unable to parse quota input: ' . $quotaString . '</error>');
+		return -1;
 	}
 }

--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -48,7 +48,7 @@ class Quota extends FolderCommand {
 		$quotaString = strtolower($input->getArgument('quota'));
 		$quota = ($quotaString === 'unlimited') ? FileInfo::SPACE_UNLIMITED : \OCP\Util::computerFileSize($quotaString);
 		if ($quota) {
-			$this->folderManager->setFolderQuota($folderId, $quota);
+			$this->folderManager->setFolderQuota($folder['id'], $quota);
 			return 0;
 		}
 		$output->writeln('<error>Unable to parse quota input: ' . $quotaString . '</error>');

--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -23,20 +23,15 @@ namespace OCA\GroupFolders\Command;
 
 use OC\Core\Command\Base;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Command\FolderCommand;
 use OCP\Files\IRootFolder;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Rename extends Base {
+class Rename extends FolderCommand {
 	private $folderManager;
 	private $rootFolder;
-
-	public function __construct(FolderManager $folderManager, IRootFolder $rootFolder) {
-		parent::__construct();
-		$this->folderManager = $folderManager;
-		$this->rootFolder = $rootFolder;
-	}
 
 	protected function configure() {
 		$this
@@ -48,19 +43,11 @@ class Rename extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$folderId = (int)$input->getArgument('folder_id');
-		if ((string)$folderId !== $input->getArgument('folder_id')) {
-			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
-			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
-			return;
-		}
-		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
-		if ($folder) {
-			$this->folderManager->renameFolder($folderId, $input->getArgument('name'));
-			return 0;
-		} else {
-			$output->writeln('<error>Folder not found: ' . $folderId . '</error>');
+		$folder = $this->getFolder($input, $output);
+		if ($folder === false) {
 			return -1;
 		}
+		$this->folderManager->renameFolder($folderId, $input->getArgument('name'));
+		return 0;
 	}
 }

--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -49,6 +49,11 @@ class Rename extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$folderId = (int)$input->getArgument('folder_id');
+		if ((string)$folderId !== $input->getArgument('folder_id')) {
+			// Protect against removing folderId === 0 when typing a string (e.g. folder name instead of folder id)
+			$output->writeln('<error>Folder id argument is not an integer. Got ' . $input->getArgument('folder_id') . '</error>');
+			return;
+		}
 		$folder = $this->folderManager->getFolder($folderId, $this->rootFolder->getMountPoint()->getNumericStorageId());
 		if ($folder) {
 			$this->folderManager->renameFolder($folderId, $input->getArgument('name'));

--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -30,9 +30,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Rename extends FolderCommand {
-	private $folderManager;
-	private $rootFolder;
-
 	protected function configure() {
 		$this
 			->setName('groupfolders:rename')
@@ -47,7 +44,7 @@ class Rename extends FolderCommand {
 		if ($folder === false) {
 			return -1;
 		}
-		$this->folderManager->renameFolder($folderId, $input->getArgument('name'));
+		$this->folderManager->renameFolder($folder['id'], $input->getArgument('name'));
 		return 0;
 	}
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -10,24 +10,65 @@
     </MissingDependency>
   </file>
   <file src="lib/AppInfo/Application.php">
+    <InvalidArgument occurrences="1">
+      <code>registerEventListener</code>
+    </InvalidArgument>
     <MissingDependency occurrences="17">
       <code>$c-&gt;getServer()-&gt;getRootFolder()</code>
+      <code>$c-&gt;getServer()-&gt;getRootFolder()</code>
+      <code>ExpireGroupVersions</code>
       <code>ExpireGroupVersions</code>
       <code>ExpireGroupVersionsPlaceholder</code>
       <code>GroupVersionsExpireManager</code>
+      <code>GroupVersionsExpireManager</code>
+      <code>TrashBackend</code>
+      <code>TrashBackend</code>
+      <code>TrashBackend</code>
       <code>TrashBackend</code>
       <code>VersionsBackend</code>
+      <code>VersionsBackend</code>
+      <code>VersionsBackend</code>
+      <code>\OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</code>
       <code>\OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</code>
       <code>\OCA\GroupFolders\BackgroundJob\ExpireGroupVersionsPlaceholder</code>
     </MissingDependency>
     <UndefinedClass occurrences="1">
       <code>BeforeTemplateRenderedEvent</code>
     </UndefinedClass>
-    <InvalidArgument occurrences="1"/>
   </file>
   <file src="lib/CacheListener.php">
     <MissingDependency occurrences="1">
       <code>GroupFolderStorage</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/ACL.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/Delete.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/Group.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/Quota.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/Rename.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
+    </MissingDependency>
+  </file>
+  <file src="lib/Command/Scan.php">
+    <MissingDependency occurrences="1">
+      <code>FolderCommand</code>
     </MissingDependency>
   </file>
   <file src="lib/Controller/FolderController.php">


### PR DESCRIPTION
Prevents accidentaly selecting the first groupfolder when for example
typing the folder name of another groupfolder.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>