### PR TITLE
Fix non user avatars in sharing sidebar

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -77,7 +77,7 @@
 			<tbody v-else>
 				<tr v-for="item in list" :key="item.mappingType + '-' + item.mappingId">
 					<td>
-						<Avatar :user="item.mappingId" :size="24" />
+						<Avatar :user="item.mappingId" :is-no-user="item.mappingType !== 'user'" :size="24" />
 					</td>
 					<td v-tooltip="getFullDisplayName(item.mappingDisplayName, item.mappingType)" class="username">
 						{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}


### PR DESCRIPTION
By default the avatar component tries to load a user avatar, which either loads the wrong avatar (if there is a user with the same name as the group) or none at all. Therefore if the avatar does not belong to a user it must be explicitly specified.

**Before:**
![Groupfolders-Sharing-Sidebar-Avatar-Before](https://user-images.githubusercontent.com/26858233/147492720-0652ffc3-0e32-49aa-a8ea-3a7845a0e251.png)

**After:**
![Groupfolders-Sharing-Sidebar-Avatar-After](https://user-images.githubusercontent.com/26858233/147492728-e784e22f-c88a-4d13-bd34-ee76fbc1fc74.png)