### PR TITLE
Allow non admin to use aclMappingSearch

### DIFF
--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -229,7 +229,6 @@ class FolderController extends OCSController {
 
 	/**
 	 * @NoAdminRequired
-	 * @AuthorizedAdminSetting(settings=OCA\GroupFolders\Settings\Admin)
 	 * @param int $id
 	 * @param $fileId
 	 * @param string $search


### PR DESCRIPTION
aclMappingSearch call canManageAcl that will do the authorization check
so don't restrict with a middleware potentially authorized users.

Fix #1834

cc @kaskicc

Signed-off-by: Carl Schwan <carl@carlschwan.eu>