### PR TITLE
Fix expire commands and background job when trash and/or version apps are disabled

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,10 +35,11 @@ Note: Encrypting the contents of group folders is currently not supported.]]></d
 
 	<background-jobs>
 		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</job>
+		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupTrash</job>
 	</background-jobs>
 
 	<commands>
-		<command>OCA\GroupFolders\Command\ExpireGroupVersions</command>
+		<command>OCA\GroupFolders\Command\ExpireGroup\ExpireGroupBase</command>
 		<command>OCA\GroupFolders\Command\ListCommand</command>
 		<command>OCA\GroupFolders\Command\ACL</command>
 		<command>OCA\GroupFolders\Command\Quota</command>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,9 +28,14 @@ use OCA\GroupFolders\ACL\ACLManagerFactory;
 use OCA\GroupFolders\ACL\RuleManager;
 use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\ACL\UserMapping\UserMappingManager;
+use OCA\GroupFolders\BackgroundJob\ExpireGroupPlaceholder;
+use OCA\GroupFolders\BackgroundJob\ExpireGroupTrash as ExpireGroupTrashJob;
+use OCA\GroupFolders\BackgroundJob\ExpireGroupVersions as ExpireGroupVersionsJob;
 use OCA\GroupFolders\CacheListener;
-use OCA\GroupFolders\Command\ExpireGroupVersions;
-use OCA\GroupFolders\Command\ExpireGroupVersionsPlaceholder;
+use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupBase;
+use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupVersionsTrash;
+use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupVersions;
+use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupTrash;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Helper\LazyFolder;
 use OCA\GroupFolders\Listeners\LoadAdditionalScriptsListener;
@@ -84,16 +89,20 @@ class Application extends App implements IBootstrap {
 			);
 		});
 
-		$context->registerService(TrashBackend::class, function (IAppContainer $c) {
-			return new TrashBackend(
+		$context->registerService(TrashBackend::class, function (IAppContainer $c): TrashBackend {
+			$trashBackend = new TrashBackend(
 				$c->get(FolderManager::class),
 				$c->get(TrashManager::class),
 				$c->get('GroupAppFolder'),
 				$c->get(MountProvider::class),
 				$c->get(ACLManagerFactory::class),
-				$c->getServer()->getRootFolder(),
-				$c->get(VersionsBackend::class)
+				$c->getServer()->getRootFolder()
 			);
+			$hasVersionApp = interface_exists(\OCA\Files_Versions\Versions\IVersionBackend::class);
+			if ($hasVersionApp) {
+				$trashBackend->setVersionsBackend($c->get(VersionsBackend::class));
+			}
+			return $trashBackend;
 		});
 
 		$context->registerService(VersionsBackend::class, function (IAppContainer $c) {
@@ -105,27 +114,57 @@ class Application extends App implements IBootstrap {
 			);
 		});
 
-		$context->registerService(ExpireGroupVersions::class, function (IAppContainer $c) {
-			if (interface_exists('OCA\Files_Versions\Versions\IVersionBackend')) {
-				return new ExpireGroupVersions(
+		$context->registerService(ExpireGroupBase::class, function (IAppContainer $c): ExpireGroupBase {
+			// Multiple implementation of this class exists depending on if the trash and versions
+			// backends are enabled.
+
+			$hasVersionApp = interface_exists(\OCA\Files_Versions\Versions\IVersionBackend::class);
+			$hasTrashApp = interface_exists(\OCA\Files_Trashbin\Trash\ITrashBackend::class);
+
+			if ($hasVersionApp && $hasTrashApp) {
+				return new ExpireGroupVersionsTrash(
 					$c->get(GroupVersionsExpireManager::class),
 					$c->get(TrashBackend::class),
 					$c->get(Expiration::class)
 				);
 			}
-			return new ExpireGroupVersionsPlaceholder();
+
+			if ($hasVersionApp) {
+				return new ExpireGroupVersions(
+					$c->get(GroupVersionsExpireManager::class),
+				);
+			}
+
+			if ($hasTrashApp) {
+				return new ExpireGroupTrash(
+					$c->get(TrashBackend::class),
+					$c->get(Expiration::class)
+				);
+			}
+
+			return new ExpireGroupBase();
 		});
 
 		$context->registerService(\OCA\GroupFolders\BackgroundJob\ExpireGroupVersions::class, function (IAppContainer $c) {
-			if (interface_exists('OCA\Files_Versions\Versions\IVersionBackend')) {
-				return new \OCA\GroupFolders\BackgroundJob\ExpireGroupVersions(
+			if (interface_exists(\OCA\Files_Versions\Versions\IVersionBackend::class)) {
+				return new ExpireGroupVersionsJob(
 					$c->get(GroupVersionsExpireManager::class),
+				);
+			}
+
+			return new ExpireGroupPlaceholder();
+		});
+
+		$context->registerService(\OCA\GroupFolders\BackgroundJob\ExpireGroupTrash::class, function (IAppContainer $c) {
+			if (interface_exists(\OCA\Files_Trashbin\Trash\ITrashBackend::class)) {
+				return new ExpireGroupTrashJob(
 					$c->get(TrashBackend::class),
 					$c->get(Expiration::class),
 					$c->get(IConfig::class)
 				);
 			}
-			return new \OCA\GroupFolders\BackgroundJob\ExpireGroupVersionsPlaceholder();
+
+			return new ExpireGroupPlaceholder();
 		});
 
 		$context->registerService(ACLManagerFactory::class, function (IAppContainer $c) {

--- a/lib/BackgroundJob/ExpireGroupPlaceholder.php
+++ b/lib/BackgroundJob/ExpireGroupPlaceholder.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\BackgroundJob;
+
+class ExpireGroupPlaceholder extends \OC\BackgroundJob\TimedJob {
+	public function __construct() {
+		// Run at some point in a far far future :p
+		$this->setInterval(60 * 60 * 99999999);
+	}
+
+	protected function run($argument) {
+		// noop
+	}
+}

--- a/lib/Command/ExpireGroup/ExpireGroupBase.php
+++ b/lib/Command/ExpireGroup/ExpireGroupBase.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Command\ExpireGroup;
+
+use OC\Core\Command\Base;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Base class for the group folder expiration commands.
+ */
+class ExpireGroupBase extends Base {
+	public function __construct() {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('groupfolders:expire')
+			->setDescription('Trigger expiration for files stored in group folders (trash and versions). Currently disabled.');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$output->writeln('<error>groupfolder expiration handling is currently disabled because there is nothing to expire. Enable the "Delete Files" or/and "Versions" app to enable this feature.</error>');
+		return 0;
+	}
+}

--- a/lib/Command/ExpireGroup/ExpireGroupVersions.php
+++ b/lib/Command/ExpireGroup/ExpireGroupVersions.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2021 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Command\ExpireGroup;
+
+use OC\Core\Command\Base;
+use OCA\Files_Versions\Versions\IVersion;
+use OCA\GroupFolders\Trash\TrashBackend;
+use OCA\GroupFolders\Versions\GroupVersionsExpireManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Trigger expiry of versions for files stored in group folders.
+ */
+class ExpireGroupVersions extends ExpireGroupBase {
+	/** @var GroupVersionsExpireManager */
+	protected $expireManager;
+
+	public function __construct(
+		GroupVersionsExpireManager $expireManager
+	) {
+		parent::__construct();
+		$this->expireManager = $expireManager;
+	}
+
+	protected function configure() {
+		parent::configure();
+		$this
+			->setName('groupfolders:expire')
+			->setDescription('Trigger expiry of versions for files stored in group folders');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$this->expireManager->listen(GroupVersionsExpireManager::class, 'enterFolder', function (array $folder) use ($output) {
+			$output->writeln("<info>Expiring version in '${folder['mount_point']}'</info>");
+		});
+		$this->expireManager->listen(GroupVersionsExpireManager::class, 'deleteVersion', function (IVersion $version) use ($output) {
+			$id = $version->getRevisionId();
+			$file = $version->getSourceFileName();
+			$output->writeln("<info>Expiring version $id for '$file'</info>");
+		});
+
+		$this->expireManager->listen(GroupVersionsExpireManager::class, 'deleteFile', function ($id) use ($output) {
+			$output->writeln("<info>Cleaning up versions for no longer existing file with id $id</info>");
+		});
+
+		$this->expireManager->expireAll();
+		return 0;
+	}
+}

--- a/lib/Command/ExpireGroup/ExpireGroupVersionsTrash.php
+++ b/lib/Command/ExpireGroup/ExpireGroupVersionsTrash.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Command\ExpireGroup;
+
+use OCA\Files_Trashbin\Expiration;
+use OCA\GroupFolders\Trash\TrashBackend;
+use OCA\GroupFolders\Versions\GroupVersionsExpireManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExpireGroupVersionsTrash extends ExpireGroupVersions {
+	/** @var TrashBackend */
+	private $trashBackend;
+
+	/** @var Expiration */
+	private $expiration;
+
+	public function __construct(
+		GroupVersionsExpireManager $expireManager,
+		TrashBackend $trashBackend,
+		Expiration $expiration
+	) {
+		parent::__construct($expireManager);
+		$this->trashBackend = $trashBackend;
+		$this->expiration = $expiration;
+	}
+
+	protected function configure() {
+		parent::configure();
+		$this
+			->setName('groupfolders:expire')
+			->setDescription('Trigger expiry of versions and trashbin for files stored in group folders');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		parent::execute($input, $output);
+
+		[$count, $size] = $this->trashBackend->expire($this->expiration);
+		$output->writeln("<info>Removed $count expired trashbin items</info>");
+
+		return 0;
+	}
+}

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -56,7 +56,7 @@ class TrashBackend implements ITrashBackend {
 	/** @var ACLManagerFactory */
 	private $aclManagerFactory;
 
-	/** @var VersionsBackend */
+	/** @var ?VersionsBackend */
 	private $versionsBackend;
 
     /** @var IRootFolder */
@@ -68,16 +68,18 @@ class TrashBackend implements ITrashBackend {
 		Folder $appFolder,
 		MountProvider $mountProvider,
 		ACLManagerFactory $aclManagerFactory,
-		IRootFolder $rootFolder,
-		VersionsBackend $versionsBackend
+		IRootFolder $rootFolder
 	) {
 		$this->folderManager = $folderManager;
 		$this->trashManager = $trashManager;
 		$this->appFolder = $appFolder;
 		$this->mountProvider = $mountProvider;
 		$this->aclManagerFactory = $aclManagerFactory;
-		$this->versionsBackend = $versionsBackend;
 		$this->rootFolder = $rootFolder;
+	}
+
+	public function setVersionsBackend(VersionsBackend $versionsBackend): void {
+		$this->versionsBackend = $versionsBackend;
 	}
 
 	public function listTrashRoot(IUser $user): array {
@@ -397,7 +399,7 @@ class TrashBackend implements ITrashBackend {
 					}
 					$node->getStorage()->getCache()->remove($node->getInternalPath());
 					$this->trashManager->removeItem($folderId, $groupTrashItem['name'], $groupTrashItem['deleted_time']);
-					if (!is_null($groupTrashItem['file_id'])) {
+					if (!is_null($groupTrashItem['file_id']) && !is_null($this->versionsBackend)) {
 						$this->versionsBackend->deleteAllVersionsForFile($folderId, $groupTrashItem['file_id']);
 					}
 				} else {


### PR DESCRIPTION
Fix #1815

Fix #1812

For the background jobs, split the version expiration and trash expiration in two separate jobs. Both use the same placeholder in case the respective app is not enabled.

For the commands, create 4 different versions (using inheritance) with the 4 different combo enabled/disabled.

Signed-off-by: Carl Schwan <carl@carlschwan.eu>