### PR TITLE
[stable23] Fix double use of the same variable

### DIFF
--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -32,7 +32,6 @@ use OCA\GroupFolders\Mount\MountProvider;
 use OCP\Constants;
 use OCP\Files\IRootFolder;
 use OCP\IUserManager;
-use OCP\Constants;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
Caused by a bad backport in https://github.com/nextcloud/groupfolders/pull/1835

Signed-off-by: Carl Schwan <carl@carlschwan.eu>