### PR TITLE
Code did not use localisation string

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -1,6 +1,8 @@
 <?php script($_['appId'], ['groupfolders-settings']); ?>
 <div id="searchresults" style="display: none"></div>
 <div id="groupfolders-wrapper">
-	<h2>Group folders</h2>
+	<h2>
+		<?php p($l->t('Group folders')); ?>
+	</h2>
 	<div id="groupfolders-root"/>
 </div>


### PR DESCRIPTION
The group folders admin page always shows the English headline, no matter what UI language is chosen. The code simply had not yet used the localisation string.