### PR TITLE
fix(CLI): Define int type to set folder quota

### DIFF
--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -48,7 +48,7 @@ class Quota extends FolderCommand {
 		$quotaString = strtolower($input->getArgument('quota'));
 		$quota = ($quotaString === 'unlimited') ? FileInfo::SPACE_UNLIMITED : \OCP\Util::computerFileSize($quotaString);
 		if ($quota) {
-			$this->folderManager->setFolderQuota($folder['id'], $quota);
+			$this->folderManager->setFolderQuota($folder['id'], (int)$quota);
 			return 0;
 		}
 		$output->writeln('<error>Unable to parse quota input: ' . $quotaString . '</error>');


### PR DESCRIPTION
Hello,

I would like define quota with command line: `php occ groupfolders:quota $FOLDER_ID "1 GB"` but an error throw.

## Error

```
$ php occ groupfolders:quota $FOLDER_ID "1 GB"
An unhandled exception has been thrown:
TypeError: OCA\GroupFolders\Folder\FolderManager::setFolderQuota(): Argument #2 ($quota) must be of type int, float given, called in /var/www/html/custom_apps/groupfolders/lib/Command/Quota.php on line 51 and defined in /var/www/html/custom_apps/groupfolders/lib/Folder/FolderManager.php:581
Stack trace:
#0 /var/www/html/custom_apps/groupfolders/lib/Command/Quota.php(51): OCA\GroupFolders\Folder\FolderManager->setFolderQuota(1, 1073741824)
#1 /var/www/html/3rdparty/symfony/console/Command/Command.php(255): OCA\GroupFolders\Command\Quota->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#2 /var/www/html/core/Command/Base.php(168): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /var/www/html/3rdparty/symfony/console/Application.php(1009): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /var/www/html/3rdparty/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand(Object(OCA\GroupFolders\Command\Quota), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#5 /var/www/html/3rdparty/symfony/console/Application.php(149): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/lib/private/Console/Application.php(211): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/console.php(99): OC\Console\Application->run()
#8 /var/www/html/occ(11): require_once('/var/www/html/c...')
#9 {main}
```
## Resolution

The variable [`$quota`](https://github.com/nextcloud/groupfolders/blob/v11.1.2/lib/Command/Quota.php#L49) comes from function [`computerFileSize`](https://github.com/nextcloud/server/blob/v23.0.0/core/src/OC/util.js#L77) which return an number but function [`setFolderQuota`](https://github.com/nextcloud/groupfolders/blob/v11.1.2/lib/Folder/FolderManager.php#L581) would like integer.

2 solutions :
- Change `setFolderQuota` to receive number
- Change like I make on this PR to transform number to integer

What do you think ?

# Version

- Nextcloud : docker image nextcloud:23.0.0-fpm-alpine
- php : 8.0.14
- groupfolders : 11.1.2