### PR TITLE
Block sharing root of groupfolder

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -29,14 +29,10 @@ use OCP\Files\IRootFolder;
 use OCP\IUser;
 
 class ACLManager {
-	/** @var RuleManager */
-	private $ruleManager;
-	/** @var CappedMemoryCache */
-	private $ruleCache;
-	/** @var IUser */
-	private $user;
-	/** @var int|null */
-	private $rootStorageId = null;
+	private RuleManager $ruleManager;
+	private CappedMemoryCache $ruleCache;
+	private IUser $user;
+	private ?int $rootStorageId = null;
 	/** @var callable */
 	private $rootFolderProvider;
 
@@ -59,9 +55,8 @@ class ACLManager {
 	}
 
 	/**
-	 * @param int $folderId
-	 * @param array $paths
-	 * @return (Rule[])[]
+	 * @param string[] $paths
+	 * @return array<string, Rule[]>
 	 */
 	private function getRules(array $paths): array {
 		// beware: adding new rules to the cache besides the cap
@@ -89,7 +84,6 @@ class ACLManager {
 	}
 
 	/**
-	 * @param string $path
 	 * @return string[]
 	 */
 	private function getParents(string $path): array {
@@ -125,9 +119,6 @@ class ACLManager {
 
 	/**
 	 * Get the combined "lowest" permissions for an entire directory tree
-	 *
-	 * @param string $path
-	 * @return int
 	 */
 	public function getPermissionsForTree(string $path): int {
 		$path = ltrim($path, '/');

--- a/lib/ACL/ACLManagerFactory.php
+++ b/lib/ACL/ACLManagerFactory.php
@@ -26,7 +26,8 @@ namespace OCA\GroupFolders\ACL;
 use OCP\IUser;
 
 class ACLManagerFactory {
-	private $ruleManager;
+	private RuleManager $ruleManager;
+	/** @var callable */
 	private $rootFolderProvider;
 
 	public function __construct(RuleManager $ruleManager, callable $rootFolderProvider) {

--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -39,7 +39,7 @@ class ACLStorageWrapper extends Wrapper {
 		$this->inShare = $arguments['in_share'];
 	}
 
-	private function getACLPermissionsForPath(string $path) {
+	private function getACLPermissionsForPath(string $path): int {
 		$permissions = $this->aclManager->getACLPermissionsForPath($path);
 
 		// if there is no read permissions, than deny everything
@@ -51,7 +51,7 @@ class ACLStorageWrapper extends Wrapper {
 		return $canRead ? $permissions : 0;
 	}
 
-	private function checkPermissions(string $path, int $permissions) {
+	private function checkPermissions(string $path, int $permissions): bool {
 		return ($this->getACLPermissionsForPath($path) & $permissions) === $permissions;
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -85,7 +85,8 @@ class Application extends App implements IBootstrap {
 				$c->get(IRequest::class),
 				$c->get(ISession::class),
 				$c->get(IMountProviderCollection::class),
-				$c->get(IDBConnection::class)
+				$c->get(IDBConnection::class),
+				$c->get(IConfig::class)
 			);
 		});
 

--- a/lib/Mount/GroupMountPoint.php
+++ b/lib/Mount/GroupMountPoint.php
@@ -38,7 +38,7 @@ class GroupMountPoint extends MountPoint {
 
 	public function getOption($name, $default) {
 		$options = $this->getOptions();
-		return isset($options[$name]) ? $options[$name] : $default;
+		return $options[$name] ?? $default;
 	}
 
 	public function getOptions() {

--- a/lib/Mount/MountPermissionStorageWrapper.php
+++ b/lib/Mount/MountPermissionStorageWrapper.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Mount;
+
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCA\GroupFolders\ACL\ACLCacheWrapper;
+use OCP\Files\Cache\ICacheEntry;
+
+/**
+ * Storage wrapper allowing to disable sharing and other permissions for the
+ * root of the group folders.
+ */
+class MountPermissionStorageWrapper extends Wrapper {
+
+	private ICacheEntry $rootEntry;
+
+	public function __construct($parameters) {
+		parent::__construct($parameters);
+		$this->rootEntry = $parameters['rootCacheEntry'];
+	}
+
+	public function isSharable($path) {
+		return $this->rootEntry->getPath() . '/' . $this->rootEntry['mount_point'] !== $path && parent::isSharable($path);
+	}
+
+	/**
+	 * get a cache instance for the storage
+	 *
+	 * @param string $path
+	 * @param \OC\Files\Storage\Storage (optional) the storage to pass to the cache
+	 * @return \OCP\Files\Cache\ICache
+	 */
+	public function getCache($path = '', $storage = null) {
+		if (!$storage) {
+			$storage = $this;
+		}
+		$sourceCache = parent::getCache($path, $storage);
+		return new MountPermissionCacheWrapper($sourceCache, $this->rootEntry);
+	}
+}


### PR DESCRIPTION
Currently doesn't work even if when using the debugger the permissions are correctly set. I wonder if the permissions of the root/mount point are defined somewhere else...