### PR TITLE
Make property visibility compatible with Wrapper implementation

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -35,7 +35,8 @@ class GroupFolderStorage extends Quota implements IDisableEncryptionStorage {
 	private ICacheEntry $rootEntry;
 	private IUserSession $userSession;
 	private IUser $mountOwner;
-	private ?RootEntryCache $cache = null;
+	/** @var RootEntryCache|null */
+	public $cache = null;
 
 	public function __construct($parameters) {
 		parent::__construct($parameters);


### PR DESCRIPTION
Revert the typing/visibility change from https://github.com/nextcloud/groupfolders/commit/d85b5966700f03eee443065864e4ad8d79832e9b to match with the parent class https://github.com/nextcloud/server/blob/cbf9064b8ecde6f497146f6711fff83307a0730f/lib/private/Files/Storage/Wrapper/Wrapper.php#L46

Fixes an error about `Access level to OCA\\GroupFolders\\Mount\\GroupFolderStorage::$cache must be public (as in class OC\\Files\\Storage\\Wrapper\\Wrapper) at /var/www/html/apps-extra/groupfolders/lib/Mount/GroupFolderStorage.php#33` and an empty white page when loading the files app.