### PR TITLE
[stable23] Update parent folders cache when restoring files from trash

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -164,7 +164,7 @@ class TrashBackend implements ITrashBackend {
 
 		$targetLocation = $targetFolder->getInternalPath() . '/' . $originalLocation;
 		$targetFolder->getStorage()->moveFromStorage($trashStorage, $node->getInternalPath(), $targetLocation);
-		$targetFolder->getStorage()->getCache()->moveFromCache($trashStorage->getCache(), $node->getInternalPath(), $targetLocation);
+		$targetFolder->getStorage()->getUpdater()->renameFromStorage($trashStorage, $node->getInternalPath(), $targetLocation);
 		$this->trashManager->removeItem($folderId, $item->getName(), $item->getDeletedTime());
 	}
 


### PR DESCRIPTION
Manual backport of #1962 to stable23.

Call `Updater->renameFromStorage()` in `TrashBackend->restoreItem()` to
make sure that the file cache of parent folder gets updated.

This fixes a bug where files that got restored to a groupfolder don't
get synced by clients (due to missing update of the parents etag).

Fixes: #1760

Signed-off-by: Jonas <jonas@freesources.org>
