### PR TITLE
specify return type in Rule::jsonSerialize

### DIFF
--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -98,7 +98,7 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 		$writer->write($data);
 	}
 
-	public function jsonSerialize() {
+	public function jsonSerialize(): array {
 		return [
 			'mapping' => [
 				'type' => $this->getUserMapping()->getType(),

--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -98,7 +98,8 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 		$writer->write($data);
 	}
 
-	public function jsonSerialize(): array {
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
 		return [
 			'mapping' => [
 				'type' => $this->getUserMapping()->getType(),


### PR DESCRIPTION
otherwise you get an `Error: Return type of Rule::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize()`
error with php 8.1

Signed-off-by: Robin Appelman <robin@icewind.nl>