### PR TITLE
Speedup querying group info

### DIFF
--- a/lib/Controller/DelegationController.php
+++ b/lib/Controller/DelegationController.php
@@ -54,10 +54,6 @@ class DelegationController extends OCSController {
 			$data[] = [
 				'id' => $group->getGID(),
 				'displayname' => $group->getDisplayName(),
-				'usercount' => $group->count(),
-				'disabled' => $group->countDisabled(),
-				'canAdd' => $group->canAddUser(),
-				'canRemove' => $group->canRemoveUser(),
 			];
 		}
 


### PR DESCRIPTION
We don't need the user count inside of the groups since we don't display
it.

With 1100 LDAP groups, this reduce the LDAP query count from 6693 to
only 30.