### PR TITLE
Sort versions in descending order

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -62,7 +62,7 @@ class VersionsBackend implements IVersionBackend {
 				$folderId = $mount->getFolderId();
 				/** @var Folder $versionsFolder */
 				$versionsFolder = $this->getVersionsFolder($mount->getFolderId())->get((string)$file->getId());
-				return array_map(function (Node $versionFile) use ($file, $user, $folderId) {
+				$versions = array_map(function (Node $versionFile) use ($file, $user, $folderId): GroupVersion {
 					if ($versionFile instanceof Folder) {
 						$this->logger->error('Found an unexpected subfolder inside the groupfolder version folder.');
 					}
@@ -80,6 +80,10 @@ class VersionsBackend implements IVersionBackend {
 						$folderId
 					);
 				}, $versionsFolder->getDirectoryListing());
+				usort($versions, function (GroupVersion $v1, GroupVersion $v2): int {
+					return $v2->getTimestamp() <=> $v1->getTimestamp();
+				});
+				return $versions;
 			} catch (NotFoundException $e) {
 				return [];
 			}


### PR DESCRIPTION
The regular file backend manually sorts the files by timestamp as the directory listing for the versioned file is returned in ascending order.


https://github.com/nextcloud/server/blob/d5953e5c33be1a2d8341101c67e4b40cb95b0c7f/apps/files_versions/lib/Storage.php#L500

This PR makes sure that versions are also listed with the latest first for gorupfolder versions.

Fixes https://github.com/nextcloud/groupfolders/issues/1901