### PR TITLE
enable encryption with system keys for groupfolders

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -78,6 +78,7 @@ class Application extends App implements IBootstrap {
 			};
 			$config = $c->get(IConfig::class);
 			$allowRootShare = $config->getAppValue('groupfolders', 'allow_root_share', 'true') === 'true';
+			$enableEncryption = $config->getAppValue('groupfolders', 'enable_encryption', 'false') === 'true';
 
 			return new MountProvider(
 				$c->getServer()->getGroupManager(),
@@ -90,7 +91,8 @@ class Application extends App implements IBootstrap {
 				$c->get(IMountProviderCollection::class),
 				$c->get(IDBConnection::class),
 				$c->get(ICacheFactory::class)->createLocal("groupfolders"),
-				$allowRootShare
+				$allowRootShare,
+				$enableEncryption
 			);
 		});
 

--- a/lib/Mount/GroupFolderNoEncryptionStorage.php
+++ b/lib/Mount/GroupFolderNoEncryptionStorage.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Mount;
+
+use OCP\Files\Storage\IDisableEncryptionStorage;
+
+class GroupFolderNoEncryptionStorage extends GroupFolderStorage implements IDisableEncryptionStorage {
+}

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -30,7 +30,7 @@ use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\IUser;
 use OCP\IUserSession;
 
-class GroupFolderStorage extends Quota implements IDisableEncryptionStorage {
+class GroupFolderStorage extends Quota {
 	private int $folderId;
 	private ICacheEntry $rootEntry;
 	private IUserSession $userSession;

--- a/lib/Mount/GroupMountPoint.php
+++ b/lib/Mount/GroupMountPoint.php
@@ -22,8 +22,9 @@
 namespace OCA\GroupFolders\Mount;
 
 use OC\Files\Mount\MountPoint;
+use OCP\Files\Mount\ISystemMountPoint;
 
-class GroupMountPoint extends MountPoint {
+class GroupMountPoint extends MountPoint implements ISystemMountPoint {
 	/** @var int */
 	private $folderId;
 
@@ -34,17 +35,6 @@ class GroupMountPoint extends MountPoint {
 
 	public function getMountType() {
 		return 'group';
-	}
-
-	public function getOption($name, $default) {
-		$options = $this->getOptions();
-		return isset($options[$name]) ? $options[$name] : $default;
-	}
-
-	public function getOptions() {
-		$options = parent::getOptions();
-		$options['encrypt'] = false;
-		return $options;
 	}
 
 	public function getFolderId(): int {

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -71,6 +71,7 @@ class MountProvider implements IMountProvider {
 	private ICache $cache;
 	private ?int $rootStorageId = null;
 	private bool $allowRootShare;
+	private bool $enableEncryption;
 
 	public function __construct(
 		IGroupManager $groupProvider,
@@ -83,7 +84,8 @@ class MountProvider implements IMountProvider {
 		IMountProviderCollection $mountProviderCollection,
 		IDBConnection $connection,
 		ICache $cache,
-		bool $allowRootShare
+		bool $allowRootShare,
+		bool $enableEncryption
 	) {
 		$this->groupProvider = $groupProvider;
 		$this->folderManager = $folderManager;
@@ -96,6 +98,7 @@ class MountProvider implements IMountProvider {
 		$this->connection = $connection;
 		$this->cache = $cache;
 		$this->allowRootShare = $allowRootShare;
+		$this->enableEncryption = $enableEncryption;
 	}
 
 	private function getRootStorageId(): int {
@@ -208,14 +211,25 @@ class MountProvider implements IMountProvider {
 			'storage' => $storage,
 			'root' => $rootPath
 		]);
-		$quotaStorage = new GroupFolderStorage([
-			'storage' => $baseStorage,
-			'quota' => $quota,
-			'folder_id' => $id,
-			'rootCacheEntry' => $cacheEntry,
-			'userSession' => $this->userSession,
-			'mountOwner' => $user,
-		]);
+		if ($this->enableEncryption) {
+			$quotaStorage = new GroupFolderStorage([
+				'storage' => $baseStorage,
+				'quota' => $quota,
+				'folder_id' => $id,
+				'rootCacheEntry' => $cacheEntry,
+				'userSession' => $this->userSession,
+				'mountOwner' => $user,
+			]);
+		} else {
+			$quotaStorage = new GroupFolderNoEncryptionStorage([
+				'storage' => $baseStorage,
+				'quota' => $quota,
+				'folder_id' => $id,
+				'rootCacheEntry' => $cacheEntry,
+				'userSession' => $this->userSession,
+				'mountOwner' => $user,
+			]);
+		}
 		$maskedStore = new PermissionsMask([
 			'storage' => $quotaStorage,
 			'mask' => $permissions

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -61,15 +61,15 @@ namespace OCA\Files_Trashbin\Trash {
 
 	interface ITrashItem extends FileInfo {
 		public function getTrashBackend(): ITrashBackend;
-	
+
 		public function getOriginalLocation(): string;
-	
+
 		public function getDeletedTime(): int;
-	
+
 		public function getTrashPath(): string;
-	
+
 		public function isRootItem(): bool;
-	
+
 		public function getUser(): IUser;
 
 		public function getTitle(): string;
@@ -603,10 +603,10 @@ namespace OC\Files\Mount {
 		protected $class;
 		protected $storageId;
 		protected $rootId = null;
-	
+
 		/** @var int|null */
 		protected $mountId;
-	
+
 		/**
 		 * @param string|\OCP\Files\Storage\IStorage $storage
 		 * @param string $mountpoint
@@ -619,7 +619,7 @@ namespace OC\Files\Mount {
 		public function __construct($storage, $mountpoint, $arguments = null, $loader = null, $mountOptions = null, $mountId = null) {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * get complete path to the mount point, relative to data/
 		 *
@@ -628,7 +628,7 @@ namespace OC\Files\Mount {
 		public function getMountPoint() {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * Sets the mount point path, relative to data/
 		 *
@@ -637,28 +637,28 @@ namespace OC\Files\Mount {
 		public function setMountPoint($mountPoint) {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @return \OCP\Files\Storage\IStorage
 		 */
 		public function getStorage() {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @return string
 		 */
 		public function getStorageId() {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @return int
 		 */
 		public function getNumericStorageId() {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @param string $path
 		 * @return string
@@ -666,14 +666,14 @@ namespace OC\Files\Mount {
 		public function getInternalPath($path) {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @param callable $wrapper
 		 */
 		public function wrapStorage($wrapper) {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * Get a mount option
 		 *
@@ -684,7 +684,7 @@ namespace OC\Files\Mount {
 		public function getOption($name, $default) {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * Get all options for the mount
 		 *
@@ -693,18 +693,18 @@ namespace OC\Files\Mount {
 		public function getOptions() {
 			throw new \Exception('stub');
 		}
-	
+
 		/**
 		 * @return int
 		 */
 		public function getStorageRootId() {
 			throw new \Exception('stub');
 		}
-	
+
 		public function getMountId() {
 			throw new \Exception('stub');
 		}
-	
+
 		public function getMountType() {
 			throw new \Exception('stub');
 		}
@@ -914,4 +914,8 @@ namespace OC\Files\Storage\Wrapper{
 	class PermissionsMask extends Wrapper {
 		public function getQuota() {}
 	}
+}
+
+namespace OCP\Files\Mount {
+	interface ISystemMountPoint {}
 }


### PR DESCRIPTION
- [ ] requires https://github.com/nextcloud/server/pull/33500 for the marker interface

It's probably possible to do some backwards compatibility hack to keep compatibility with versions that don't have the marker interface