### PR TITLE
Fix folder with hashtag

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -239,7 +239,7 @@ class AclDavService {
 		}
 		const props = {}
 		props[ACL_PROPERTIES.PROPERTY_ACL_LIST] = aclList
-		return client._client.propPatch(client._client.baseUrl + model.path + '/' + model.name, props)
+		return client._client.propPatch(client._client.baseUrl + model.path.replace('#', '%23') + '/' + encodeURIComponent(model.name), props)
 	}
 
 }


### PR DESCRIPTION
Make sure the url is properly encoded otherwise we can't change the ACL
of a folder