### PR TITLE
Fix accessing groupfolders from remote instance

### DIFF
--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -63,6 +63,10 @@ class ACLPlugin extends ServerPlugin {
 
 	private function isAdmin(string $path): bool {
 		$folderId = $this->folderManager->getFolderByPath($path);
+		if ($this->user === null) {
+			// Happens when sharing with a remote instance
+			return false;
+		}
 		return $this->folderManager->canManageACL($folderId, $this->user);
 	}
 


### PR DESCRIPTION
When sharing a groupfolder to remote instance the user is null, so there is no need to check if it is admin

Fix #2085