### PR TITLE
Fix timestamp and rollback of versions

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -111,7 +111,7 @@ class VersionsBackend implements IVersionBackend {
 			$versionMount = $versionFolder->getMountPoint();
 			$sourceMount = $file->getMountPoint();
 			$sourceCache = $sourceMount->getStorage()->getCache();
-			$revision = $this->timeFactory->getTime();
+			$revision = $file->getMTime();
 
 			$versionInternalPath = $versionFolder->getInternalPath() . '/' . $revision;
 			$sourceInternalPath = $file->getInternalPath();
@@ -135,7 +135,10 @@ class VersionsBackend implements IVersionBackend {
 			$versionInternalPath = $version->getVersionFile()->getInternalPath();
 
 			$targetMount->getStorage()->copyFromStorage($versionMount->getStorage(), $versionInternalPath, $targetInternalPath);
-			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $targetMount->getSourcePath() . '/' . $targetInternalPath);
+			$targetMount->getStorage()->touch($targetInternalPath, $version->getRevisionId());
+			$targetMount->getStorage()->getScanner()->scan($targetInternalPath);
+			$versionMount->getStorage()->unlink($versionInternalPath);
+			$versionMount->getStorage()->getCache()->remove($versionInternalPath);
 		}
 	}
 

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -135,7 +135,7 @@ class VersionsBackend implements IVersionBackend {
 			$versionInternalPath = $version->getVersionFile()->getInternalPath();
 
 			$targetMount->getStorage()->copyFromStorage($versionMount->getStorage(), $versionInternalPath, $targetInternalPath);
-			$targetMount->getStorage()->touch($targetInternalPath, $version->getRevisionId());
+			$targetMount->getStorage()->touch($targetInternalPath, intval($version->getRevisionId()));
 			$targetMount->getStorage()->getScanner()->scan($targetInternalPath);
 			$versionMount->getStorage()->unlink($versionInternalPath);
 			$versionMount->getStorage()->getCache()->remove($versionInternalPath);


### PR DESCRIPTION
Fix https://github.com/nextcloud/groupfolders/issues/2055 and fix https://github.com/nextcloud/groupfolders/issues/2077

File versioning for groupfolders is still broken. I'm not a programmer but after some investigation this change does improve things. This is my first pull request, thus I'm not sure whether this is the right way to go. Feel free to guide me into the right direction! Thanks.


