### PR TITLE
Log instead of throw for trash item not removable

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -108,7 +108,8 @@ class Application extends App implements IBootstrap {
 				$c->get('GroupAppFolder'),
 				$c->get(MountProvider::class),
 				$c->get(ACLManagerFactory::class),
-				$c->getServer()->getRootFolder()
+				$c->getServer()->getRootFolder(),
+				$c->get(LoggerInterface::class)
 			);
 			$hasVersionApp = interface_exists(\OCA\Files_Versions\Versions\IVersionBackend::class);
 			if ($hasVersionApp) {


### PR DESCRIPTION
Should help with https://github.com/nextcloud/groupfolders/issues/2067

The exception stops execution of the job even though other items might still be in the queue and might not cause issues

Log an error instead of throwing so admins can hande erroring files manually

Signed-off-by: Anna Larch <anna@nextcloud.com>