### PR TITLE
cleanup trash from deleted groupfolders

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -243,7 +243,11 @@ class TrashBackend implements ITrashBackend {
 		return in_array($folderId, $folderIds);
 	}
 
-	private function userHasAccessToPath(IUser $user, string $path, int $permission = Constants::PERMISSION_READ): bool {
+	private function userHasAccessToPath(
+		IUser $user,
+		string $path,
+		int $permission = Constants::PERMISSION_READ
+	): bool {
 		$activePermissions = $this->aclManagerFactory->getACLManager($user)
 			->getACLPermissionsForPath('__groupfolders/' . ltrim($path, '/'));
 		return (bool)($activePermissions & $permission);
@@ -267,6 +271,14 @@ class TrashBackend implements ITrashBackend {
 			}
 		}
 		return null;
+	}
+
+	private function getTrashRoot(): Folder {
+		try {
+			return $this->appFolder->get('trash');
+		} catch (NotFoundException $e) {
+			return $this->appFolder->newFolder('trash');;
+		}
 	}
 
 	private function getTrashFolder(int $folderId): Folder {
@@ -407,6 +419,29 @@ class TrashBackend implements ITrashBackend {
 				}
 			}
 		}
+
+		$this->cleanupDeletedFoldersTrash($folders);
+
 		return [$count, $size];
+	}
+
+	/**
+	 * Cleanup trashbin of of groupfolders that have been deleted
+	 *
+	 * @param array $existingFolders
+	 * @return void
+	 */
+	private function cleanupDeletedFoldersTrash(array $existingFolders): void {
+		$trashRoot = $this->getTrashRoot();
+		foreach ($trashRoot->getDirectoryListing() as $trashFolder) {
+			$folderId = $trashFolder->getName();
+			if (is_numeric($folderId)) {
+				$folderId = (int)$folderId;
+				if (!isset($existingFolders[$folderId])) {
+					$this->cleanTrashFolder($folderId);
+					$this->getTrashFolder($folderId)->delete();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
When performing groupfolder trashbin cleanup, look for any groupfolder trash directory for which the groupfolder has been deleted and remove those.

Without this the trash in deleted groupfolder is never removed.

To test:

1. Create a groupfolder
2. Upload and delete some files
3. Force-run the `ExpireGroupTrash` job
4. Check the groupfolder trash directory