### PR TITLE
`restore` hook in groupfolders versions

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -136,6 +136,12 @@ class VersionsBackend implements IVersionBackend {
 
 			$targetMount->getStorage()->copyFromStorage($versionMount->getStorage(), $versionInternalPath, $targetInternalPath);
 			$versionMount->getStorage()->getCache()->copyFromCache($targetCache, $versionCache->get($versionInternalPath), $targetMount->getSourcePath() . '/' . $targetInternalPath);
+
+			\OC_Hook::emit('\OCP\Versions', 'rollback', [
+				'path' => \OC\Files\Filesystem::getView()->getRelativePath($version->getSourceFile()->getPath()),
+				'revision' => $version->getRevisionId(),
+				'node' => $version->getSourceFile(),
+			]);
 		}
 	}
 


### PR DESCRIPTION
Hi all
There are reports from users about ONLYOFFICE editors not working properly with opening after restoring a version. The problem repeats only in the group folder. Related to skipping the restore hook.

@juliushaertl 
Please see the suggestion for a fix.

Signed-off-by: Sergey Linnik <sergey.linnik@onlyoffice.com>