### PR TITLE
fix(sidebar): Use icon slot for read-only ACL states

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -22,10 +22,14 @@
 <template>
 	<div v-if="readOnly">
 		<NcButton v-if="!isAllowed" v-tooltip="t('groupfolders', 'Denied')">
-			<Cancel :size="16" />
+			<template #icon>
+				<Cancel :size="16" />
+			</template>
 		</NcButton>
 		<NcButton v-else v-tooltip="t('groupfolders', 'Allowed')">
-			<Check :size="16" />
+			<template #icon>
+				<Check :size="16" />
+			</template>
 		</NcButton>
 	</div>
 	<div v-else>


### PR DESCRIPTION
1) Create a user
2) Create a group
3) Create a groupfolder
4) Assign the group
5) Log in as the user
6) Open the sharing sidebar tab of the groupfolder

| Before | After
|---|---|
|  ![Bildschirmfoto vom 2023-02-17 17-32-29](https://user-images.githubusercontent.com/1374172/219710636-2cb947c2-d6c6-422b-accd-d5f5aeb59f0d.png) | ![Bildschirmfoto vom 2023-02-17 17-28-47](https://user-images.githubusercontent.com/1374172/219710486-5508f9e5-141a-486f-9250-bcb8e2cbc9d3.png) |
|---|---|
