### PR TITLE
fix: Include `admin` group in list of all groups

### DIFF
--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -37,6 +37,7 @@ export interface Folder {
 }
 
 export class Api {
+
 	getUrl(endpoint: string): string {
 		return OC.generateUrl(`apps/groupfolders/${endpoint}`);
 	}
@@ -45,14 +46,11 @@ export class Api {
 		return $.getJSON(this.getUrl('folders'))
 			.then((data: OCSResult<Folder[]>) => Object.keys(data.ocs.data).map(id => data.ocs.data[id]));
 	}
+
 	// Returns all NC groups
 	listGroups(): Thenable<Group[]> {
 		return $.getJSON(this.getUrl('delegation/groups'))
-			.then((data: OCSResult<Group[]>) => {
-				// No need to present the admin group as it is automaticaly added
-				const groups = data.ocs.data.filter(g => g.gid !== 'admin')
-				return groups
-			});
+			.then((data: OCSResult<Group[]>) => data.ocs.data)
 	}
 
 	// Returns all groups that have been granted delegated admin or subadmin rights on groupfolders
@@ -69,7 +67,7 @@ export class Api {
 	updateDelegatedGroups(newGroups: Group[], classname: string): Thenable<void> {
 		return axios.post(generateUrl('/apps/settings/') + '/settings/authorizedgroups/saveSettings', {
 			newGroups,
-			class: classname
+			class: classname,
 		})
 		.then((data) => data.data)
 	}


### PR DESCRIPTION
* Resolves: #2203 

Currently the `admin` group is **not** automatically added as a member group to a new folder, so users of the `admin` group can not access group folders.

Moreover the `admin` group can currently not be added as a member because it is filtered from the list of available groups.

This PR simply removes that filter, as I think adding `admin` group as a member should be done explicitly, also the other way round we would need to add it to the member groups by default **and** add it to all existing group folders.