### PR TITLE
UI improvements of the Group Folders' list

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -143,17 +143,25 @@
 					border-bottom: var(--color-border) 1px solid;
 				}
 			}
-			&:hover {
-				background-color: transparent;
-			}
 			&:not(:last-child):hover {
-				box-shadow: 5px 0 0 var(--color-primary-element) inset;
+				td {
+					background-color: var(--color-background-dark);
+					&:first-child {
+						border-radius: 6px 0 0 6px;
+					}
+					&:last-child {
+						border-radius: 0 6px 6px 0;
+					}
+				}
 			}
 			&:last-child {
 				td {
 					padding: 35px 0;
 				}
 			}
+			&:last-child:hover {
+				background-color: transparent;
+			}			
 			td {
 				a {
 					color: var(--color-text-lighter);

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -22,7 +22,7 @@
 		cursor: pointer;
 
 		.sort_arrow {
-			float: right;
+			padding-left: 10px;
 			color: #888;
 		}
 	}
@@ -123,6 +123,51 @@
 		width: 200px;
 		max-width: calc(100% - 40px);
 	}
+
+	thead {
+		tr {
+			th {
+				color: var(--color-text-lighter);
+				&:first-child {
+					font-weight: bold;
+					color: var(--color-main-text);
+				}
+			}
+		}
+	}
+
+	tbody {
+		tr {
+			&:not(:last-child) {
+				td {
+					border-bottom: var(--color-border) 1px solid;
+				}
+			}
+			&:hover {
+				background-color: transparent;
+			}
+			&:not(:last-child):hover {
+				box-shadow: 5px 0 0 var(--color-primary-element) inset;
+			}
+			&:last-child {
+				td {
+					padding: 35px 0;
+				}
+			}
+			td {
+				a {
+					color: var(--color-text-lighter);
+				}
+				&.mountpoint {
+					a {
+						color: var(--color-main-text);
+						font-weight: bold;
+					}
+				}
+			}
+		}
+	}	
+
 }
 
 #groupfolders-admin-delegation {


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

For these changes, I was inspired by the appearance of the user list.

## Before 
![2023-04-28_12-30](https://user-images.githubusercontent.com/33763786/235126926-74aaf50d-051c-4a21-b77c-6940d20ecf3a.png)

## After
![2023-04-28_12-37](https://user-images.githubusercontent.com/33763786/235126951-075becb2-ba37-4ba5-8490-d57ff78e4447.png)

Consider this along with the other two (mentioned in the "After" screenshot) : #2341 #2342 