### PR TITLE
Check for folder existence in FolderController

### DIFF
--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -145,6 +145,10 @@ class FolderController extends OCSController {
 		if ($storageId === null) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
+		$folder = $this->manager->getFolder($id, $storageId);
+		if ($folder === false) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
 		return null;
 	}
 

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -124,11 +124,12 @@ class FolderController extends OCSController {
 	 * @NoAdminRequired
 	 */
 	public function getFolder(int $id): DataResponse {
-		$storageId = $this->getRootFolderStorageId();
-		if ($storageId === null) {
-			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		$response = $this->checkFolderExists($id);
+		if ($response) {
+			return $response;
 		}
 
+		$storageId = $this->getRootFolderStorageId();
 		$folder = $this->manager->getFolder($id, $storageId);
 		if (!$this->delegationService->hasApiAccess()) {
 			$folder = $this->filterNonAdminFolder($folder);
@@ -137,6 +138,14 @@ class FolderController extends OCSController {
 			}
 		}
 		return new DataResponse($this->formatFolder($folder));
+	}
+
+	private function checkFolderExists(int $id): ?DataResponse {
+		$storageId = $this->getRootFolderStorageId();
+		if ($storageId === null) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+		return null;
 	}
 
 	private function getRootFolderStorageId(): ?int {
@@ -157,10 +166,12 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function removeFolder(int $id): DataResponse {
-		$folder = $this->mountProvider->getFolder($id);
-		if ($folder) {
-			$folder->delete();
+		$response = $this->checkFolderExists($id);
+		if ($response) {
+			return $response;
 		}
+		$folder = $this->mountProvider->getFolder($id);
+		$folder->delete();
 		$this->manager->removeFolder($id);
 		return new DataResponse(['success' => true]);
 	}
@@ -179,6 +190,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function addGroup(int $id, string $group): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->addApplicableGroup($id, $group);
 		return new DataResponse(['success' => true]);
 	}
@@ -188,6 +203,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function removeGroup(int $id, string $group): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->removeApplicableGroup($id, $group);
 		return new DataResponse(['success' => true]);
 	}
@@ -197,6 +216,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function setPermissions(int $id, string $group, int $permissions): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->setGroupPermissions($id, $group, $permissions);
 		return new DataResponse(['success' => true]);
 	}
@@ -207,6 +230,10 @@ class FolderController extends OCSController {
 	 * @throws \OCP\DB\Exception
 	 */
 	public function setManageACL(int $id, string $mappingType, string $mappingId, bool $manageAcl): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->setManageACL($id, $mappingType, $mappingId, $manageAcl);
 		return new DataResponse(['success' => true]);
 	}
@@ -216,6 +243,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function setQuota(int $id, int $quota): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->setFolderQuota($id, $quota);
 		return new DataResponse(['success' => true]);
 	}
@@ -225,6 +256,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function setACL(int $id, bool $acl): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->setFolderACL($id, $acl);
 		return new DataResponse(['success' => true]);
 	}
@@ -234,6 +269,10 @@ class FolderController extends OCSController {
 	 * @RequireGroupFolderAdmin
 	 */
 	public function renameFolder(int $id, string $mountpoint): DataResponse {
+	$response = $this->checkFolderExists($id);
+	if ($response) {
+		return $response;
+	}
 		$this->manager->renameFolder($id, $mountpoint);
 		return new DataResponse(['success' => true]);
 	}


### PR DESCRIPTION
Based on customer bug report: all folder changes requests return a success, even if the folder doesn't exist.

Added a private method based on already existing code, to return 404 if folder is not exist.
Sorry for my poor PHP-knowledge, i did the best i could :upside_down_face: Please feel free to suggest changes or edit by yourself.