### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -370,7 +370,7 @@ export default {
 
 	.avatar.icon-group-white {
 		display: inline-block;
-		background-color: var(--color-primary, #0082c9);
+		background-color: var(--color-primary-element, #0082c9);
 		padding: 16px;
 	}
 

--- a/src/settings/FolderGroups.tsx
+++ b/src/settings/FolderGroups.tsx
@@ -150,7 +150,7 @@ function AdminGroupSelect({allGroups, allCircles, onChange}: CircleGroupSelectPr
 			input: (provided) => ({
 				...provided,
 				height: 30,
-				color: 'var(--color-primary-text)'
+				color: 'var(--color-primary-element-text)'
 			}),
 			control: (provided) => ({
 				...provided,


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.