### PR TITLE
fix PHP 8.2 ${var} deprecated

### DIFF
--- a/lib/Command/ExpireGroup/ExpireGroupVersions.php
+++ b/lib/Command/ExpireGroup/ExpireGroupVersions.php
@@ -51,7 +51,7 @@ class ExpireGroupVersions extends ExpireGroupBase {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$this->expireManager->listen(GroupVersionsExpireManager::class, 'enterFolder', function (array $folder) use ($output) {
-			$output->writeln("<info>Expiring version in '${folder['mount_point']}'</info>");
+			$output->writeln("<info>Expiring version in '{$folder['mount_point']}'</info>");
 		});
 		$this->expireManager->listen(GroupVersionsExpireManager::class, 'deleteVersion', function (IVersion $version) use ($output) {
 			$id = $version->getRevisionId();

--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -83,7 +83,7 @@ class Scan extends FolderCommand {
 			/** @var IScanner&\OC\Hooks\BasicEmitter $scanner */
 			$scanner = $mount->getStorage()->getScanner();
 
-			$output->writeln("Scanning group folder with id\t<info>${folder['id']}</info>", OutputInterface::VERBOSITY_VERBOSE);
+			$output->writeln("Scanning group folder with id\t<info>{$folder['id']}</info>", OutputInterface::VERBOSITY_VERBOSE);
 			if ($scanner instanceof NoopScanner) {
 				$output->writeln("Scanning group folders using an object store as primary storage is not supported.");
 				return -1;


### PR DESCRIPTION
with PHP 8.2 Using ${var} in strings is deprecated, use {$var} instead

closing issue [#2412](https://github.com/nextcloud/groupfolders/issues/2412)