### PR TITLE
Fix readdir() call in loop with undesirable false evaluation potential

### DIFF
--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -107,7 +107,7 @@ class ACLStorageWrapper extends Wrapper {
 
 		$handle = parent::opendir($path);
 		$items = [];
-		while ($file = readdir($handle)) {
+		while (($file = readdir($handle)) !== false) {
 			if ($file !== '.' && $file !== '..') {
 				if ($this->checkPermissions(trim($path . '/' . $file, '/'), Constants::PERMISSION_READ)) {
 					$items[] = $file;


### PR DESCRIPTION
Fixes a `readdir()` call within a loop that had undesirable false evaluation potential in:

* `opendir()` in `OCA\GroupFolders\ACL\ACLStorageWrapper`

Same deal as nextcloud/server#38630

Ref: https://www.php.net/manual/en/function.readdir.php