### PR TITLE
fix: Do not use `EventDispatcherInterface` but OCP `IEventDispatcher`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"cs:fix": "php-cs-fixer fix",
 		"psalm": "psalm.phar --threads=1",
 		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline",
-		"psalm:clear": "psalm.phar --clear-cache && psalm --clear-global-cache",
+		"psalm:clear": "psalm.phar --clear-cache && psalm.phar --clear-global-cache",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MissingParamType,InvalidFalsableReturnType",
 		"test:unit": "vendor/bin/phpunit -c tests/phpunit.xml"
 	},

--- a/lib/Versions/GroupVersionsExpireManager.php
+++ b/lib/Versions/GroupVersionsExpireManager.php
@@ -29,7 +29,7 @@ use OC\Hooks\BasicEmitter;
 use OC\User\User;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCP\AppFramework\Utility\ITimeFactory;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use OCP\EventDispatcher\IEventDispatcher;
 
 class GroupVersionsExpireManager extends BasicEmitter {
 	private $folderManager;
@@ -43,7 +43,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 		ExpireManager $expireManager,
 		VersionsBackend $versionsBackend,
 		ITimeFactory $timeFactory,
-		EventDispatcherInterface $dispatcher
+		IEventDispatcher $dispatcher
 	) {
 		$this->folderManager = $folderManager;
 		$this->expireManager = $expireManager;

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -547,11 +547,12 @@ namespace OC\Files {
 }
 
 namespace OC\User {
-	use OCP\UserInterface;
+	use OCP\EventDispatcher\IEventDispatcher;
 	use OCP\IUser;
-	use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+	use OCP\UserInterface;
+
 	class User implements IUser {
-		public function __construct(string $uid, ?UserInterface $backend, EventDispatcherInterface $dispatcher, $emitter = null, IConfig $config = null, $urlGenerator = null) {}
+		public function __construct(string $uid, ?UserInterface $backend, IEventDispatcher $dispatcher, $emitter = null, IConfig $config = null, $urlGenerator = null) {}
 	}
 }
 


### PR DESCRIPTION
The interfaces were changed on current master (upcoming Nextcloud 28), so the event dispatcher for the User class should be the interface from OCP instead of directly use the Symfony dispatcher.

Fixes:
> TypeError: OC\User\User::__construct(): Argument #3 ($dispatcher) must be of type OCP\EventDispatcher\IEventDispatcher, OC\EventDispatcher\SymfonyAdapter given, called in /var/www/html/custom_apps/groupfolders/lib/Versions/GroupVersionsExpireManager.php on line 69 and defined in /var/www/html/lib/private/User/User.php:105