### PR TITLE
Adapt version backend to new features

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -47,6 +47,7 @@ use OCA\GroupFolders\Mount\MountProvider;
 use OCA\GroupFolders\Trash\TrashBackend;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCA\GroupFolders\Versions\GroupVersionsExpireManager;
+use OCA\GroupFolders\Versions\GroupVersionsMapper;
 use OCA\GroupFolders\Versions\VersionsBackend;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -55,6 +56,8 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\IAppContainer;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\IMimeTypeLoader;
+use OCP\Files\IRootFolder;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -131,10 +134,13 @@ class Application extends App implements IBootstrap {
 
 		$context->registerService(VersionsBackend::class, function (IAppContainer $c): VersionsBackend {
 			return new VersionsBackend(
+				$c->get(IRootFolder::class),
 				$c->get('GroupAppFolder'),
 				$c->get(MountProvider::class),
 				$c->get(ITimeFactory::class),
-				$c->get(LoggerInterface::class)
+				$c->get(LoggerInterface::class),
+				$c->get(GroupVersionsMapper::class),
+				$c->get(IMimeTypeLoader::class),
 			);
 		});
 

--- a/lib/Helper/LazyFolder.php
+++ b/lib/Helper/LazyFolder.php
@@ -266,4 +266,8 @@ class LazyFolder implements Folder {
 	public function unlock($type) {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
+
+	public function getParentId(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
 }

--- a/lib/Migration/Version16000Date20230821085801.php
+++ b/lib/Migration/Version16000Date20230821085801.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Louis Chmn <louis@chmn.me>
+ *
+ * @author Louis Chmn <louis@chmn.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version16000Date20230821085801 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable("group_folders_versions")) {
+			return null;
+		}
+
+		$table = $schema->createTable("group_folders_versions");
+		$table->addColumn('id', Types::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('file_id', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('timestamp', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('size', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('mimetype', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('metadata', Types::TEXT, [
+			'notnull' => true,
+			'default' => '{}',
+		]);
+
+		$table->setPrimaryKey(['id']);
+		$table->addUniqueIndex(['file_id', 'timestamp'], 'gf_versions_uniq_index');
+
+		return $schema;
+	}
+}

--- a/lib/Versions/GroupVersion.php
+++ b/lib/Versions/GroupVersion.php
@@ -30,11 +30,6 @@ use OCP\Files\FileInfo;
 use OCP\IUser;
 
 class GroupVersion extends Version {
-	/** @var File */
-	private $versionFile;
-
-	/** @var int */
-	private $folderId;
 
 	public function __construct(
 		int $timestamp,
@@ -46,12 +41,11 @@ class GroupVersion extends Version {
 		FileInfo $sourceFileInfo,
 		IVersionBackend $backend,
 		IUser $user,
-		File $versionFile,
-		int $folderId
+		string $label,
+		private File $versionFile,
+		private int $folderId,
 	) {
-		parent::__construct($timestamp, $revisionId, $name, $size, $mimetype, $path, $sourceFileInfo, $backend, $user);
-		$this->versionFile = $versionFile;
-		$this->folderId = $folderId;
+		parent::__construct($timestamp, $revisionId, $name, $size, $mimetype, $path, $sourceFileInfo, $backend, $user, $label);
 	}
 
 	public function getVersionFile(): File {

--- a/lib/Versions/GroupVersionEntity.php
+++ b/lib/Versions/GroupVersionEntity.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Louis Chmn <louis@chmn.me>
+ *
+ * @author Louis Chmn <louis@chmn.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Versions;
+
+use JsonSerializable;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * @method int getFileId()
+ * @method void setFileId(int $fileId)
+ * @method int getTimestamp()
+ * @method void setTimestamp(int $timestamp)
+ * @method int|float getSize()
+ * @method void setSize(int|float $size)
+ * @method int getMimetype()
+ * @method void setMimetype(int $mimetype)
+ * @method string getMetadata()
+ * @method void setMetadata(string $metadata)
+ */
+class GroupVersionEntity extends Entity implements JsonSerializable {
+	protected ?int $fileId = null;
+	protected ?int $timestamp = null;
+	protected ?int $size = null;
+	protected ?int $mimetype = null;
+	protected ?string $metadata = null;
+
+	public function __construct() {
+		$this->addType('id', Types::INTEGER);
+		$this->addType('file_id', Types::INTEGER);
+		$this->addType('timestamp', Types::INTEGER);
+		$this->addType('size', Types::INTEGER);
+		$this->addType('mimetype', Types::INTEGER);
+		$this->addType('metadata', Types::STRING);
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->id,
+			'file_id' => $this->fileId,
+			'timestamp' => $this->timestamp,
+			'size' => $this->size,
+			'mimetype' => $this->mimetype,
+			'metadata' => $this->metadata,
+		];
+	}
+
+	public function getLabel(): string {
+		return $this->getDecodedMetadata()['label'] ?? '';
+	}
+
+	public function setLabel(string $label): void {
+		$metadata = $this->getDecodedMetadata();
+		$metadata['label'] = $label;
+		$this->setDecodedMetadata($metadata);
+		$this->markFieldUpdated('metadata');
+	}
+
+	public function getDecodedMetadata(): array {
+		return json_decode($this->metadata ?? '', true, 512, JSON_THROW_ON_ERROR) ?? [];
+	}
+
+	public function setDecodedMetadata(array $value): void {
+		$this->metadata = json_encode($value, JSON_THROW_ON_ERROR);
+		$this->markFieldUpdated('metadata');
+	}
+}

--- a/lib/Versions/GroupVersionsMapper.php
+++ b/lib/Versions/GroupVersionsMapper.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Louis Chmn <louis@chmn.me>
+ *
+ * @author Louis Chmn <louis@chmn.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\GroupFolders\Versions;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * @extends QBMapper<GroupVersionEntity>
+ */
+class GroupVersionsMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'group_folders_versions', GroupVersionEntity::class);
+	}
+
+	/**
+	 * @return GroupVersionEntity[]
+	 */
+	public function findAllVersionsForFileId(int $fileId): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			 ->from($this->getTableName())
+			 ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)));
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @return GroupVersionEntity
+	 */
+	public function findCurrentVersionForFileId(int $fileId): GroupVersionEntity {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			 ->from($this->getTableName())
+			 ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)))
+			 ->orderBy('timestamp', 'DESC')
+			 ->setMaxResults(1);
+
+		return $this->findEntity($qb);
+	}
+
+	public function findVersionForFileId(int $fileId, int $timestamp): GroupVersionEntity {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			 ->from($this->getTableName())
+			 ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)))
+			 ->andWhere($qb->expr()->eq('timestamp', $qb->createNamedParameter($timestamp)));
+
+		return $this->findEntity($qb);
+	}
+
+	public function deleteAllVersionsForFileId(int $fileId): int {
+		$qb = $this->db->getQueryBuilder();
+
+		return $qb->delete($this->getTableName())
+			 ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)))
+			 ->executeStatement();
+	}
+}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -260,6 +260,20 @@ namespace OCA\Files_Versions\Versions {
 		public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): ?File;
 	}
 
+	interface INameableVersionBackend {
+		public function setVersionLabel(IVersion $version, string $label): void;
+	}
+
+	interface IDeletableVersionBackend {
+		public function deleteVersion(IVersion $version): void;
+	}
+
+	interface INeedSyncVersionBackend {
+		public function createVersionEntity(File $file): void;
+		public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void;
+		public function deleteVersionsEntity(File $file): void;
+	}
+
 	interface IVersion {
 		public function getBackend(): IVersionBackend;
 
@@ -293,7 +307,8 @@ namespace OCA\Files_Versions\Versions {
 			string $path,
 			FileInfo $sourceFileInfo,
 			IVersionBackend $backend,
-			IUser $user
+			IUser $user,
+			string $label = ''
 		) {
 		}
 


### PR DESCRIPTION
Adapt the version backend to the new files versions feature.

## New
+ Support naming a version
+ Support deleting a version
+ Adds DB table to store version infos
+ Fix version creation that was using the current time instead of the version mtime
+ Adapt `LazyFolder` to new `FileInfo` interface https://github.com/nextcloud/server/pull/38150

## Todo
- [x] Test version import from previous versions
- [x] Check tests

Fix https://github.com/nextcloud/server/issues/39138
Needs https://github.com/nextcloud/server/pull/40296