### PR TITLE
pass around preload rules in acl wrapper instead of relying on the cache

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -30,8 +30,8 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchQuery;
 
 class ACLCacheWrapper extends CacheWrapper {
-	private $aclManager;
-	private $inShare;
+	private ACLManager $aclManager;
+	private bool $inShare;
 
 	private function getACLPermissionsForPath(string $path, array $rules = []) {
 		if ($rules) {
@@ -70,7 +70,7 @@ class ACLCacheWrapper extends CacheWrapper {
 	public function getFolderContentsById($fileId) {
 		$results = $this->getCache()->getFolderContentsById($fileId);
 		$rules = $this->preloadEntries($results);
-		$entries = array_map(function($entry) use ($rules) {
+		$entries = array_map(function ($entry) use ($rules) {
 			return $this->formatCacheEntry($entry, $rules);
 		}, $results);
 		return array_filter(array_filter($entries));

--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -33,8 +33,12 @@ class ACLCacheWrapper extends CacheWrapper {
 	private $aclManager;
 	private $inShare;
 
-	private function getACLPermissionsForPath(string $path) {
-		$permissions = $this->aclManager->getACLPermissionsForPath($path);
+	private function getACLPermissionsForPath(string $path, array $rules = []) {
+		if ($rules) {
+			$permissions = $this->aclManager->getPermissionsForPathFromRules($path, $rules);
+		} else {
+			$permissions = $this->aclManager->getACLPermissionsForPath($path);
+		}
 
 		// if there is no read permissions, than deny everything
 		if ($this->inShare) {
@@ -52,10 +56,10 @@ class ACLCacheWrapper extends CacheWrapper {
 		$this->inShare = $inShare;
 	}
 
-	protected function formatCacheEntry($entry) {
+	protected function formatCacheEntry($entry, array $rules = []) {
 		if (isset($entry['permissions'])) {
 			$entry['scan_permissions'] = $entry['permissions'];
-			$entry['permissions'] &= $this->getACLPermissionsForPath($entry['path']);
+			$entry['permissions'] &= $this->getACLPermissionsForPath($entry['path'], $rules);
 			if (!$entry['permissions']) {
 				return false;
 			}
@@ -65,8 +69,10 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	public function getFolderContentsById($fileId) {
 		$results = $this->getCache()->getFolderContentsById($fileId);
-		$this->preloadEntries($results);
-		$entries = array_map([$this, 'formatCacheEntry'], $results);
+		$rules = $this->preloadEntries($results);
+		$entries = array_map(function($entry) use ($rules) {
+			return $this->formatCacheEntry($entry, $rules);
+		}, $results);
 		return array_filter(array_filter($entries));
 	}
 
@@ -90,11 +96,12 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	/**
 	 * @param ICacheEntry[] $entries
+	 * @return Rule[][]
 	 */
-	private function preloadEntries(array $entries) {
+	private function preloadEntries(array $entries): array {
 		$paths = array_map(function (ICacheEntry $entry) {
 			return $entry->getPath();
 		}, $entries);
-		$this->aclManager->preloadPaths($paths);
+		return $this->aclManager->preloadPaths($paths, false);
 	}
 }

--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -102,6 +102,6 @@ class ACLCacheWrapper extends CacheWrapper {
 		$paths = array_map(function (ICacheEntry $entry) {
 			return $entry->getPath();
 		}, $entries);
-		return $this->aclManager->preloadPaths($paths, false);
+		return $this->aclManager->getRelevantRulesForPath($paths, false);
 	}
 }

--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -70,6 +70,14 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 		return $this->permissions;
 	}
 
+	/**
+	 * Apply this rule to an existing permission set, returning the resulting permissions
+	 *
+	 * All permissions included in the current mask will overwrite the existing permissions
+	 *
+	 * @param int $permissions
+	 * @return int
+	 */
 	public function applyPermissions(int $permissions): int {
 		$invertedMask = ~$this->mask;
 		// create a bitmask that has all inherit and allow bits set to 1 and all deny bits to 0

--- a/lib/Listeners/CircleDestroyedEventListener.php
+++ b/lib/Listeners/CircleDestroyedEventListener.php
@@ -32,7 +32,6 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
 class CircleDestroyedEventListener implements IEventListener {
-
 	public function __construct(
 		private FolderManager $folderManager,
 	) {

--- a/lib/Migration/Version1401000Date20230426112001.php
+++ b/lib/Migration/Version1401000Date20230426112001.php
@@ -33,7 +33,6 @@ use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
 class Version1401000Date20230426112001 extends SimpleMigrationStep {
-
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();

--- a/lib/Migration/Version16000Date20230821085801.php
+++ b/lib/Migration/Version16000Date20230821085801.php
@@ -36,7 +36,6 @@ use OCP\Migration\SimpleMigrationStep;
  * Auto-generated migration step: Please modify to your needs!
  */
 class Version16000Date20230821085801 extends SimpleMigrationStep {
-
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -138,7 +138,7 @@ class MountProvider implements IMountProvider {
 			return $this->getJailPath($folder['folder_id']);
 		}, $foldersWithAcl);
 		$aclManager = $this->aclManagerFactory->getACLManager($user, $this->getRootStorageId());
-		$rootRules = $aclManager->preloadPaths($aclRootPaths);
+		$rootRules = $aclManager->getRelevantRulesForPath($aclRootPaths);
 
 		return array_values(array_filter(array_map(function ($folder) use ($user, $loader, $conflicts, $aclManager, $rootRules) {
 			// check for existing files in the user home and rename them if needed

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -138,9 +138,9 @@ class MountProvider implements IMountProvider {
 			return $this->getJailPath($folder['folder_id']);
 		}, $foldersWithAcl);
 		$aclManager = $this->aclManagerFactory->getACLManager($user, $this->getRootStorageId());
-		$aclManager->preloadPaths($aclRootPaths);
+		$rootRules = $aclManager->preloadPaths($aclRootPaths);
 
-		return array_values(array_filter(array_map(function ($folder) use ($user, $loader, $conflicts, $aclManager) {
+		return array_values(array_filter(array_map(function ($folder) use ($user, $loader, $conflicts, $aclManager, $rootRules) {
 			// check for existing files in the user home and rename them if needed
 			$originalFolderName = $folder['mount_point'];
 			if (in_array($originalFolderName, $conflicts)) {
@@ -168,7 +168,8 @@ class MountProvider implements IMountProvider {
 				$loader,
 				$folder['acl'],
 				$user,
-				$aclManager
+				$aclManager,
+				$rootRules
 			);
 		}, $folders)));
 	}
@@ -200,7 +201,8 @@ class MountProvider implements IMountProvider {
 		IStorageFactory $loader = null,
 		bool $acl = false,
 		IUser $user = null,
-		?ACLManager $aclManager = null
+		?ACLManager $aclManager = null,
+		array $rootRules = []
 	): ?IMountPoint {
 		if (!$cacheEntry) {
 			// trigger folder creation
@@ -219,12 +221,12 @@ class MountProvider implements IMountProvider {
 		if ($acl && $user) {
 			$inShare = $this->getCurrentUID() === null || $this->getCurrentUID() !== $user->getUID();
 			$aclManager ??= $this->aclManagerFactory->getACLManager($user, $this->getRootStorageId());
+			$aclRootPermissions = $aclManager->getPermissionsForPathFromRules($rootPath, $rootRules);
 			$storage = new ACLStorageWrapper([
 				'storage' => $storage,
 				'acl_manager' => $aclManager,
-				'in_share' => $inShare
+				'in_share' => $inShare,
 			]);
-			$aclRootPermissions = $aclManager->getACLPermissionsForPath($rootPath);
 			$cacheEntry['permissions'] &= $aclRootPermissions;
 		}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -30,7 +30,6 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\Settings\IDelegatedSettings;
 
 class Admin implements IDelegatedSettings {
-
 	public function __construct(
 		private IInitialState $initialState,
 		private ApplicationService $applicationService,

--- a/lib/Versions/GroupVersion.php
+++ b/lib/Versions/GroupVersion.php
@@ -30,7 +30,6 @@ use OCP\Files\FileInfo;
 use OCP\IUser;
 
 class GroupVersion extends Version {
-
 	public function __construct(
 		int $timestamp,
 		int $revisionId,


### PR DESCRIPTION
Since the cache is intentionally limited in size (for memory reasons), it doesn't "work" for large folders or when you have a lot of groupfolders with acl enables.

This adds some more manual passing of preloaded rules around to avoid the need to rely on the generic cache in those cases.