### PR TITLE
don't apply acls when scanning

### DIFF
--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -1502,6 +1502,7 @@ namespace OC\Files\Storage\Wrapper{
 
 	class Jail extends Wrapper {
 		public function getUnjailedPath(string $path): string {}
+		public function getUnjailedStorage(): IStorage {}
 	}
 
 	class Quota extends Wrapper {


### PR DESCRIPTION
we want to scan the full storage, even if the current user can't see all the files