### PR TITLE
Update Psalm to 5.9 to sync with server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 		"sabre/dav": "^4.1",
 		"sabre/xml": "^2.2",
 		"symfony/event-dispatcher": "^5.3.11",
-		"psalm/phar": "^4.10",
+		"psalm/phar": "^5.9",
 		"nextcloud/coding-standard": "^1.0",
 		"nextcloud/ocp": "dev-master"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -241,26 +241,26 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5c5b6d8600ddaf9f466736e34103b2921cc9b0e3"
+                "reference": "5047d4e94814933e913a562a410d87cf27b2c284"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5c5b6d8600ddaf9f466736e34103b2921cc9b0e3",
-                "reference": "5c5b6d8600ddaf9f466736e34103b2921cc9b0e3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5047d4e94814933e913a562a410d87cf27b2c284",
+                "reference": "5047d4e94814933e913a562a410d87cf27b2c284",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ~8.0 || ~8.1",
+                "php": "~8.0 || ~8.1 || ~8.2 || ~8.3",
                 "psr/clock": "^1.0",
-                "psr/container": "^1.1.1",
+                "psr/container": "^2.0.2",
                 "psr/event-dispatcher": "^1.0",
-                "psr/log": "^1.1"
+                "psr/log": "^1.1.4"
             },
             "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "26.0.0-dev"
+                    "dev-master": "29.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -278,7 +278,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-02-09T00:37:24+00:00"
+            "time": "2023-11-28T09:57:05+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1006,22 +1006,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -1048,9 +1053,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/event-dispatcher",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "616c61f244d35253185f76d157a16652",
+    "content-hash": "b941b1d343cd286749cbd1f0f901ba5e",
     "packages": [
         {
             "name": "php-parallel-lint/php-parallel-lint",
@@ -923,16 +923,16 @@
         },
         {
             "name": "psalm/phar",
-            "version": "4.18.1",
+            "version": "5.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/phar.git",
-                "reference": "2c5140c62d897982d7f623d8dbb25ab802557c5f"
+                "reference": "be4f93e50edf473d60a6e6f9c1d78546a3a32b90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/phar/zipball/2c5140c62d897982d7f623d8dbb25ab802557c5f",
-                "reference": "2c5140c62d897982d7f623d8dbb25ab802557c5f",
+                "url": "https://api.github.com/repos/psalm/phar/zipball/be4f93e50edf473d60a6e6f9c1d78546a3a32b90",
+                "reference": "be4f93e50edf473d60a6e6f9c1d78546a3a32b90",
                 "shasum": ""
             },
             "require": {
@@ -952,9 +952,9 @@
             "description": "Composer-based Psalm Phar",
             "support": {
                 "issues": "https://github.com/psalm/phar/issues",
-                "source": "https://github.com/psalm/phar/tree/4.18.1"
+                "source": "https://github.com/psalm/phar/tree/5.16.0"
             },
-            "time": "2022-01-08T21:49:33+00:00"
+            "time": "2023-11-22T22:05:24+00:00"
         },
         {
             "name": "psr/clock",

--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -35,6 +35,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListCommand extends Base {
+	/** @var array<int,string> */
 	public const PERMISSION_NAMES = [
 		Constants::PERMISSION_READ => 'read',
 		Constants::PERMISSION_UPDATE => 'write',
@@ -132,7 +133,7 @@ class ListCommand extends Base {
 		if ($permissions === 0) {
 			return 'none';
 		}
-		return implode(', ', array_filter(self::PERMISSION_NAMES, function ($possiblePermission) use ($permissions) {
+		return implode(', ', array_filter(self::PERMISSION_NAMES, function (int $possiblePermission) use ($permissions) {
 			return $possiblePermission & $permissions;
 		}, ARRAY_FILTER_USE_KEY));
 	}

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -88,8 +88,8 @@ class FolderController extends OCSController {
 	}
 
 	/**
-	 * @param array{id: mixed, mount_point: mixed, groups: array<string, array{displayName: string, type: string, permissions: integer}>, quota: int, size: int, acl: bool} $folder
-	 * @return array{id: mixed, mount_point: mixed, groups:array<string, integer>, group_details: array<empty, empty>|mixed, quota: int, size: int, acl: bool}
+	 * @param array{acl: bool, groups: array<string, array{displayName: string, type: string, permissions: int}>, id: int, manage: array<array-key, array{displayname?: string, id?: string, type?: "group"|"user"|"circle"}>, mount_point: mixed, quota: int, size: int} $folder
+	 * @return array{acl: bool, group_details: array<string, array{displayName: string, type: string, permissions: int}>, groups: array<string, int>, id: int, manage: array<array-key, array{displayname?: string, id?: string, type?: "group"|"user"|"circle"}>, mount_point: mixed, quota: int, size: int}
 	 */
 	private function formatFolder(array $folder): array {
 		// keep compatibility with the old 'groups' field

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -359,7 +359,7 @@ class FolderManager {
 	 * @param CirclesQueryHelper|null $queryHelper
 	 * @param string|null $entityId the type of the entity
 	 *
-	 * @return array{displayname?: string, id?: string, type?: "group"|"user"|"circle"}
+	 * @return array{displayName: string, permissions: int, type: 'circle'|'group'}
 	 */
 	private function generateApplicableMapEntry(
 		array $row,

--- a/lib/Listeners/CircleDestroyedEventListener.php
+++ b/lib/Listeners/CircleDestroyedEventListener.php
@@ -31,6 +31,9 @@ use OCA\GroupFolders\Folder\FolderManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 
+/**
+ * @template-implements IEventListener<CircleDestroyedEvent>
+ */
 class CircleDestroyedEventListener implements IEventListener {
 	public function __construct(
 		private FolderManager $folderManager,

--- a/lib/Listeners/LoadAdditionalScriptsListener.php
+++ b/lib/Listeners/LoadAdditionalScriptsListener.php
@@ -25,10 +25,10 @@ declare(strict_types=1);
 
 namespace OCA\GroupFolders\Listeners;
 
-use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\IEventListener;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
 
 /**
  * @template-implements IEventListener<LoadAdditionalScriptsEvent|BeforeTemplateRenderedEvent>

--- a/lib/Listeners/LoadAdditionalScriptsListener.php
+++ b/lib/Listeners/LoadAdditionalScriptsListener.php
@@ -27,7 +27,12 @@ namespace OCA\GroupFolders\Listeners;
 
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCA\Files\Event\LoadAdditionalScriptsEvent;
+use OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent;
 
+/**
+ * @template-implements IEventListener<LoadAdditionalScriptsEvent|BeforeTemplateRenderedEvent>
+ */
 class LoadAdditionalScriptsListener implements IEventListener {
 	public function handle(Event $event): void {
 		\OCP\Util::addScript('groupfolders', 'groupfolders-files');

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -49,6 +49,9 @@ class GroupFolderStorage extends Quota {
 		return $this->folderId;
 	}
 
+	/**
+	 * @psalm-suppress FalsableReturnStatement Return type of getOwner is not clear even in server
+	 */
 	public function getOwner($path) {
 		$user = $this->userSession->getUser();
 		if ($user !== null) {
@@ -70,7 +73,7 @@ class GroupFolderStorage extends Quota {
 	}
 
 	public function getScanner($path = '', $storage = null) {
-		/** @var \OC\Files\Storage\Storage $storage */
+		/** @var \OC\Files\Storage\Wrapper\Wrapper $storage */
 		if (!$storage) {
 			$storage = $this;
 		}

--- a/lib/Versions/ExpireManager.php
+++ b/lib/Versions/ExpireManager.php
@@ -97,6 +97,7 @@ class ExpireManager {
 					$newInterval = false; // version checked so we can move to the next one
 				} else { // time to move on to the next interval
 					$interval++;
+					/** @psalm-suppress InvalidArrayOffset We know that $interval is <= 6 thanks to the -1 intervalEndsAfter in the last step */
 					$step = self::MAX_VERSIONS_PER_INTERVAL[$interval]['step'];
 					$nextVersion = $prevTimestamp - $step;
 					if (self::MAX_VERSIONS_PER_INTERVAL[$interval]['intervalEndsAfter'] === -1) {

--- a/lib/Versions/GroupVersionsExpireManager.php
+++ b/lib/Versions/GroupVersionsExpireManager.php
@@ -61,7 +61,7 @@ class GroupVersionsExpireManager extends BasicEmitter {
 	}
 
 	/**
-	 * @param array{id: int, mount_point: string, groups: array<empty, empty>|array<array-key, int>, quota: int, size: int, acl: bool} $folder
+	 * @param array{acl: bool, groups: array<array-key, array<array-key, int|string>>, id: int, mount_point: mixed, quota: int, size: 0} $folder
 	 */
 	public function expireFolder(array $folder): void {
 		$view = new View('/__groupfolders/versions/' . $folder['id']);

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,8 @@
 		xmlns="https://getpsalm.org/schema/config"
 		xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 		errorBaseline="tests/psalm-baseline.xml"
+		findUnusedBaselineEntry="true"
+		findUnusedCode="false"
 >
 	<stubs>
 		<file name="tests/stub.phpstub" preloadClasses="true"/>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,52 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.x-dev@">
+<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
   <file src="lib/ACL/ACLStorageWrapper.php">
-    <InvalidNullableReturnType occurrences="2">
+    <InvalidNullableReturnType>
       <code>filemtime</code>
       <code>hash</code>
     </InvalidNullableReturnType>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>IteratorDirectory</code>
     </UndefinedClass>
-    <UndefinedInterfaceMethod occurrences="1">
-      <code>getDirectoryContent</code>
-    </UndefinedInterfaceMethod>
-    <UndefinedMethod occurrences="2">
-      <code>parent::getMetaData($path)</code>
-      <code>parent::writeStream($path, $stream, $size)</code>
-    </UndefinedMethod>
-  </file>
-  <file src="lib/AppInfo/Application.php">
-    <UndefinedClass occurrences="2">
-      <code>BeforeTemplateRenderedEvent</code>
-      <code>CircleDestroyedEvent</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Folder/FolderManager.php">
-    <MismatchingDocblockReturnType occurrences="1">
-      <code>array{id: mixed, mount_point: mixed, groups: array&lt;empty, empty&gt;|mixed, quota: int, size: int|mixed, acl: bool}|false</code>
-    </MismatchingDocblockReturnType>
-  </file>
-  <file src="lib/Helper/LazyFolder.php">
-    <InvalidReturnStatement occurrences="2">
-      <code>$this-&gt;__call(__FUNCTION__, func_get_args())</code>
-      <code>$this-&gt;__call(__FUNCTION__, func_get_args())</code>
-    </InvalidReturnStatement>
-  </file>
-  <file src="lib/Mount/RootPermissionsMask.php">
-    <UndefinedMethod occurrences="1">
-      <code>parent::getMetaData($path)</code>
-    </UndefinedMethod>
-  </file>
-  <file src="lib/Trash/GroupTrashItem.php">
-    <UndefinedMethod occurrences="1">
-      <code>parent::__construct($backend, $originalLocation, $deletedTime, $trashPath, $fileInfo, $user)</code>
-    </UndefinedMethod>
   </file>
   <file src="lib/Versions/ExpireManager.php">
-    <TypeDoesNotContainType occurrences="2">
-      <code>self::MAX_VERSIONS_PER_INTERVAL[$interval]['intervalEndsAfter'] === -1</code>
-      <code>self::MAX_VERSIONS_PER_INTERVAL[$interval]['intervalEndsAfter'] === -1</code>
+    <TypeDoesNotContainType>
+      <code><![CDATA[self::MAX_VERSIONS_PER_INTERVAL[$interval]['intervalEndsAfter'] === -1]]></code>
+      <code><![CDATA[self::MAX_VERSIONS_PER_INTERVAL[$interval]['intervalEndsAfter'] === -1]]></code>
     </TypeDoesNotContainType>
   </file>
 </files>

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -75,135 +75,188 @@ namespace OCA\Files_Trashbin\Trash {
 		public function getTitle(): string;
 	}
 
-	class TrashItem implements ITrashItem {
-		public function getTrashBackend(): ITrashBackend {
-			throw new \Exception('stub');
+	class TrashItem implements \OCA\Files_Trashbin\Trash\ITrashItem
+	{
+		/** @var ITrashBackend */
+		private $backend;
+		/** @var string */
+		private $orignalLocation;
+		/** @var int */
+		private $deletedTime;
+		/** @var string */
+		private $trashPath;
+		/** @var FileInfo */
+		private $fileInfo;
+		/** @var IUser */
+		private $user;
+		public function __construct(\OCA\Files_Trashbin\Trash\ITrashBackend $backend, string $originalLocation, int $deletedTime, string $trashPath, \OCP\Files\FileInfo $fileInfo, \OCP\IUser $user)
+		{
 		}
-
-		public function getOriginalLocation(): string {
-			throw new \Exception('stub');
+		public function getTrashBackend() : \OCA\Files_Trashbin\Trash\ITrashBackend
+		{
 		}
-
-		public function getDeletedTime(): int {
-			throw new \Exception('stub');
+		public function getOriginalLocation() : string
+		{
 		}
-
-		public function getTrashPath(): string {
-			throw new \Exception('stub');
+		public function getDeletedTime() : int
+		{
 		}
-
-		public function isRootItem(): bool {
-			throw new \Exception('stub');
+		public function getTrashPath() : string
+		{
 		}
-
-		public function getUser(): IUser {
-			throw new \Exception('stub');
+		public function isRootItem() : bool
+		{
 		}
-
-		public function getEtag() {
+		public function getUser() : \OCP\IUser
+		{
 		}
-
-		public function getId() {
+		public function getEtag()
+		{
 		}
-
-		public function getSize($includeMounts = true) {
-			throw new \Exception('stub');
+		public function getSize($includeMounts = true)
+		{
 		}
-
-		public function getMtime() {
-			throw new \Exception('stub');
+		public function getMtime()
+		{
 		}
-
-		public function getName() {
-			throw new \Exception('stub');
+		public function getName()
+		{
 		}
-
-		public function getInternalPath() {
-			throw new \Exception('stub');
+		public function getInternalPath()
+		{
 		}
-
-		public function getPath() {
-			throw new \Exception('stub');
+		public function getPath()
+		{
 		}
-
-		public function getMimetype() {
-			throw new \Exception('stub');
+		public function getMimetype()
+		{
 		}
-
-		public function getMimePart() {
-			throw new \Exception('stub');
+		public function getMimePart()
+		{
 		}
-
-		public function getStorage() {
-			throw new \Exception('stub');
+		public function getStorage()
+		{
 		}
-
-		public function isEncrypted() {
-			throw new \Exception('stub');
+		public function getId()
+		{
 		}
-
-		public function getPermissions() {
-			throw new \Exception('stub');
+		public function isEncrypted()
+		{
 		}
-
-		public function getType() {
-			throw new \Exception('stub');
+		public function getPermissions()
+		{
 		}
-
-		public function isReadable() {
-			throw new \Exception('stub');
+		public function getType()
+		{
 		}
-
-		public function isUpdateable() {
-			throw new \Exception('stub');
+		public function isReadable()
+		{
 		}
-
-		public function isCreatable() {
-			throw new \Exception('stub');
+		public function isUpdateable()
+		{
 		}
-
-		public function isDeletable() {
-			throw new \Exception('stub');
+		public function isCreatable()
+		{
 		}
-
-		public function isShareable() {
-			throw new \Exception('stub');
+		public function isDeletable()
+		{
 		}
-
-		public function isShared() {
-			throw new \Exception('stub');
+		public function isShareable()
+		{
 		}
-
-		public function isMounted() {
-			throw new \Exception('stub');
+		public function isShared()
+		{
 		}
-
-		public function getMountPoint() {
-			throw new \Exception('stub');
+		public function isMounted()
+		{
 		}
-
-		public function getOwner() {
-			throw new \Exception('stub');
+		public function getMountPoint()
+		{
 		}
-
-		public function getChecksum() {
-			throw new \Exception('stub');
+		public function getOwner()
+		{
 		}
-
-		public function getExtension(): string {
-			throw new \Exception('stub');
+		public function getChecksum()
+		{
 		}
-
-		public function getTitle(): string {
-			throw new \Exception('stub');
+		public function getExtension() : string
+		{
 		}
-
-		public function getCreationTime(): int {
-			throw new \Exception('stub');
+		public function getTitle() : string
+		{
 		}
+		public function getCreationTime() : int
+		{
+		}
+		public function getUploadTime() : int
+		{
+		}
+		public function getParentId() : int
+		{
+		}
+		/**
+		* @inheritDoc
+		* @return array<string, int|string|bool|float|string[]|int[]>
+		*/
+		public function getMetadata() : array
+		{
+		}
+	}
+}
 
-		public function getUploadTime(): int {
-			throw new \Exception('stub');
+namespace OCA\Files\Event {
+	/**
+	* This event is triggered when the files app is rendered.
+	* It can be used to add additional scripts to the files app.
+	*
+	* @since 17.0.0
+	*/
+	class LoadAdditionalScriptsEvent extends \OCP\EventDispatcher\Event
+	{
+		private $hiddenFields = [];
+		public function addHiddenField(string $name, string $value) : void
+		{
+		}
+		public function getHiddenFields() : array
+		{
+		}
+	}
+}
+
+namespace OCA\Files_Sharing\Event {
+	/**
+	* Emitted before the rendering step of the public share page happens. The event
+	* holds a flag that specifies if it is the authentication page of a public share.
+	*
+	* @since 20.0.0
+	*/
+	class BeforeTemplateRenderedEvent extends \OCP\EventDispatcher\Event
+	{
+		/**
+		* @since 20.0.0
+		*/
+		public const SCOPE_PUBLIC_SHARE_AUTH = 'publicShareAuth';
+		/** @var IShare */
+		private $share;
+		/** @var string|null */
+		private $scope;
+		/**
+		* @since 20.0.0
+		*/
+		public function __construct(\OCP\Share\IShare $share, ?string $scope = null)
+		{
+		}
+		/**
+		* @since 20.0.0
+		*/
+		public function getShare() : \OCP\Share\IShare
+		{
+		}
+		/**
+		* @since 20.0.0
+		*/
+		public function getScope() : ?string
+		{
 		}
 	}
 }
@@ -236,28 +289,66 @@ namespace OCA\Files_Versions\Versions {
 	use OCP\Files\Storage\IStorage;
 	use OCP\IUser;
 
-	interface IVersionBackend {
-		public function useBackendForStorage(IStorage $storage): bool;
-
+	/**
+	* @since 15.0.0
+	*/
+	interface IVersionBackend
+	{
 		/**
-		 * @return IVersion[]
-		 */
-		public function getVersionsForFile(IUser $user, FileInfo $file): array;
-
-		public function createVersion(IUser $user, FileInfo $file);
-
-		public function rollback(IVersion $version);
-
+		* Whether or not this version backend should be used for a storage
+		*
+		* If false is returned then the next applicable backend will be used
+		*
+		* @param IStorage $storage
+		* @return bool
+		* @since 17.0.0
+		*/
+		public function useBackendForStorage(\OCP\Files\Storage\IStorage $storage) : bool;
 		/**
-		 * @return resource|false
-		 * @throws NotFoundException
-		 */
-		public function read(IVersion $version);
-
+		* Get all versions for a file
+		*
+		* @param IUser $user
+		* @param FileInfo $file
+		* @return IVersion[]
+		* @since 15.0.0
+		*/
+		public function getVersionsForFile(\OCP\IUser $user, \OCP\Files\FileInfo $file) : array;
 		/**
-		 * @param int|string $revision
-		 */
-		public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): ?File;
+		* Create a new version for a file
+		*
+		* @param IUser $user
+		* @param FileInfo $file
+		* @since 15.0.0
+		*/
+		public function createVersion(\OCP\IUser $user, \OCP\Files\FileInfo $file);
+		/**
+		* Restore this version
+		*
+		* @param IVersion $version
+		* @since 15.0.0
+		*/
+		public function rollback(\OCA\Files_Versions\Versions\IVersion $version);
+		/**
+		* Open the file for reading
+		*
+		* @param IVersion $version
+		* @return resource|false
+		* @throws NotFoundException
+		* @since 15.0.0
+		*/
+		public function read(\OCA\Files_Versions\Versions\IVersion $version);
+		/**
+		* Get the preview for a specific version of a file
+		*
+		* @param IUser $user
+		* @param FileInfo $sourceFile
+		* @param int|string $revision
+		*
+		* @return File
+		*
+		* @since 15.0.0
+		*/
+		public function getVersionFile(\OCP\IUser $user, \OCP\Files\FileInfo $sourceFile, $revision) : \OCP\Files\File;
 	}
 
 	interface INameableVersionBackend {
@@ -783,187 +874,112 @@ namespace OC\Files\Storage {
 	use OCP\Files\Storage\IStorage;
 	use OCP\Files\Cache\IScanner;
 
-	class Storage implements IStorage {
-        /** @var ?IScanner */
-		public $scanner;
+	interface Storage extends \OCP\Files\Storage {
+		/**
+		* get a cache instance for the storage
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage|null (optional) the storage to pass to the cache
+		* @return \OC\Files\Cache\Cache
+		*/
+		public function getCache($path = '', $storage = null);
 
-		public function __construct(array $parameters) {
-		}
+		/**
+		* get a scanner instance for the storage
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the scanner
+		* @return \OC\Files\Cache\Scanner
+		*/
+		public function getScanner($path = '', $storage = null);
 
-		public function getId() {}
 
-		public function mkdir($path) {}
+		/**
+		* get the user id of the owner of a file or folder
+		*
+		* @param string $path
+		* @return string
+		*/
+		public function getOwner($path);
 
-		public function rmdir($path) {}
+		/**
+		* get a watcher instance for the cache
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the watcher
+		* @return \OC\Files\Cache\Watcher
+		*/
+		public function getWatcher($path = '', $storage = null);
 
-		public function opendir($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* get a propagator instance for the cache
+		*
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the watcher
+		* @return \OC\Files\Cache\Propagator
+		*/
+		public function getPropagator($storage = null);
 
-		public function is_dir($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* get a updater instance for the cache
+		*
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the watcher
+		* @return \OC\Files\Cache\Updater
+		*/
+		public function getUpdater($storage = null);
 
-		public function is_file($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* @return \OC\Files\Cache\Storage
+		*/
+		public function getStorageCache();
 
-		public function stat($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* @param string $path
+		* @return array|null
+		*/
+		public function getMetaData($path);
 
-		public function filetype($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* @param string $path The path of the file to acquire the lock for
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		* @throws \OCP\Lock\LockedException
+		*/
+		public function acquireLock($path, $type, ILockingProvider $provider);
 
-		public function filesize($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* @param string $path The path of the file to release the lock for
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		* @throws \OCP\Lock\LockedException
+		*/
+		public function releaseLock($path, $type, ILockingProvider $provider);
 
-		public function isCreatable($path) {
-			throw new \Exception('stub');
-		}
+		/**
+		* @param string $path The path of the file to change the lock for
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		* @throws \OCP\Lock\LockedException
+		*/
+		public function changeLock($path, $type, ILockingProvider $provider);
 
-		public function isReadable($path) {
-			throw new \Exception('stub');
-		}
-
-		public function isUpdatable($path) {
-			throw new \Exception('stub');
-		}
-
-		public function isDeletable($path) {
-			throw new \Exception('stub');
-		}
-
-		public function isSharable($path) {
-			throw new \Exception('stub');
-		}
-
-		public function getPermissions($path) {
-			throw new \Exception('stub');
-		}
-
-		public function file_exists($path) {
-			throw new \Exception('stub');
-		}
-
-		public function filemtime($path) {
-			throw new \Exception('stub');
-		}
-
-		public function file_get_contents($path) {
-			throw new \Exception('stub');
-		}
-
-		public function file_put_contents($path, $data) {
-			throw new \Exception('stub');
-		}
-
-		public function unlink($path) {
-			throw new \Exception('stub');
-		}
-
-		public function rename($path1, $path2) {
-			throw new \Exception('stub');
-		}
-
-		public function copy($path1, $path2) {
-			throw new \Exception('stub');
-		}
-
-		public function fopen($path, $mode) {
-			throw new \Exception('stub');
-		}
-
-		public function getMimeType($path) {
-			throw new \Exception('stub');
-		}
-
-		public function hash($type, $path, $raw = false) {
-			throw new \Exception('stub');
-		}
-
-		public function free_space($path) {
-			throw new \Exception('stub');
-		}
-
-		public function touch($path, $mtime = null) {
-			throw new \Exception('stub');
-		}
-
-		public function getLocalFile($path) {
-			throw new \Exception('stub');
-		}
-
-		public function hasUpdated($path, $time) {
-			throw new \Exception('stub');
-		}
-
-		public function getETag($path) {
-			throw new \Exception('stub');
-		}
-
-		public function isLocal() {
-			throw new \Exception('stub');
-		}
-
-		public function instanceOfStorage($class) {
-			throw new \Exception('stub');
-		}
-
-		public function getDirectDownload($path) {
-			throw new \Exception('stub');
-		}
-
-		public function verifyPath($path, $fileName) {
-			throw new \Exception('stub');
-		}
-
-		public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-			throw new \Exception('stub');
-		}
-
-		public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
-			throw new \Exception('stub');
-		}
-
-		public function test() {
-			throw new \Exception('stub');
-		}
-
-		public function getAvailability() {
-			throw new \Exception('stub');
-		}
-
-		public function setAvailability($isAvailable) {
-			throw new \Exception('stub');
-		}
-
-		public function getOwner($path) {
-			throw new \Exception('stub');
-		}
-
-		public function getCache() {
-			throw new \Exception('stub');
-		}
-
-		public function getPropagator() {
-			throw new \Exception('stub');
-		}
-
-		public function getScanner() {
-			throw new \Exception('stub');
-		}
-
-		public function getUpdater() {
-			throw new \Exception('stub');
-		}
-
-		public function getWatcher() {
-			throw new \Exception('stub');
-		}
-    }
+		/**
+		* Get the contents of a directory with metadata
+		*
+		* @param string $directory
+		* @return \Traversable an iterator, containing file metadata
+		*
+		* The metadata array will contain the following fields
+		*
+		* - name
+		* - mimetype
+		* - mtime
+		* - size
+		* - etag
+		* - storage_mtime
+		* - permissions
+		*/
+		public function getDirectoryContent($directory): \Traversable;
+	}
 }
 
 namespace OC\Files\Storage\Wrapper{
@@ -975,11 +991,514 @@ namespace OC\Files\Storage\Wrapper{
 	use OCP\Files\Storage\IStorage;
 	use OCP\Files\Cache\IScanner;
 
-	class Wrapper extends Storage {
-		protected Storage $storage;
-
-		public function getWrapperStorage(): ?IStorage {}
+	class Wrapper implements \OC\Files\Storage\Storage, \OCP\Files\Storage\ILockingStorage, \OCP\Files\Storage\IWriteStreamStorage
+	{
+		/**
+		* @var \OC\Files\Storage\Storage $storage
+		*/
+		protected $storage;
+		public $cache;
+		public $scanner;
+		public $watcher;
+		public $propagator;
+		public $updater;
+		/**
+		* @param array $parameters
+		*/
+		public function __construct($parameters)
+		{
+		}
+		/**
+		* @return \OC\Files\Storage\Storage
+		*/
+		public function getWrapperStorage()
+		{
+		}
+		/**
+		* Get the identifier for the storage,
+		* the returned id should be the same for every storage object that is created with the same parameters
+		* and two storage objects with the same id should refer to two storages that display the same files.
+		*
+		* @return string
+		*/
+		public function getId()
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.mkdir.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function mkdir($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.rmdir.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function rmdir($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.opendir.php
+		*
+		* @param string $path
+		* @return resource|false
+		*/
+		public function opendir($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.is_dir.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function is_dir($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.is_file.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function is_file($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.stat.php
+		* only the following keys are required in the result: size and mtime
+		*
+		* @param string $path
+		* @return array|bool
+		*/
+		public function stat($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.filetype.php
+		*
+		* @param string $path
+		* @return string|bool
+		*/
+		public function filetype($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.filesize.php
+		* The result for filesize when called on a folder is required to be 0
+		*/
+		public function filesize($path) : false|int|float
+		{
+		}
+		/**
+		* check if a file can be created in $path
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function isCreatable($path)
+		{
+		}
+		/**
+		* check if a file can be read
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function isReadable($path)
+		{
+		}
+		/**
+		* check if a file can be written to
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function isUpdatable($path)
+		{
+		}
+		/**
+		* check if a file can be deleted
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function isDeletable($path)
+		{
+		}
+		/**
+		* check if a file can be shared
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function isSharable($path)
+		{
+		}
+		/**
+		* get the full permissions of a path.
+		* Should return a combination of the PERMISSION_ constants defined in lib/public/constants.php
+		*
+		* @param string $path
+		* @return int
+		*/
+		public function getPermissions($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.file_exists.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function file_exists($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.filemtime.php
+		*
+		* @param string $path
+		* @return int|bool
+		*/
+		public function filemtime($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.file_get_contents.php
+		*
+		* @param string $path
+		* @return string|false
+		*/
+		public function file_get_contents($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.file_put_contents.php
+		*
+		* @param string $path
+		* @param mixed $data
+		* @return int|float|false
+		*/
+		public function file_put_contents($path, $data)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.unlink.php
+		*
+		* @param string $path
+		* @return bool
+		*/
+		public function unlink($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.rename.php
+		*
+		* @param string $source
+		* @param string $target
+		* @return bool
+		*/
+		public function rename($source, $target)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.copy.php
+		*
+		* @param string $source
+		* @param string $target
+		* @return bool
+		*/
+		public function copy($source, $target)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.fopen.php
+		*
+		* @param string $path
+		* @param string $mode
+		* @return resource|bool
+		*/
+		public function fopen($path, $mode)
+		{
+		}
+		/**
+		* get the mimetype for a file or folder
+		* The mimetype for a folder is required to be "httpd/unix-directory"
+		*
+		* @param string $path
+		* @return string|bool
+		*/
+		public function getMimeType($path)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.hash.php
+		*
+		* @param string $type
+		* @param string $path
+		* @param bool $raw
+		* @return string|bool
+		*/
+		public function hash($type, $path, $raw = false)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.free_space.php
+		*
+		* @param string $path
+		* @return int|float|bool
+		*/
+		public function free_space($path)
+		{
+		}
+		/**
+		* search for occurrences of $query in file names
+		*
+		* @param string $query
+		* @return array|bool
+		*/
+		public function search($query)
+		{
+		}
+		/**
+		* see https://www.php.net/manual/en/function.touch.php
+		* If the backend does not support the operation, false should be returned
+		*
+		* @param string $path
+		* @param int $mtime
+		* @return bool
+		*/
+		public function touch($path, $mtime = null)
+		{
+		}
+		/**
+		* get the path to a local version of the file.
+		* The local version of the file can be temporary and doesn't have to be persistent across requests
+		*
+		* @param string $path
+		* @return string|false
+		*/
+		public function getLocalFile($path)
+		{
+		}
+		/**
+		* check if a file or folder has been updated since $time
+		*
+		* @param string $path
+		* @param int $time
+		* @return bool
+		*
+		* hasUpdated for folders should return at least true if a file inside the folder is add, removed or renamed.
+		* returning true for other changes in the folder is optional
+		*/
+		public function hasUpdated($path, $time)
+		{
+		}
+		/**
+		* get a cache instance for the storage
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage|null (optional) the storage to pass to the cache
+		* @return \OC\Files\Cache\Cache
+		*/
+		public function getCache($path = '', $storage = null)
+		{
+		}
+		/**
+		* get a scanner instance for the storage
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the scanner
+		* @return \OC\Files\Cache\Scanner
+		*/
+		public function getScanner($path = '', $storage = null)
+		{
+		}
+		/**
+		* get the user id of the owner of a file or folder
+		*
+		* @param string $path
+		* @return string
+		*/
+		public function getOwner($path)
+		{
+		}
+		/**
+		* get a watcher instance for the cache
+		*
+		* @param string $path
+		* @param \OC\Files\Storage\Storage (optional) the storage to pass to the watcher
+		* @return \OC\Files\Cache\Watcher
+		*/
+		public function getWatcher($path = '', $storage = null)
+		{
+		}
+		public function getPropagator($storage = null)
+		{
+		}
+		public function getUpdater($storage = null)
+		{
+		}
+		/**
+		* @return \OC\Files\Cache\Storage
+		*/
+		public function getStorageCache()
+		{
+		}
+		/**
+		* get the ETag for a file or folder
+		*
+		* @param string $path
+		* @return string|false
+		*/
+		public function getETag($path)
+		{
+		}
+		/**
+		* Returns true
+		*
+		* @return true
+		*/
+		public function test()
+		{
+		}
+		/**
+		* Returns the wrapped storage's value for isLocal()
+		*
+		* @return bool wrapped storage's isLocal() value
+		*/
+		public function isLocal()
+		{
+		}
+		/**
+		* Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
+		*
+		* @param class-string<IStorage> $class
+		* @return bool
+		*/
+		public function instanceOfStorage($class)
+		{
+		}
+		/**
+		* @psalm-template T of IStorage
+		* @psalm-param class-string<T> $class
+		* @psalm-return T|null
+		*/
+		public function getInstanceOfStorage(string $class)
+		{
+		}
+		/**
+		* Pass any methods custom to specific storage implementations to the wrapped storage
+		*
+		* @param string $method
+		* @param array $args
+		* @return mixed
+		*/
+		public function __call($method, $args)
+		{
+		}
+		/**
+		* A custom storage implementation can return an url for direct download of a give file.
+		*
+		* For now the returned array can hold the parameter url - in future more attributes might follow.
+		*
+		* @param string $path
+		* @return array|bool
+		*/
+		public function getDirectDownload($path)
+		{
+		}
+		/**
+		* Get availability of the storage
+		*
+		* @return array [ available, last_checked ]
+		*/
+		public function getAvailability()
+		{
+		}
+		/**
+		* Set availability of the storage
+		*
+		* @param bool $isAvailable
+		*/
+		public function setAvailability($isAvailable)
+		{
+		}
+		/**
+		* @param string $path the path of the target folder
+		* @param string $fileName the name of the file itself
+		* @return void
+		* @throws InvalidPathException
+		*/
+		public function verifyPath($path, $fileName)
+		{
+		}
+		/**
+		* @param IStorage $sourceStorage
+		* @param string $sourceInternalPath
+		* @param string $targetInternalPath
+		* @return bool
+		*/
+		public function copyFromStorage(\OCP\Files\Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath)
+		{
+		}
+		/**
+		* @param IStorage $sourceStorage
+		* @param string $sourceInternalPath
+		* @param string $targetInternalPath
+		* @return bool
+		*/
+		public function moveFromStorage(\OCP\Files\Storage\IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath)
+		{
+		}
+		public function getMetaData($path)
+		{
+		}
+		/**
+		* @param string $path
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		* @throws \OCP\Lock\LockedException
+		*/
+		public function acquireLock($path, $type, \OCP\Lock\ILockingProvider $provider)
+		{
+		}
+		/**
+		* @param string $path
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		*/
+		public function releaseLock($path, $type, \OCP\Lock\ILockingProvider $provider)
+		{
+		}
+		/**
+		* @param string $path
+		* @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
+		* @param \OCP\Lock\ILockingProvider $provider
+		*/
+		public function changeLock($path, $type, \OCP\Lock\ILockingProvider $provider)
+		{
+		}
+		/**
+		* @return bool
+		*/
+		public function needsPartFile()
+		{
+		}
+		public function writeStream(string $path, $stream, int $size = null) : int
+		{
+		}
+		public function getDirectoryContent($directory) : \Traversable
+		{
+		}
 	}
+
+
 
 	class Jail extends Wrapper {
 		public function getUnjailedPath(string $path): string {}
@@ -992,10 +1511,6 @@ namespace OC\Files\Storage\Wrapper{
 	class PermissionsMask extends Wrapper {
 		public function getQuota() {}
 	}
-}
-
-namespace OCP\Files\Mount {
-	interface ISystemMountPoint {}
 }
 
 namespace OC\Files\ObjectStore {
@@ -1063,7 +1578,7 @@ namespace OCA\Circles\Model\Probes {
 namespace OCA\Circles\Events {
 	use OCA\Circles\Model\Circle;
 
-	class CircleDestroyedEvent {
+	class CircleDestroyedEvent extends \OCP\EventDispatcher\Event {
 		public function getCircle(): Circle {}
 	}
 }


### PR DESCRIPTION
This should fix :
`ERROR: InvalidArgument - lib/AppInfo/Application.php:95:60 - Argument 2 of OCP\AppFramework\Bootstrap\IRegistrationContext::registerEventListener expects class-string<OCP\EventDispatcher\IEventListener<OCP\EventDispatcher\Event>>, OCA\GroupFolders\Listeners\NodeRenamedListener::class provided`

But it will find other errors that I’ll fix in here.

| Dev Changes   | From    | To      | Compare                                                                |
|---------------|---------|---------|------------------------------------------------------------------------|
| nextcloud/ocp | 5c5b6d8 | 5047d4e | [...](https://github.com/nextcloud-deps/ocp/compare/5c5b6d8...5047d4e) |
| psalm/phar    | 4.18.1  | 5.16.0  | [...](https://github.com/psalm/phar/compare/4.18.1...5.16.0)           |
| psr/container | 1.1.2   | 2.0.2   | [...](https://github.com/php-fig/container/compare/1.1.2...2.0.2)      |

