### PR TITLE
fix(ACL): don't put inherited ACL permissions in the propPatch request payload

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -309,7 +309,7 @@ export default {
 			const rule = new Rule()
 			rule.fromValues(option.type, option.id, option.displayname, 0b00000, 0b11111)
 			this.list.push(rule)
-			client.propPatch(this.model, this.list).then(() => {
+			client.propPatch(this.model, this.list.filter(rule => !rule.inherited)).then(() => {
 				this.showAclCreate = false
 			})
 		},
@@ -319,7 +319,7 @@ export default {
 			if (index > -1) {
 				list.splice(index, 1)
 			}
-			client.propPatch(this.model, list).then(() => {
+			client.propPatch(this.model, list.filter(rule => !rule.inherited)).then(() => {
 				this.list.splice(index, 1)
 				const inheritedAcl = this.inheritedAclsById[rule.getUniqueMappingIdentifier()]
 				if (inheritedAcl != null) {
@@ -347,7 +347,7 @@ export default {
 			}
 			item.inherited = false
 			Vue.set(this.list, index, item)
-			client.propPatch(this.model, this.list).then(() => {
+			client.propPatch(this.model, this.list.filter(rule => !rule.inherited)).then(() => {
 				// TODO block UI during save
 			})
 		},


### PR DESCRIPTION
* Fix #2659
* Including inherited permissions in `client.propPatch` request makes them local

:warning: As https://github.com/nextcloud/groupfolders/issues/2637 is not solved yet, tested it on stable26 and stable27 only

Before | After
-- | --
create ACL | ![image](https://github.com/nextcloud/groupfolders/assets/93392545/60bc96ff-d6b3-4f50-b7c0-1159aa432193)
![image](https://github.com/nextcloud/groupfolders/assets/93392545/ce5db64c-9218-4b61-a6ae-a9cea7eeb990) | ![image](https://github.com/nextcloud/groupfolders/assets/93392545/7c43bbc0-383b-47c5-aba7-05c0167b64ed)
remove ACL | ![image](https://github.com/nextcloud/groupfolders/assets/93392545/1412ec0c-aab3-4838-a9f0-ba62053fa9d0)
![image](https://github.com/nextcloud/groupfolders/assets/93392545/2284f16b-6bdf-4ea1-8164-e0d83b2c18d5) | ![image](https://github.com/nextcloud/groupfolders/assets/93392545/d6a94b90-ccfb-4b9b-9cc0-c956835e81d2)