### PR TITLE
Fix display of files/folders in scan command

### DIFF
--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -91,7 +91,7 @@ class Scan extends FolderCommand {
 
 			$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($output, &$statsRow) {
 				$output->writeln("\tFile\t<info>/$path</info>", OutputInterface::VERBOSITY_VERBOSE);
-				$statsRow[2]++;
+				$statsRow[1]++;
 				// abortIfInterrupted doesn't exist in nc14
 				if (method_exists($this, 'abortIfInterrupted')) {
 					$this->abortIfInterrupted();
@@ -100,7 +100,7 @@ class Scan extends FolderCommand {
 
 			$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function ($path) use ($output, &$statsRow) {
 				$output->writeln("\tFolder\t<info>/$path</info>", OutputInterface::VERBOSITY_VERBOSE);
-				$statsRow[1]++;
+				$statsRow[2]++;
 				// abortIfInterrupted doesn't exist in nc14
 				if (method_exists($this, 'abortIfInterrupted')) {
 					$this->abortIfInterrupted();


### PR DESCRIPTION
Was reported at https://help.nextcloud.com/t/occ-groupfolders-scan-files-and-folders-mixed-up/170749/

The header looks like 
https://github.com/nextcloud/groupfolders/blob/2aff6aaeb4dc615ea2462ede1fe1e4b5aee3f505/lib/Command/Scan.php#L121-L123