### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -241,12 +241,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "2ac04202af2904a000d3e4090f7def301a4cecfe"
+                "reference": "762d54befc31afb0e007f2549e12040420b2312a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/2ac04202af2904a000d3e4090f7def301a4cecfe",
-                "reference": "2ac04202af2904a000d3e4090f7def301a4cecfe",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/762d54befc31afb0e007f2549e12040420b2312a",
+                "reference": "762d54befc31afb0e007f2549e12040420b2312a",
                 "shasum": ""
             },
             "require": {
@@ -277,7 +277,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2023-11-23T10:57:48+00:00"
+            "time": "2024-01-03T00:33:17+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency