### PR TITLE
Revert: don't apply acls when scanning

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -24,10 +24,7 @@ namespace OCA\GroupFolders\Mount;
 use OC\Files\Cache\Scanner;
 use OC\Files\ObjectStore\ObjectStoreScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
-use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\Quota;
-use OC\Files\Storage\Wrapper\Wrapper;
-use OCA\GroupFolders\ACL\ACLStorageWrapper;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -76,32 +73,10 @@ class GroupFolderStorage extends Quota {
 	}
 
 	public function getScanner($path = '', $storage = null) {
-		// note that we explicitly don't used the passed in storage
-		// as we want to perform the scan on the underlying filesystem
-		// without any of the group folder permissions applied
-
-		/** @var Wrapper $storage */
-		$storage = $this->storage;
-
-		// we want to scan without ACLs applied
-		if ($storage->instanceOfStorage(ACLStorageWrapper::class)) {
-			// sanity check in case the code setting up the wrapper hierarchy is changed without updating this
-			if (!$this->storage instanceof Jail) {
-				throw new \Exception("groupfolder storage layout changed unexpectedly");
-			}
-
-			$jailRoot = $this->storage->getUnjailedPath('');
-			$aclStorage = $this->storage->getUnjailedStorage();
-
-			if (!$aclStorage instanceof ACLStorageWrapper) {
-				throw new \Exception("groupfolder storage layout changed unexpectedly");
-			}
-			$storage = new Jail([
-				'storage' => $aclStorage->getWrapperStorage(),
-				'root' => $jailRoot,
-			]);
+		/** @var \OC\Files\Storage\Wrapper\Wrapper $storage */
+		if (!$storage) {
+			$storage = $this;
 		}
-
 		if ($storage->instanceOfStorage(ObjectStoreStorage::class)) {
 			$storage->scanner = new ObjectStoreScanner($storage);
 		} elseif (!isset($storage->scanner)) {

--- a/tests/ACL/ACLScannerTest.php
+++ b/tests/ACL/ACLScannerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace OCA\groupfolders\tests\ACL;
+
+use OC\Files\Storage\Temporary;
+use OCA\GroupFolders\ACL\ACLManager;
+use OCA\GroupFolders\ACL\ACLStorageWrapper;
+use OCP\Constants;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class ACLScannerTest extends TestCase {
+	private function getAclManager(array $rules): ACLManager {
+		$manager = $this->getMockBuilder(ACLManager::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$manager->method('getACLPermissionsForPath')
+			->willReturnCallback(function ($path) use ($rules) {
+				return $rules[$path] ?? Constants::PERMISSION_ALL;
+			});
+		return $manager;
+	}
+
+	public function testScanAclStorage() {
+		$baseStorage = new Temporary([]);
+		$baseStorage->mkdir('foo');
+		$baseStorage->mkdir('foo/bar');
+		$baseStorage->mkdir('foo/bar/asd');
+		$cache = $baseStorage->getCache();
+		$baseStorage->getScanner()->scan('');
+
+		$cache->update($cache->getId('foo/bar/asd'), ['size' => -1]);
+		$cache->calculateFolderSize('foo/bar');
+		$cache->calculateFolderSize('foo');
+
+		$this->assertEquals(-1, $cache->get('foo/bar')->getSize());
+
+		$acls = $this->getAclManager([
+			'foo/bar' => 0,
+			'foo/bar/asd' => 0,
+		]);
+
+		$aclStorage = new ACLStorageWrapper([
+			'storage' => $baseStorage,
+			'acl_manager' => $acls,
+			'in_share' => false,
+		]);
+
+		$scanner = $aclStorage->getScanner();
+		$aclCache = $aclStorage->getCache();
+		$scanner->scan('');
+
+		$this->assertEquals(0, $cache->get('foo/bar')->getSize());
+
+		$this->assertEquals(31, $cache->get('foo/bar')->getPermissions());
+		$this->assertEquals(false, $aclCache->get('foo/bar'));
+	}
+}


### PR DESCRIPTION
The storage wrapper shenanigans break other wrappers like encryption

reverts: https://github.com/nextcloud/groupfolders/pull/2642

I've also tried to create a test case for the original "fix" but I can't seem to reproduce the issue anymore.