### PR TITLE
fix: mask out rule permissions before merging permissions

### DIFF
--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -51,7 +51,7 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 		$this->userMapping = $userMapping;
 		$this->fileId = $fileId;
 		$this->mask = $mask;
-		$this->permissions = $permissions;
+		$this->permissions = $permissions & $mask;
 	}
 
 	public function getUserMapping(): IUserMapping {

--- a/tests/ACL/ACLCacheWrapperTest.php
+++ b/tests/ACL/ACLCacheWrapperTest.php
@@ -28,9 +28,11 @@ use OCA\GroupFolders\ACL\ACLCacheWrapper;
 use OCA\GroupFolders\ACL\ACLManager;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
-use OCP\IDBConnection;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class ACLCacheWrapperTest extends TestCase {
 	/** @var ACLManager|\PHPUnit_Framework_MockObject_MockObject */
 	private $aclManager;
@@ -42,10 +44,6 @@ class ACLCacheWrapperTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		\OC::$server->registerService(IDBConnection::class, function () {
-			return $this->createMock(IDBConnection::class);
-		});
 
 		$this->aclManager = $this->createMock(ACLManager::class);
 		$this->aclManager->method('getACLPermissionsForPath')

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -298,10 +298,13 @@ class FolderManagerTest extends TestCase {
 	 * @return \PHPUnit_Framework_MockObject_MockObject|IUser
 	 */
 	protected function getUser($groups = []) {
+		$id = uniqid();
 		$user = $this->createMock(IUser::class);
 		$this->groupManager->expects($this->any())
 			->method('getUserGroupIds')
 			->willReturn($groups);
+		$user->method('getUID')
+			->willReturn($id);
 
 		return $user;
 	}


### PR DESCRIPTION
To test:

- Create group1 and group2
- Create user1 and add it to group1 and group2
- Create a groupfolder with access to group1 and group2 and acl enabled
- On the groupfolder, set all permissions to allow for group1, and all except read to deny for group2
- Create a subfolder `folder`
- On the subfolder, set all to deny for group2.
- `occ groupfolders:permissions 1` should list the following permissions

```
+--------+---------------+-----------------------------------------+
| Path   | User/Group    | Permissions                             |
+--------+---------------+-----------------------------------------+
| /      | group: group2 | -write, -create, -delete, -share        |
|        | group: group1 | +read, +write, +create, +delete, +share |
| folder | group: group2 | -read, -write, -create, -delete, -share |
+--------+---------------+-----------------------------------------+
```

User1 has no access to the subfolder, as it is denied through group2

- On folder, set all share permissions to deny and the rest to inherit
- `occ groupfolders:permissions 1` should list the following permissions

```
+--------+---------------+-----------------------------------------+
| Path   | User/Group    | Permissions                             |
+--------+---------------+-----------------------------------------+
| /      | group: group2 | -write, -create, -delete, -share        |
|        | group: group1 | +read, +write, +create, +delete, +share |
| folder | group: group1 | -share                                  |
|        | group: group2 | -read, -write, -create, -delete, -share |
+--------+---------------+-----------------------------------------+
```

On master: user1 now suddenly has access to the folder, even though there should be no new allow permissions for them.

With this PR his permissions are still denied.