### PR TITLE
fix: fix fully inherited acl state not being show as inherited

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -120,7 +120,7 @@ export default {
 			return this.state & 1
 		},
 		isInherited() {
-			return (this.state & 2) === 0
+			return this.inherited || (this.state & 2) === 0
 		},
 		icon() {
 			switch (this.state) {


### PR DESCRIPTION
Fix the ACL state button for inherited rules not being shown as inherited.