### PR TITLE
Support moving versions across storages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 build
 vendor
 js/
+cypress/downloads/

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
 	// faster video processing
 	videoCompression: false,
 
+	// Prevent elements to be scrolled under a top bar during actions (click, clear, type, etc). Default is 'top'.
+	// https://github.com/cypress-io/cypress/issues/871
+	scrollBehavior: 'center',
+
 	// Visual regression testing
 	env: {
 		failSilently: false,

--- a/cypress/e2e/files/filesUtils.ts
+++ b/cypress/e2e/files/filesUtils.ts
@@ -31,33 +31,83 @@ export const triggerActionForFile = (filename: string, actionId: string) => {
 	cy.get(`[data-cy-files-list-row-action="${CSS.escape(actionId)}"] > button`).should('exist').click()
 }
 
-export const moveFile = (fileName: string, dirName: string) => {
+export const moveFile = (fileName: string, dirPath: string) => {
 	getRowForFile(fileName).should('be.visible')
 	triggerActionForFile(fileName, 'move-copy')
 
 	cy.get('.file-picker').within(() => {
 		// intercept the copy so we can wait for it
-		cy.intercept('MOVE', /\/remote.php\/dav\/files\//).as('moveFile')
+		cy.intercept({ method: 'MOVE', times: 1, url: /\/remote.php\/dav\/files\// }).as('moveFile')
 
-		if (dirName === '/') {
+		if (dirPath === '/') {
 			// select home folder
 			cy.get('button[title="Home"]').should('be.visible').click()
 			// click move
 			cy.contains('button', 'Move').should('be.visible').click()
-		} else if (dirName === '.') {
+		} else if (dirPath === '.') {
 			// click move
 			cy.contains('button', 'Copy').should('be.visible').click()
 		} else {
-			// select the folder
-			cy.get(`[data-filename="${dirName}"]`).should('be.visible').click()
+			const directories = dirPath.split('/')
+			directories.forEach((directory) => {
+				// select the folder
+				cy.get(`[data-filename="${directory}"]`).should('be.visible').click()
+			})
+
 			// click move
-			cy.contains('button', `Move to ${dirName}`).should('be.visible').click()
+			cy.contains('button', `Move to ${directories.at(-1)}`).should('be.visible').click()
 		}
 
 		cy.wait('@moveFile')
 	})
 }
 
-export const navigateToFolder = (folderName: string) => {
-	getRowForFile(folderName).should('be.visible').find('[data-cy-files-list-row-name-link]').click()
+export const copyFile = (fileName: string, dirPath: string) => {
+	getRowForFile(fileName).should('be.visible')
+	triggerActionForFile(fileName, 'move-copy')
+
+	cy.get('.file-picker').within(() => {
+		// intercept the copy so we can wait for it
+		cy.intercept({ method: 'COPY', times: 1, url: /\/remote.php\/dav\/files\// }).as('copyFile')
+
+		if (dirPath === '/') {
+			// select home folder
+			cy.get('button[title="Home"]').should('be.visible').click()
+			// click copy
+			cy.contains('button', 'Copy').should('be.visible').click()
+		} else if (dirPath === '.') {
+			// click copy
+			cy.contains('button', 'Copy').should('be.visible').click()
+		} else {
+			const directories = dirPath.split('/')
+			directories.forEach((directory) => {
+				// select the folder
+				cy.get(`[data-filename="${directory}"]`).should('be.visible').click()
+			})
+
+			// click copy
+			cy.contains('button', `Copy to ${directories.at(-1)}`).should('be.visible').click()
+		}
+
+		cy.wait('@copyFile')
+	})
+}
+
+export const navigateToFolder = (dirPath: string) => {
+	const directories = dirPath.split('/')
+	directories.forEach((directory) => {
+		getRowForFile(directory).should('be.visible').find('[data-cy-files-list-row-name-link]').click()
+	})
+
+}
+
+export const closeSidebar = () => {
+	// {force: true} as it might be hidden behind toasts
+	cy.get('[cy-data-sidebar] .app-sidebar__close').click({ force: true })
+}
+
+export const clickOnBreadcumbs = (label: string) => {
+	cy.intercept({ method: 'PROPFIND', url: /\/remote.php\/dav\// }).as('propfind')
+	cy.get('[data-cy-files-content-breadcrumbs]').contains(label).click()
+	cy.wait('@propfind')
 }

--- a/cypress/e2e/files_versions/version_cross_storage_move.cy.ts
+++ b/cypress/e2e/files_versions/version_cross_storage_move.cy.ts
@@ -1,0 +1,149 @@
+/**
+ * @copyright Copyright (c) 2024 Louis Chmn <louis@chmn.me>
+ *
+ * @author Louis Chmn <louis@chmn.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import type { User } from '@nextcloud/cypress'
+
+import { PERMISSION_DELETE, PERMISSION_READ, PERMISSION_WRITE, addUserToGroup, createGroup, createGroupFolder } from '../groupfoldersUtils'
+import { assertVersionContent, nameVersion, openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
+import { clickOnBreadcumbs, closeSidebar, copyFile, moveFile, navigateToFolder } from '../files/filesUtils'
+
+/**
+ *
+ * @param filePath
+ */
+function assertVersionsContent(filePath: string) {
+	const path = filePath.split('/').slice(0, -1).join('/')
+
+	clickOnBreadcumbs('All files')
+
+	if (path !== '') {
+		navigateToFolder(path)
+	}
+
+	openVersionsPanel(filePath)
+
+	cy.get('[data-files-versions-version]').should('have.length', 3)
+	cy.get('[data-files-versions-version]').eq(2).contains('v1')
+	assertVersionContent(0, 'v3')
+	assertVersionContent(1, 'v2')
+	assertVersionContent(2, 'v1')
+	closeSidebar()
+}
+
+describe('Versions cross storage move', () => {
+	let randomGroupName: string
+	let randomGroupFolderName: string
+	let randomFileName: string
+	let randomCopiedFileName: string
+	let user: User
+
+	before(() => {
+		randomGroupName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+		randomGroupFolderName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+
+		cy.createRandomUser().then(_user => { user = _user })
+		createGroup(randomGroupName)
+
+		cy.then(() => {
+			addUserToGroup(randomGroupName, user.userId)
+			createGroupFolder(randomGroupFolderName, randomGroupName, [PERMISSION_READ, PERMISSION_WRITE, PERMISSION_DELETE])
+		})
+	})
+
+	beforeEach(() => {
+		const randomString = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+		randomFileName = randomString + '.txt'
+		randomCopiedFileName = randomString + ' (copy).txt'
+		uploadThreeVersions(user, `${randomGroupFolderName}/${randomFileName}`)
+
+		cy.login(user)
+		cy.visit('/apps/files')
+		navigateToFolder(randomGroupFolderName)
+		openVersionsPanel(`${randomGroupFolderName}/${randomFileName}`)
+		nameVersion(2, 'v1')
+		closeSidebar()
+	})
+
+	it('Correctly moves versions to the user\'s FS when the user moves the file out of the groupfolder', () => {
+		moveFile(randomFileName, '/')
+
+		assertVersionsContent(randomFileName)
+
+		moveFile(randomFileName, randomGroupFolderName)
+
+		assertVersionsContent(`${randomGroupFolderName}/${randomFileName}`)
+	})
+
+	it('Correctly copies versions to the user\'s FS when the user copies the file out of the groupfolder', () => {
+		copyFile(randomFileName, '/')
+
+		assertVersionsContent(randomFileName)
+
+		copyFile(randomFileName, randomGroupFolderName)
+
+		assertVersionsContent(`${randomGroupFolderName}/${randomCopiedFileName}`)
+	})
+
+	context('When a file is in a subfolder', () => {
+		let randomSubFolderName
+		let randomCopiedSubFolderName
+		let randomSubSubFolderName
+
+		beforeEach(() => {
+			const randomString = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+			randomSubFolderName = randomString
+			randomCopiedSubFolderName = randomString + ' (copy)'
+
+			randomSubSubFolderName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+			clickOnBreadcumbs('All files')
+			cy.mkdir(user, `/${randomGroupFolderName}/${randomSubFolderName}`)
+			cy.mkdir(user, `/${randomGroupFolderName}/${randomSubFolderName}/${randomSubSubFolderName}`)
+			cy.login(user)
+			navigateToFolder(randomGroupFolderName)
+		})
+
+		it('Correctly moves versions when user moves the containing folder out of the groupfolder', () => {
+			moveFile(randomFileName, `${randomSubFolderName}/${randomSubSubFolderName}`)
+			moveFile(randomSubFolderName, '/')
+
+			assertVersionsContent(`${randomSubFolderName}/${randomSubSubFolderName}/${randomFileName}`)
+
+			clickOnBreadcumbs('All files')
+			moveFile(randomSubFolderName, randomGroupFolderName)
+
+			assertVersionsContent(`${randomGroupFolderName}/${randomSubFolderName}/${randomSubSubFolderName}/${randomFileName}`)
+		})
+
+		// TODO: re-enable this test when the copy event from groupfolder to the home storage contains the file list.
+		xit('Correctly copies versions when user copies the containing folder out of the groupfolder', () => {
+			moveFile(randomFileName, `${randomSubFolderName}/${randomSubSubFolderName}`)
+			copyFile(randomSubFolderName, '/')
+
+			assertVersionsContent(`${randomSubFolderName}/${randomSubSubFolderName}/${randomFileName}`)
+
+			clickOnBreadcumbs('All files')
+			copyFile(randomSubFolderName, randomGroupFolderName)
+
+			assertVersionsContent(`${randomGroupFolderName}/${randomCopiedSubFolderName}/${randomSubSubFolderName}/${randomFileName}`)
+		})
+	})
+})

--- a/cypress/e2e/files_versions/version_download.cy.ts
+++ b/cypress/e2e/files_versions/version_download.cy.ts
@@ -56,8 +56,8 @@ describe('Versions download', () => {
 	})
 
 	it('Download versions and assert their content', () => {
-		assertVersionContent(randomFileName, 0, 'v3')
-		assertVersionContent(randomFileName, 1, 'v2')
-		assertVersionContent(randomFileName, 2, 'v1')
+		assertVersionContent(0, 'v3')
+		assertVersionContent(1, 'v2')
+		assertVersionContent(2, 'v1')
 	})
 })

--- a/cypress/e2e/files_versions/version_restoration.cy.ts
+++ b/cypress/e2e/files_versions/version_restoration.cy.ts
@@ -70,8 +70,8 @@ describe('Versions restoration', () => {
 	})
 
 	it('Downloads versions and assert there content', () => {
-		assertVersionContent(randomFileName, 0, 'v1')
-		assertVersionContent(randomFileName, 1, 'v3')
-		assertVersionContent(randomFileName, 2, 'v2')
+		assertVersionContent(0, 'v1')
+		assertVersionContent(1, 'v3')
+		assertVersionContent(2, 'v2')
 	})
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,3 +20,8 @@
  *
  */
 import './commands'
+
+// Fix ResizeObserver loop limit exceeded happening in Cypress only
+// @see https://github.com/cypress-io/cypress/issues/20341
+Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop limit exceeded'))
+Cypress.on('uncaught:exception', err => !err.message.includes('ResizeObserver loop completed with undelivered notifications'))

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -390,6 +390,49 @@ namespace OCA\Files_Versions\Versions {
 		public function getUser(): IUser;
 	}
 
+	/**
+	 * @since 29.0.0
+	 */
+	interface IVersionsImporterBackend {
+		/**
+		* Import the given versions for the target file.
+		*
+		* @param Node $target - The target is not yet created.
+		* @param IVersion[] $versions
+		* @since 29.0.0
+		*/
+		public function importVersionsForFile(IUser $user, Node $source, Node $target, array $versions): void;
+
+		/**
+		* Clear all versions for a file
+		*
+		* @since 29.0.0
+		*/
+		public function clearVersionsForFile(IUser $user, Node $source, Node $target): void;
+	}
+
+	/**
+	* This interface allows for just direct accessing of the metadata column JSON
+	* @since 29.0.0
+	*/
+	interface IMetadataVersion {
+		/**
+		* retrieves the all the metadata
+		*
+		* @return string[]
+		* @since 29.0.0
+		*/
+		public function getMetadata(): array;
+
+		/**
+		* retrieves the metadata value from our $key param
+		*
+		* @param string $key the key for the json value of the metadata column
+		* @since 29.0.0
+		*/
+		public function getMetadataValue(string $key): ?string;
+	}
+
 	class Version implements IVersion {
 		public function __construct(
 			int $timestamp,


### PR DESCRIPTION
As of https://github.com/nextcloud/server/pull/44187

One limitation is that when copying a folder from and to a groupfolder, versions of subfolders will be lost. This is due to the `NodeCopiedEvent` event not containing the list of moved files in subfolders. This needs to be addressed in the server.

Example: When moving `/a` containing `/a/b/c.txt` into `/d` which is a groupfolder, then `c.txt` will lose its versions because the `NodeCopiedEvent` does not contain the information that `c.txt` was copied. Weirdly, it works when moving a folder containing `/a/c.txt`.

The test exists and is disabled for now.