### PR TITLE
Expose the app version to the capabilities endpoint

### DIFF
--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -11,14 +11,17 @@ use OCA\GroupFolders\Folder\FolderManager;
 use OCP\Capabilities\ICapability;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\App\IAppManager;
 
 class Capabilities implements ICapability {
 	private IUserSession $userSession;
 	private FolderManager $folderManager;
+	private IAppManager $appManager;
 
-	public function __construct(IUserSession $userSession, FolderManager $folderManager) {
+	public function __construct(IUserSession $userSession, FolderManager $folderManager, IAppManager $appManager) {
 		$this->userSession = $userSession;
 		$this->folderManager = $folderManager;
+		$this->appManager = $appManager;
 	}
 
 	public function getCapabilities(): array {
@@ -28,6 +31,7 @@ class Capabilities implements ICapability {
 		}
 		return [
 			Application::APP_ID => [
+				'appVersion' => $this->appManager->getAppVersion(Application::APP_ID),
 				'hasGroupFolders' => $this->hasFolders($user),
 			],
 		];

--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\AppInfo;
 
 use OCA\GroupFolders\Folder\FolderManager;
+use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IUser;
 use OCP\IUserSession;
-use OCP\App\IAppManager;
 
 class Capabilities implements ICapability {
 	private IUserSession $userSession;


### PR DESCRIPTION
Minor update on the `lib/Appinfo/Capabilities.php` to expose the appVersion of groupfolders in the result of a `ocs/v2.php/cloud/capabilities` web request. 
This is useful when managing multiple Nextcloud to monitor and report the app version. Many other Nextcloud Apps are already exposing this data (circles, richdocuments, deck to name a few)

Request JSON output before:
```
        "groupfolders": {
          "hasGroupFolders": true
        },
```
Request JSON output after:
```
        "groupfolders": {
          "appVersion": "16.0.4",
          "hasGroupFolders": true
        },
```

Best regards, 