### PR TITLE
feat: add option to resolve inherited option per-user instead of per-path

### DIFF
--- a/lib/ACL/ACLManagerFactory.php
+++ b/lib/ACL/ACLManagerFactory.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\ACL;
 
 use OCA\GroupFolders\Trash\TrashManager;
+use OCP\IConfig;
 use OCP\IUser;
 
 class ACLManagerFactory {
@@ -32,12 +33,20 @@ class ACLManagerFactory {
 	public function __construct(
 		private RuleManager $ruleManager,
 		private TrashManager $trashManager,
+		private IConfig $config,
 		callable $rootFolderProvider,
 	) {
 		$this->rootFolderProvider = $rootFolderProvider;
 	}
 
 	public function getACLManager(IUser $user, ?int $rootStorageId = null): ACLManager {
-		return new ACLManager($this->ruleManager, $this->trashManager, $user, $this->rootFolderProvider, $rootStorageId);
+		return new ACLManager(
+			$this->ruleManager,
+			$this->trashManager,
+			$user,
+			$this->rootFolderProvider,
+			$rootStorageId,
+			$this->config->getAppValue('groupfolders', 'acl-inherit-per-user', 'false') === 'true',
+		);
 	}
 }

--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -155,4 +155,31 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 			$permissions
 		);
 	}
+
+	/**
+	 * apply a new rule on top of the existing
+	 *
+	 * All non-inherit fields of the new rule will overwrite the current permissions
+	 *
+	 * @param array $rules
+	 * @return void
+	 */
+	public function applyRule(Rule $rule): void {
+		$this->permissions = $rule->applyPermissions($this->permissions);
+		$this->mask |= $rule->getMask();
+	}
+
+	/**
+	 * Create a default, no-op rule
+	 *
+	 * @return Rule
+	 */
+	public static function defaultRule(): Rule {
+		return new Rule(
+			new UserMapping('dummy', ''),
+			-1,
+			0,
+			0
+		);
+	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -223,6 +223,7 @@ class Application extends App implements IBootstrap {
 			return new ACLManagerFactory(
 				$c->get(RuleManager::class),
 				$c->get(TrashManager::class),
+				$c->get(IConfig::class),
 				$rootFolderProvider
 			);
 		});


### PR DESCRIPTION
Instead of always have subfolder rules overwrite parent folder rules, first resolve the inherited rules for each user/group before combining the rules from the different users/groups.

With the default behavior, if any rule applicable to the user denies permission for a subfolder, the permission will be denied, even if the user is member of a group that has "allow" permissions.

With the new behavior, if any group the user is a member for has "allow" permissions, the user has access.

To test:

1. create groups `group1` and `group2`
2. create `user` test in `group1` and `group2`
3. create groupfolder `gf` accessible to `group1` and `group2` an ACLs enabled
4. create folder `gf/a` and create a rule on it for `group1` giving full permissions
5. create folder `gf/a/b` and create a rule on it for `group2`, denying read permissions
6. with default behavior `user` won't have access to `gf/a/b` because of the rule from 5.
7. change to the new behavior with `occ config:app:set groupfolders acl-inherit-per-user --value true`
8. now `user` does have access to `gf/a/b` because `group1` has access, users only in `group2` won't have access
