### PR TITLE
fix: Set mount point target user as storage owner

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -215,6 +215,8 @@ class MountProvider implements IMountProvider {
 
 		$storage = $this->getRootFolder()->getStorage();
 
+		$storage->setOwner($user?->getUID());
+
 		$rootPath = $this->getJailPath($id);
 
 		// apply acl before jail


### PR DESCRIPTION
Requires https://github.com/nextcloud/server/pull/44294

This will avoid that calling `getUserFolder($user)->getByid($id)` will fail on paths that have no share permission without a user session.

Fix https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/900