### PR TITLE
properly distinguish between inherited and unset permissions

### DIFF
--- a/cypress/e2e/groupfoldersUtils.ts
+++ b/cypress/e2e/groupfoldersUtils.ts
@@ -106,7 +106,7 @@ export function enterFolder(name: string) {
 
 export function enterFolderInTrashbin(name: string) {
 	cy.intercept({ times: 1, method: 'PROPFIND', url: `**/dav/trashbin/**/${name}.d*` }).as('propFindFolder')
-	cy.get(`[data-cy-files-list] [data-cy-files-list-row-name^="${name}.d"]`).click()
+	cy.get(`[data-cy-files-list] [data-cy-files-list-row-name^="${name}.d"] [data-cy-files-list-row-name]`).click()
 	cy.wait('@propFindFolder')
 }
 

--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -133,6 +133,7 @@ class ACLPlugin extends ServerPlugin {
 
 			ksort($rulesByPath);
 			$inheritedPermissionsByMapping = [];
+			$inheritedMaskByMapping = [];
 			$mappings = [];
 			foreach ($rulesByPath as $rules) {
 				foreach ($rules as $rule) {
@@ -144,18 +145,22 @@ class ACLPlugin extends ServerPlugin {
 					if (!isset($inheritedPermissionsByMapping[$mappingKey])) {
 						$inheritedPermissionsByMapping[$mappingKey] = Constants::PERMISSION_ALL;
 					}
+					if (!isset($inheritedMaskByMapping[$mappingKey])) {
+						$inheritedMaskByMapping[$mappingKey] = 0;
+					}
 					$inheritedPermissionsByMapping[$mappingKey] = $rule->applyPermissions($inheritedPermissionsByMapping[$mappingKey]);
+					$inheritedMaskByMapping[$mappingKey] |= $rule->getMask();
 				}
 			}
 
-			return array_map(function ($mapping, $permissions) use ($fileInfo) {
+			return array_map(function ($mapping, $permissions, $mask) use ($fileInfo) {
 				return new Rule(
 					$mapping,
 					$fileInfo->getId(),
-					Constants::PERMISSION_ALL,
+					$mask,
 					$permissions
 				);
-			}, $mappings, $inheritedPermissionsByMapping);
+			}, $mappings, $inheritedPermissionsByMapping, $inheritedMaskByMapping);
 		});
 
 		$propFind->handle(self::GROUP_FOLDER_ID, function () use ($fileInfo) {

--- a/src/client.js
+++ b/src/client.js
@@ -228,6 +228,9 @@ class AclDavService {
 					inheritedAclsById[id] = acl
 					if (aclsById[id] == null) {
 						aclsById[id] = acl
+					} else {
+						aclsById[id].inheritedMask = acl.mask
+						aclsById[id].inheritedPermissions = acl.permissions
 					}
 				}
 				return {

--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -44,9 +44,9 @@
 				<component :is="icon" :class="{inherited: isInherited}" :size="16" />
 			</template>
 			<NcActionRadio name="state"
-				:checked="state === STATES.INHERIT_ALLOW || state === STATES.INHERIT_DENY"
+				:checked="state === STATES.INHERIT_ALLOW || state === STATES.INHERIT_DENY || state === STATES.INHERIT_DEFAULT"
 				:disabled="disabled"
-				@change="$emit('update', STATES.INHERIT_ALLOW)">
+				@change="$emit('update', STATES.INHERIT_DEFAULT)">
 				{{ t('groupfolders', 'Inherit permission') }}
 			</NcActionRadio>
 			<NcActionRadio name="state"
@@ -68,16 +68,18 @@
 <script>
 import Check from 'vue-material-design-icons/Check.vue'
 import Cancel from 'vue-material-design-icons/Cancel.vue'
+import Minus from 'vue-material-design-icons/Minus.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
 import NcActionRadio from '@nextcloud/vue/dist/Components/NcActionRadio.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
-const STATES = {
+export const STATES = {
 	INHERIT_DENY: 0,
 	INHERIT_ALLOW: 1,
-	SELF_DENY: 2,
-	SELF_ALLOW: 3,
+	INHERIT_DEFAULT: 2,
+	SELF_DENY: 3,
+	SELF_ALLOW: 4,
 }
 
 export default {
@@ -117,13 +119,15 @@ export default {
 	},
 	computed: {
 		isAllowed() {
-			return this.state & 1
+			return this.state === STATES.INHERIT_ALLOW || this.state === STATES.SELF_ALLOW || this.state === STATES.INHERIT_DEFAULT
 		},
 		isInherited() {
-			return (this.state & 2) === 0
+			return this.state === STATES.INHERIT_ALLOW || this.state === STATES.INHERIT_DENY || this.state === STATES.INHERIT_DEFAULT
 		},
 		icon() {
 			switch (this.state) {
+			case STATES.INHERIT_DEFAULT:
+				return Minus
 			case STATES.INHERIT_ALLOW:
 			case STATES.SELF_ALLOW:
 				return Check
@@ -133,6 +137,8 @@ export default {
 		},
 		label() {
 			switch (this.state) {
+			case STATES.INHERIT_DEFAULT:
+				return t('groupfolders', 'Unset')
 			case STATES.INHERIT_DENY:
 				return t('groupfolders', 'Denied (Inherited permission)')
 			case STATES.INHERIT_ALLOW:

--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -120,7 +120,7 @@ export default {
 			return this.state & 1
 		},
 		isInherited() {
-			return this.inherited || (this.state & 2) === 0
+			return (this.state & 2) === 0
 		},
 		icon() {
 			switch (this.state) {

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -83,31 +83,31 @@
 						{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_READ, item.permissions, item.mask, item.inherited)"
+						<AclStateButton :state="getState(OC.PERMISSION_READ, item)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_READ, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_UPDATE, item.permissions, item.mask, item.inherited)"
+						<AclStateButton :state="getState(OC.PERMISSION_UPDATE, item)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_UPDATE, $event)" />
 					</td>
 					<td v-if="model.type === 'dir'" class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_CREATE, item.permissions, item.mask, item.inherited)"
+						<AclStateButton :state="getState(OC.PERMISSION_CREATE, item)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_CREATE, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_DELETE, item.permissions, item.mask, item.inherited)"
+						<AclStateButton :state="getState(OC.PERMISSION_DELETE, item)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_DELETE, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_SHARE, item.permissions, item.mask, item.inherited)"
+						<AclStateButton :state="getState(OC.PERMISSION_SHARE, item)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_SHARE, $event)" />
@@ -157,7 +157,7 @@
 import Vue from 'vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import AclStateButton from './AclStateButton.vue'
+import AclStateButton, { STATES } from './AclStateButton.vue'
 import Rule from './../model/Rule.js'
 import BinaryTools from './../BinaryTools.js'
 import client from './../client.js'
@@ -208,7 +208,7 @@ export default {
 			return this.aclCanManage
 		},
 		isNotInherited() {
-			return (permission, permissions, mask) => {
+			return (permission, mask) => {
 				return (permission & ~mask) === 0
 			}
 		},
@@ -218,10 +218,18 @@ export default {
 			}
 		},
 		getState() {
-			return (permission, permissions, mask, inherited) => {
-				const inheritance = (!inherited && this.isNotInherited(permission, permissions, mask)) << 1
-				const permitted = this.isAllowed(permission, permissions)
-				return inheritance | permitted
+			return (permission, item) => {
+				const permitted = this.isAllowed(permission, item.permissions)
+				if (this.isNotInherited(permission, item.mask)) {
+					return permitted ? STATES.SELF_ALLOW : STATES.SELF_DENY
+				} else {
+					const inheritPermitted = this.isAllowed(permission, item.inheritedPermissions)
+					if (this.isNotInherited(permission, item.inheritedMask)) {
+						return inheritPermitted ? STATES.INHERIT_ALLOW : STATES.INHERIT_DENY
+					} else {
+						return STATES.INHERIT_DEFAULT
+					}
+				}
 			}
 		},
 	},
@@ -328,13 +336,13 @@ export default {
 		},
 		changePermission(item, permission, $event) {
 			const index = this.list.indexOf(item)
-			const inherit = ($event < 2)
-			const allow = ($event & (0b01)) === 1
+			const inherit = $event === STATES.INHERIT_ALLOW || $event === STATES.INHERIT_DENY || $event === STATES.INHERIT_DEFAULT
+			const allow = $event === STATES.SELF_ALLOW
 			const bit = BinaryTools.firstHigh(permission)
 			item = item.clone()
 			if (inherit) {
 				item.mask = BinaryTools.clear(item.mask, bit)
-				// TODO check if: we can ignore permissions, since they are inherited
+				// we can ignore permissions, since they are inherited
 			} else {
 				item.mask = BinaryTools.set(item.mask, bit)
 				if (allow) {

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -83,31 +83,31 @@
 						{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_READ, item.permissions, item.mask)"
+						<AclStateButton :state="getState(OC.PERMISSION_READ, item.permissions, item.mask, item.inherited)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_READ, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_UPDATE, item.permissions, item.mask)"
+						<AclStateButton :state="getState(OC.PERMISSION_UPDATE, item.permissions, item.mask, item.inherited)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_UPDATE, $event)" />
 					</td>
 					<td v-if="model.type === 'dir'" class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_CREATE, item.permissions, item.mask)"
+						<AclStateButton :state="getState(OC.PERMISSION_CREATE, item.permissions, item.mask, item.inherited)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_CREATE, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_DELETE, item.permissions, item.mask)"
+						<AclStateButton :state="getState(OC.PERMISSION_DELETE, item.permissions, item.mask, item.inherited)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_DELETE, $event)" />
 					</td>
 					<td class="state-column">
-						<AclStateButton :state="getState(OC.PERMISSION_SHARE, item.permissions, item.mask)"
+						<AclStateButton :state="getState(OC.PERMISSION_SHARE, item.permissions, item.mask, item.inherited)"
 							:inherited="item.inherited"
 							:disabled="loading"
 							@update="changePermission(item, OC.PERMISSION_SHARE, $event)" />
@@ -207,7 +207,7 @@ export default {
 		isAdmin() {
 			return this.aclCanManage
 		},
-		isInherited() {
+		isNotInherited() {
 			return (permission, permissions, mask) => {
 				return (permission & ~mask) === 0
 			}
@@ -218,8 +218,8 @@ export default {
 			}
 		},
 		getState() {
-			return (permission, permissions, mask) => {
-				const inheritance = this.isInherited(permission, permissions, mask) << 1
+			return (permission, permissions, mask, inherited) => {
+				const inheritance = (!inherited && this.isNotInherited(permission, permissions, mask)) << 1
 				const permitted = this.isAllowed(permission, permissions)
 				return inheritance | permitted
 			}

--- a/src/model/Rule.js
+++ b/src/model/Rule.js
@@ -38,6 +38,8 @@ export default class Rule {
 		this.mask = mask
 		this.permissions = permissions
 		this.inherited = inherited
+		this.inheritedMask = 0
+		this.inheritedPermissions = 31
 	}
 
 	getProperties() {


### PR DESCRIPTION
Currently, when a rule includes inherited permissions, but there is no parent permission set to inherit, the UI shows it the same as if there was an inherited "allow" permission.

This can lead to confusion as "no inherited permissions" and "inherited allow permissions" are handled different when merging the rules configured for multiple groups/users.

With this PR, "unset" permissions are shown as a dash.

![the possible ACL state buttons](https://github.com/nextcloud/groupfolders/assets/1283854/617b1820-04ed-4b50-8080-0a68f49a5dce)
