### PR TITLE
fix: fix opening acl create select

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -305,9 +305,11 @@ export default {
 		},
 		toggleAclCreate() {
 			this.showAclCreate = !this.showAclCreate
-			Vue.nextTick(() => {
-				this.$refs.select.$el.focus()
-			})
+			if (this.showAclCreate) {
+				Vue.nextTick(() => {
+					this.$refs.select.$el.querySelector('input').focus()
+				})
+			}
 		},
 		createAcl(option) {
 			this.value = null


### PR DESCRIPTION
The old way broke when the select was moved to `NcSelect`