### PR TITLE
Fix encryption wrapper not seen by groupfolder cache

### DIFF
--- a/cypress/e2e/encryption.cy.ts
+++ b/cypress/e2e/encryption.cy.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import {
+	addUserToGroup,
+	createGroup,
+	createGroupFolder,
+	deleteGroupFolder,
+	disableEncryption,
+	disableEncryptionModule,
+	disableGroupfoldersEncryption,
+	disableHomeStorageEncryption,
+	enableEncryption,
+	enableEncryptionModule,
+	enableGroupfoldersEncryption,
+	enableHomeStorageEncryption,
+	enterFolder,
+	fileOrFolderExists,
+	PERMISSION_DELETE,
+	PERMISSION_READ,
+	PERMISSION_WRITE,
+} from './groupfoldersUtils'
+
+import {
+	assertFileContent,
+	moveFile,
+} from './files/filesUtils'
+
+import { randHash } from '../utils'
+
+import type { User } from '@nextcloud/cypress'
+
+describe('Groupfolders encryption behavior', () => {
+	let user1: User
+	let groupFolderId: string
+	let groupName: string
+	let groupFolderName: string
+
+	before(() => {
+		enableEncryptionModule()
+		enableEncryption()
+	})
+
+	beforeEach(() => {
+		if (groupFolderId) {
+			deleteGroupFolder(groupFolderId)
+		}
+		groupName = `test_group_${randHash()}`
+		groupFolderName = `test_group_folder_${randHash()}`
+
+		cy.createRandomUser()
+			.then(_user => {
+				user1 = _user
+			})
+		createGroup(groupName)
+			.then(() => {
+				addUserToGroup(groupName, user1.userId)
+				createGroupFolder(groupFolderName, groupName, [PERMISSION_READ, PERMISSION_WRITE, PERMISSION_DELETE])
+			})
+	})
+
+	after(() => {
+		// Restore default values
+		disableGroupfoldersEncryption()
+		enableHomeStorageEncryption()
+		disableEncryption()
+		disableEncryptionModule()
+	})
+
+	it('Move file from encrypted storage to encrypted groupfolder', () => {
+		enableHomeStorageEncryption()
+		enableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', '/file1.txt')
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		moveFile('file1.txt', groupFolderName)
+
+		enterFolder(groupFolderName)
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+
+	it('Move file from encrypted storage to non encrypted groupfolder', () => {
+		enableHomeStorageEncryption()
+		disableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', '/file1.txt')
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		moveFile('file1.txt', groupFolderName)
+
+		enterFolder(groupFolderName)
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+
+	it('Move file from non encrypted storage to encrypted groupfolder', () => {
+		disableHomeStorageEncryption()
+		enableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', '/file1.txt')
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		moveFile('file1.txt', groupFolderName)
+
+		enterFolder(groupFolderName)
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+
+	it('Move file from encrypted groupfolder to encrypted storage', () => {
+		enableHomeStorageEncryption()
+		enableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', `/${groupFolderName}/file1.txt`)
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		enterFolder(groupFolderName)
+		moveFile('file1.txt', '/')
+
+		cy.visit('/apps/files')
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+
+	it('Move file from encrypted groupfolder to non encrypted storage', () => {
+		disableHomeStorageEncryption()
+		enableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', `/${groupFolderName}/file1.txt`)
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		enterFolder(groupFolderName)
+		moveFile('file1.txt', '/')
+
+		cy.visit('/apps/files')
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+
+	it('Move file from non encrypted groupfolder to encrypted storage', () => {
+		enableHomeStorageEncryption()
+		disableGroupfoldersEncryption()
+
+		cy.uploadContent(user1, new Blob(['Content of the file']), 'text/plain', `/${groupFolderName}/file1.txt`)
+
+		cy.login(user1)
+		cy.visit('/apps/files')
+
+		enterFolder(groupFolderName)
+		moveFile('file1.txt', '/')
+
+		cy.visit('/apps/files')
+		fileOrFolderExists('file1.txt')
+		assertFileContent('file1.txt', 'Content of the file')
+	})
+})

--- a/cypress/e2e/files/filesUtils.ts
+++ b/cypress/e2e/files/filesUtils.ts
@@ -94,3 +94,11 @@ export const clickOnBreadcumbs = (label: string) => {
 	cy.get('[data-cy-files-content-breadcrumbs]').contains(label).click()
 	cy.wait('@propfind')
 }
+
+export const assertFileContent = (fileName: string, expectedContent: string) => {
+	cy.intercept({ method: 'GET', times: 1, url: 'remote.php/**' }).as('downloadFile')
+	getRowForFile(fileName).should('be.visible')
+	triggerActionForFile(fileName, 'download')
+	cy.wait('@downloadFile')
+		.then(({ response }) => expect(response?.body).to.equal(expectedContent))
+}

--- a/cypress/e2e/groupfoldersUtils.ts
+++ b/cypress/e2e/groupfoldersUtils.ts
@@ -57,6 +57,39 @@ export function deleteGroupFolder(groupFolderId: string) {
 	return cy.runOccCommand(`groupfolders:delete ${groupFolderId}`)
 }
 
+export function enableEncryptionModule() {
+	return cy.runOccCommand('app:enable encryption')
+}
+
+export function disableEncryptionModule() {
+	return cy.runOccCommand('app:disable encryption')
+}
+
+export function enableEncryption() {
+	return cy.runOccCommand('config:app:set --value=yes core encryption_enabled')
+}
+
+export function disableEncryption() {
+	return cy.runOccCommand('config:app:delete core encryption_enabled')
+}
+
+export function enableHomeStorageEncryption() {
+	// Default value is enabled
+	return cy.runOccCommand('config:app:delete encryption encryptHomeStorage')
+}
+
+export function disableHomeStorageEncryption() {
+	return cy.runOccCommand('config:app:set --value=0 encryption encryptHomeStorage')
+}
+
+export function enableGroupfoldersEncryption() {
+	return cy.runOccCommand('config:app:set --value=true groupfolders enable_encryption')
+}
+
+export function disableGroupfoldersEncryption() {
+	return cy.runOccCommand('config:app:delete groupfolders enable_encryption')
+}
+
 export function fileOrFolderExists(name: string) {
 	// Make sure file list is loaded first
 	cy.get('[data-cy-files-list-tfoot],[data-cy-files-content-empty]').should('be.visible')

--- a/lib/Mount/GroupFolderEncryptionJail.php
+++ b/lib/Mount/GroupFolderEncryptionJail.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Mount;
+
+use OC\Files\Cache\Wrapper\CacheJail;
+use OC\Files\Storage\Wrapper\Jail;
+
+/**
+ * Jail with overridden behaviors specific to group folders when encryption is
+ * enabled.
+ */
+class GroupFolderEncryptionJail extends Jail {
+	public function getCache($path = '', $storage = null) {
+		if (!$storage) {
+			$storage = $this->getWrapperStorage();
+		}
+		// By default the Jail reuses the inner cache, but when encryption is
+		// enabled the storage needs to be passed to the cache so it takes into
+		// account the outer Encryption wrapper.
+		$sourceCache = $this->getWrapperStorage()->getCache($this->getUnjailedPath($path), $storage);
+		return new CacheJail($sourceCache, $this->rootPath);
+	}
+}

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -217,11 +217,11 @@ class MountProvider implements IMountProvider {
 			$cacheEntry['permissions'] &= $aclRootPermissions;
 		}
 
-		$baseStorage = new Jail([
-			'storage' => $storage,
-			'root' => $rootPath
-		]);
 		if ($this->enableEncryption) {
+			$baseStorage = new GroupFolderEncryptionJail([
+				'storage' => $storage,
+				'root' => $rootPath
+			]);
 			$quotaStorage = new GroupFolderStorage([
 				'storage' => $baseStorage,
 				'quota' => $quota,
@@ -231,6 +231,10 @@ class MountProvider implements IMountProvider {
 				'mountOwner' => $user,
 			]);
 		} else {
+			$baseStorage = new Jail([
+				'storage' => $storage,
+				'root' => $rootPath
+			]);
 			$quotaStorage = new GroupFolderNoEncryptionStorage([
 				'storage' => $baseStorage,
 				'quota' => $quota,

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -750,8 +750,14 @@ namespace OC\Files\Cache {
 
 namespace OC\Files\Cache\Wrapper {
 	use OC\Files\Cache\Cache;
+	use OCP\Files\Cache\ICache;
+
 	class CacheWrapper extends Cache {
         public function getCache(): Cache {}
+	}
+
+	class CacheJail extends CacheWrapper {
+		public function __construct(?ICache $cache, string $root, ?CacheDependencies $dependencies = null) {}
 	}
 }
 


### PR DESCRIPTION
Fixes #2909

Besides the fix itself this pull request also adds E2E tests related to the issue (although it would have been better if they were integration tests, but those were not setup yet in the groupfolders app).

`Jail` wrappers [reuse the cache of the wrapped storage even if another storage is explicitly given](https://github.com/nextcloud/server/blob/d31ed8dbcad9e040b496e63cdd2c0916f9c8a9a4/lib/private/Files/Storage/Wrapper/Jail.php#L400). Due to that, when the cache is got from an storage and that storage has a `Jail` all the wrappers above it are not known to the cache, and only those wrapped by the `Jail` are taken into account.

In general that works fine, as in most cases the cache does not need to know the details of a storage. However, it needs to know if an `Encryption` wrapper is present in the storage when moving files into it, as the file cache [explicitly clears the `encrypted` flag when moving a file from an encrypted storage to a non encrypted storage](https://github.com/nextcloud/server/blob/ec5133b739eabc76271789504b4dbb91a534f552/lib/private/Files/Cache/Cache.php#L754-L757).

When encryption is enabled the `Encryption` wrapper is applied [on the storage of the `GroupMountPoint`](https://github.com/nextcloud/groupfolders/blob/316d0365f32449475efd61391f2dc04d240d5bef/lib/Mount/MountProvider.php#L270). As [that storage internally has a `Jail`](https://github.com/nextcloud/groupfolders/blob/316d0365f32449475efd61391f2dc04d240d5bef/lib/Mount/MountProvider.php#L233-L236), even if the cache is got on the outer storage wrapper the cache does not know about the `Encryption` wrapper, only about the storage wrapped by the `Jail`, so all files moved from an encrypted storage to an encrypted groupfolder ended wrongly marked as not encrypted.

To solve that now the `Jail` used by groupfolders does not reuse the inner cache when encryption is enabled, and instead passes the given storage. This is applied only when encryption is enabled, as [reusing the inner cache was done as a performance optimization](https://github.com/nextcloud/server/commit/460344336e283d6ebca4066a3a876ca4843600bd#diff-5d784b969063accbd75d6add01be4a5d98051172cf4826b7bd904710218a7504R399
).

Note that it does not seem to be possible to move the `Encryption` wrapper below the `Jail`, as [the `Encryption` constructor requires a mount point](https://github.com/nextcloud/server/blob/ec5133b739eabc76271789504b4dbb91a534f552/lib/private/Files/Storage/Wrapper/Encryption.php#L120), and the `GroupMountPoint` storage includes the `Jail` (but maybe I am missing something :-) ).

An alternative fix would be, in server, adding an optional parameter to `Jail` wrappers to not reuse the internal cache and then, in groupfolders app, disable reusing the internal cache when encryption is enabled. This would make possible to easily adjust the behaviour if problematic also in other `Jail` uses.

However, note that reusing the inner cache when encryption is enabled does not seem to be a problem when using shared folders (at least when trying with just a folder shared by another user, maybe there are some fancy scenarios in which it fails too, I do not know :shrug:), as in that case, although `SharedStorage` is a `Jail`, [it is created with a null storage](https://github.com/nextcloud/server/blob/85b5dd0a4325672c8dcef82df04a2c0306a4fb5b/apps/files_sharing/lib/SharedStorage.php#L124) and then initialized when needed [to wrap the storage of the shared file owner](https://github.com/nextcloud/server/blob/85b5dd0a4325672c8dcef82df04a2c0306a4fb5b/apps/files_sharing/lib/SharedStorage.php#L170-L190), which is already fully setup and therefore already includes an `Encryption` wrapper.

Independently of that, it is worth noting that, unlike other storage wrappers, [`GroupFolderStorage` persists the `Cache` object once got](https://github.com/nextcloud/groupfolders/blob/975c40040e889ffe3718990f85817d65f4a18bfd/lib/Mount/GroupFolderStorage.php#L63-L73) (by default [storage wrappers get it from the wrapped storage every time](https://github.com/nextcloud/server/blob/4910e7e2310502cde223204f4c7488b4b08655fe/lib/private/Files/Storage/Wrapper/Wrapper.php#L397-L402)). Therefore, if a cache was got on the `GroupFolderStorage` before it was wrapped with the `Encryption` wrapper that cache would not seen the `Encryption` wrapper even with neither of the fixes.

However, as [the storage passed to the `GroupMountPoint`](https://github.com/nextcloud/groupfolders/blob/316d0365f32449475efd61391f2dc04d240d5bef/lib/Mount/MountProvider.php#L270) constructor [will be wrapped as needed](https://github.com/nextcloud/server/blob/ec5133b739eabc76271789504b4dbb91a534f552/lib/private/Files/Mount/MountPoint.php#L121) (for example, to add the `Encryption` wrapper) and the outer wrapper will be the storage set in the `GroupMountPoint` that should not be a problem (unless the constructor of `GroupMountPoint` or `MountPoint` is eventually modified to explicitly or implicitly get the cache before wrapping the storage).
