### PR TITLE
fix(ACL): Add check to prevent users from revoking their own access

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\GroupFolders\ACL;
 
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
@@ -22,6 +23,7 @@ class ACLManager {
 	public function __construct(
 		private readonly RuleManager $ruleManager,
 		private readonly TrashManager $trashManager,
+		private readonly IUserMappingManager $userMappingManager,
 		private readonly LoggerInterface $logger,
 		private readonly IUser $user,
 		private readonly \Closure $rootFolderProvider,
@@ -85,7 +87,7 @@ class ACLManager {
 		$fromTrashbin = str_starts_with($path, '__groupfolders/trash/');
 		if ($fromTrashbin) {
 			/* Exploded path will look like ["__groupfolders", "trash", "1", "folderName.d2345678", "rest/of/the/path.txt"] */
-			[,,$groupFolderId,$rootTrashedItemName] = explode('/', $path, 5);
+			[, , $groupFolderId, $rootTrashedItemName] = explode('/', $path, 5);
 			$groupFolderId = (int)$groupFolderId;
 			/* Remove the date part */
 			$separatorPos = strrpos($rootTrashedItemName, '.d');
@@ -139,6 +141,20 @@ class ACLManager {
 	public function getACLPermissionsForPath(string $path): int {
 		$path = ltrim($path, '/');
 		$rules = $this->getRules($this->getRelevantPaths($path));
+
+		return $this->calculatePermissionsForPath($rules);
+	}
+
+	/**
+	 * Check what the effective permissions would be for the current user for a path would be with a new set of rules
+	 *
+	 * @param list<Rule> $newRules
+	 */
+	public function testACLPermissionsForPath(string $path, array $newRules): int {
+		$path = ltrim($path, '/');
+		$rules = $this->getRules($this->getRelevantPaths($path));
+
+		$rules[$path] = $this->filterApplicableRulesToUser($newRules);
 
 		return $this->calculatePermissionsForPath($rules);
 	}
@@ -228,5 +244,26 @@ class ACLManager {
 
 	public function preloadRulesForFolder(string $path): void {
 		$this->ruleManager->getRulesForFilesByParent($this->user, $this->getRootStorageId(), $path);
+	}
+
+	/**
+	 * Filter a list to only the rules applicable to the current user
+	 *
+	 * @param list<Rule> $rules
+	 * @return list<Rule>
+	 */
+	private function filterApplicableRulesToUser(array $rules): array {
+		$userMappings = $this->userMappingManager->getMappingsForUser($this->user);
+		return array_values(array_filter($rules, function (Rule $rule) use ($userMappings): bool {
+			foreach ($userMappings as $userMapping) {
+				if (
+					$userMapping->getType() == $rule->getUserMapping()->getType() &&
+					$userMapping->getId() == $rule->getUserMapping()->getId()
+				) {
+					return true;
+				}
+			}
+			return false;
+		}));
 	}
 }

--- a/lib/ACL/ACLManagerFactory.php
+++ b/lib/ACL/ACLManagerFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\GroupFolders\ACL;
 
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCP\IAppConfig;
 use OCP\IUser;
@@ -19,6 +20,7 @@ class ACLManagerFactory {
 		private readonly TrashManager $trashManager,
 		private readonly IAppConfig $config,
 		private readonly LoggerInterface $logger,
+		private readonly IUserMappingManager $userMappingManager,
 		private readonly \Closure $rootFolderProvider,
 	) {
 	}
@@ -27,6 +29,7 @@ class ACLManagerFactory {
 		return new ACLManager(
 			$this->ruleManager,
 			$this->trashManager,
+			$this->userMappingManager,
 			$this->logger,
 			$user,
 			$this->rootFolderProvider,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -217,6 +217,7 @@ class Application extends App implements IBootstrap {
 				$c->get(TrashManager::class),
 				$c->get(IAppConfig::class),
 				$c->get(LoggerInterface::class),
+				$c->get(IUserMappingManager::class),
 				$rootFolderProvider
 			);
 		});

--- a/src/client.js
+++ b/src/client.js
@@ -252,7 +252,8 @@ class AclDavService {
 				} else {
 					// Handle unexpected status codes
 					logger.error('Unexpected status:', { responseStatus: response.status, responseStatusText: response.statusText })
-					throw new Error(t('groupfolders', 'Unexpected status from server'))
+
+					throw new Error(response.xhr.responseXML?.querySelector('message')?.textContent ?? t('groupfolders', 'Unexpected status from server'))
 				}
 		  }).catch(error => {
 			// Handle network errors or exceptions

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -12,6 +12,7 @@ use OCA\GroupFolders\ACL\ACLManager;
 use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\ACL\RuleManager;
 use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCP\Constants;
 use OCP\Files\IRootFolder;
@@ -24,6 +25,7 @@ use Test\TestCase;
 class ACLManagerTest extends TestCase {
 	private RuleManager&MockObject $ruleManager;
 	private TrashManager&MockObject $trashManager;
+	private IUserMappingManager&MockObject $userMappingManager;
 	private LoggerInterface&MockObject $logger;
 	private IUser&MockObject $user;
 	private ACLManager $aclManager;
@@ -37,6 +39,7 @@ class ACLManagerTest extends TestCase {
 		$this->user = $this->createMock(IUser::class);
 		$this->ruleManager = $this->createMock(RuleManager::class);
 		$this->trashManager = $this->createMock(TrashManager::class);
+		$this->userMappingManager = $this->createMock(IUserMappingManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->aclManager = $this->getAclManager();
 		$this->dummyMapping = $this->createMapping('dummy');
@@ -75,7 +78,7 @@ class ACLManagerTest extends TestCase {
 		$rootFolder->method('getMountPoint')
 			->willReturn($rootMountPoint);
 
-		return new ACLManager($this->ruleManager, $this->trashManager, $this->logger, $this->user, fn (): IRootFolder&MockObject => $rootFolder, null, $perUserMerge);
+		return new ACLManager($this->ruleManager, $this->trashManager, $this->userMappingManager, $this->logger, $this->user, fn (): IRootFolder&MockObject => $rootFolder, null, $perUserMerge);
 	}
 
 	public function testGetACLPermissionsForPathNoRules(): void {


### PR DESCRIPTION
When changing ACL rules, check if the new rule set would lead the current user without read permissions

- [x] make the UI properly handle the error
- [ ] ~(maybe) add an option to force revoking the access anyway~