### PR TITLE
fix(BackgroundJob): prevent running ExpireGroupVersions job in parallel

### DIFF
--- a/lib/BackgroundJob/ExpireGroupVersions.php
+++ b/lib/BackgroundJob/ExpireGroupVersions.php
@@ -33,8 +33,11 @@ class ExpireGroupVersions extends TimedJob {
 
 	public function __construct(GroupVersionsExpireManager $expireManager, ITimeFactory $timeFactory) {
 		parent::__construct($timeFactory);
+
 		// Run once per hour
 		$this->setInterval(60 * 60);
+		// But don't run if still running
+		$this->setAllowParallelRuns(false);
 
 		$this->expireManager = $expireManager;
 	}


### PR DESCRIPTION
Some folders takes a very long time (> 12hours) to be processed, while we optimise them, we should prevent a cron overlap!