### PR TITLE
fix: Adjust sidebar data attribute name to changes in server

### DIFF
--- a/cypress/e2e/files/filesUtils.ts
+++ b/cypress/e2e/files/filesUtils.ts
@@ -103,7 +103,7 @@ export const navigateToFolder = (dirPath: string) => {
 
 export const closeSidebar = () => {
 	// {force: true} as it might be hidden behind toasts
-	cy.get('[cy-data-sidebar] .app-sidebar__close').click({ force: true })
+	cy.get('[data-cy-sidebar] .app-sidebar__close').click({ force: true })
 }
 
 export const clickOnBreadcumbs = (label: string) => {


### PR DESCRIPTION
Since [commit 7f3cc7502b in server](https://github.com/nextcloud/server/commit/7f3cc7502ba81174671ee87dda58f9275bdde4e0) `data-cy-sidebar` is used instead of `cy-data-sidebar`.