### PR TITLE
fix(AclStateButton): Increase contrast for inherited permissions

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -157,5 +157,6 @@ export default {
 <style scoped>
 	.inherited {
 		opacity: 0.5;
+		color: var(--color-text-maxcontrast);
 	}
 </style>


### PR DESCRIPTION
## Description

Increase contrast for inherited icons as is now

### Photos (Subtle change)

| Before | After |
| ---------- | ------- |
| ![existing-contrast](https://github.com/user-attachments/assets/39835c0c-4b56-409a-b7f7-a9f4c477fbf1)|![max-contrast](https://github.com/user-attachments/assets/9556a36f-b539-46fd-bd57-2c86cba90b5f)|
