### PR TITLE
[stable28] fix: IConfig instead of IAppConfig

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -61,7 +61,6 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
-use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -198,7 +197,7 @@ class Application extends App implements IBootstrap {
 				return new ExpireGroupVersionsJob(
 					$c->get(ITimeFactory::class),
 					$c->get(GroupVersionsExpireManager::class),
-					$c->get(IAppConfig::class),
+					$c->get(IConfig::class),
 					$c->get(FolderManager::class),
 					$c->get(LoggerInterface::class),
 				);


### PR DESCRIPTION
For some reason that wasn't caught in https://github.com/nextcloud/groupfolders/pull/3057