### PR TITLE
feat(ACL): Show actual inherited permissions

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -157,5 +157,6 @@ export default {
 <style scoped>
 	.inherited {
 		opacity: 0.5;
+		color: var(--color-text-maxcontrast);
 	}
 </style>

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -247,7 +247,11 @@ export default {
 					if (this.isNotInherited(permission, item.inheritedMask)) {
 						return inheritPermitted ? STATES.INHERIT_ALLOW : STATES.INHERIT_DENY
 					} else {
-						return STATES.INHERIT_DEFAULT
+						// return STATES.INHERIT_DEFAULT
+						// Inherited or not an action is either allowed or not allowed and it should be reflected
+						// Currently we different the permissions using contrast, using the max for inherited permisions
+						// WIP: Figure out how to properly check default permissions for group folders
+						return (permitted || inheritPermitted) ? STATES.INHERIT_ALLOW : STATES.INHERIT_DENY
 					}
 				}
 			}


### PR DESCRIPTION
### Photos

| Before | After |
| ---------- | ------- |
| ![inherited-masked](https://github.com/user-attachments/assets/4b9c6d0c-6557-423f-9493-f3e3056b8cd6)|![inherited-real](https://github.com/user-attachments/assets/b4eb4af5-734b-4a4d-91df-53f8482dd464) |


### TODO
- [x] Increase contrast for inherited icons as is now
- [x] Remove the dash completely as "inherited" does not necessarily mean blank?
- [ ] Better screenshot of after having but allowed and not allowed?