### PR TITLE
Update info.xml

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,8 +12,7 @@
 Folders can be configured from *Group folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more groups, control their write/sharing permissions and assign a quota for the folder.
-
-Note: Encrypting the contents of group folders is currently not supported.]]></description>
+]]></description>
 	<version>18.0.0-beta.1</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>


### PR DESCRIPTION
Removed line "Encrypting the contents of group folders is currently not supported" because Server-side encryption support was added to groupfolders app in 2022: https://github.com/nextcloud/groupfolders/pull/2068

Making these changes as it is requested by one of our customers.