### PR TITLE
fix(settings): Calculate correct default quota option sizes

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Folders can be configured from *Group folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more groups, control their write/sharing permissions and assign a quota for the folder.
 ]]></description>
-	<version>19.0.0-dev.1</version>
+	<version>19.0.0-dev.2</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>
@@ -40,6 +40,12 @@ After a folder is created, the admin can give access to the folder to one or mor
 		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</job>
 		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupTrash</job>
 	</background-jobs>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\GroupFolders\Migration\WrongDefaultQuotaRepairStep</step>
+		</post-migration>
+	</repair-steps>
 
 	<commands>
 		<command>OCA\GroupFolders\Command\ExpireGroup\ExpireGroupBase</command>

--- a/lib/Migration/WrongDefaultQuotaRepairStep.php
+++ b/lib/Migration/WrongDefaultQuotaRepairStep.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use OCA\GroupFolders\Folder\FolderManager;
+use OCP\DB\Exception;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class WrongDefaultQuotaRepairStep implements IRepairStep {
+	public function __construct(
+		private FolderManager $manager,
+	) {
+
+	}
+
+	public function getName() {
+		return 'Adjust Groupfolders with wrong default quotas';
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @throws Exception
+	 */
+	public function run(IOutput $output): void {
+		foreach ($this->manager->getAllFolders() as $id => $folder) {
+			$quota = $folder['quota'];
+
+			$changed = false;
+			if ($quota === 1073741274) {
+				$quota = 1024 ** 3;
+				$changed = true;
+			} elseif ($quota === 10737412742) {
+				$quota = 1024 ** 3 * 10;
+				$changed = true;
+			}
+
+			if ($changed) {
+				$this->manager->setFolderQuota($id, $quota);
+			}
+		}
+	}
+}

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -18,10 +18,11 @@ import AdminGroupSelect from './AdminGroupSelect'
 import SubAdminGroupSelect from './SubAdminGroupSelect'
 import { loadState } from '@nextcloud/initial-state'
 
+const bytesInOneGibibyte = Math.pow(1024, 3)
 const defaultQuotaOptions = {
-	'1 GB': 1073741274,
-	'5 GB': 5368709120,
-	'10 GB': 10737412742,
+	'1 GB': bytesInOneGibibyte,
+	'5 GB': bytesInOneGibibyte * 5,
+	'10 GB': bytesInOneGibibyte * 10,
 	Unlimited: -3,
 }
 


### PR DESCRIPTION
I first noticed the unit was wrong, decimal vs binary notation.
Then I realized the values were wrong too, not sure why this is so messed up:
```
1073741274 -1024^3   =-550
5368709120 -1024^3*5 = 0
10737412742-1024^3*10=-5498
```
Really weird how one is correct, one is off by a bit and the other that should be 10x off is slight less off than 10x??

Should we add a migration that corrects these quota values if they are configured for existing groupfolders?