### PR TITLE
Fix slow move on same object bucket during file upload.

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -11,6 +11,7 @@ use OC\Files\ObjectStore\ObjectStoreScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 use OCP\IUserSession;
 
@@ -73,9 +74,9 @@ class GroupFolderStorage extends Quota {
 	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class) &&
 			$this->instanceOfStorage(ObjectStoreStorage::class) &&
-			$sourceStorage->getObjectStore()->getStorageId() == $this->getObjectStore()->getStorageId()) {
-				// Do not import any data when source and target object storages are identical.
-				return true;
+			$sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
+			// Do not import any data when source and target object storages are identical.
+			return true;
 		}
 		return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -69,4 +69,14 @@ class GroupFolderStorage extends Quota {
 		}
 		return $storage->scanner;
 	}
+
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class) &&
+			$this->instanceOfStorage(ObjectStoreStorage::class) &&
+			$sourceStorage->getObjectStore()->getStorageId() == $this->getObjectStore()->getStorageId()) {
+				// Do not import any data when source and target object storages are identical.
+				return true;
+		}
+		return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+	}
 }


### PR DESCRIPTION
This commit fixes the issue https://github.com/nextcloud/server/issues/47856. When you upload a file into a group folder and when you use a single S3 bucket as primary storage, the final move operation hangs for a long time. In the background, Nextcloud initiates a copy-delete sequence from the bucket into the bucket, with causes a lot unnecessary overhead. Nextcloud thinks that the file must be imported to another storage and does not recognize that everything is done on the same object bucket. In that case, the import step can be completely skipped, which saves time, network bandwidth and reduces the load on the object storage.