### PR TITLE
fix(ACLPlugin): Fix PROPFIND acl-list when rules are empty

### DIFF
--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -93,7 +93,7 @@ class ACLPlugin extends ServerPlugin {
 			return;
 		}
 
-		$propFind->handle(self::ACL_LIST, function () use ($fileInfo, $mount): array {
+		$propFind->handle(self::ACL_LIST, function () use ($fileInfo, $mount): ?array {
 			$path = trim($mount->getSourcePath() . '/' . $fileInfo->getInternalPath(), '/');
 			if ($this->isAdmin($fileInfo->getPath())) {
 				$rules = $this->ruleManager->getAllRulesForPaths($mount->getNumericStorageId(), [$path]);


### PR DESCRIPTION
If the rules are empty `array_pop()` will return null which wasn't allowed and lead to an internal server error (which was also not handled properly in the frontend but that is a different problem).