### PR TITLE
[stable28] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20190,9 +20190,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
-      "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
+      "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -20224,7 +20224,7 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
-        "webpack-dev-middleware": "^5.3.1",
+        "webpack-dev-middleware": "^5.3.4",
         "ws": "^8.13.0"
       },
       "bin": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 8 of the total 13 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/files](#user-content-\@nextcloud\/files)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/password-confirmation](#user-content-\@nextcloud\/password-confirmation)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
## Fixed vulnerabilities

### @nextcloud/files <a href="#user-content-\@nextcloud\/files" id="\@nextcloud\/files">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/files`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`
  * `node_modules/@nextcloud/password-confirmation/node_modules/@nextcloud/l10n`
  * `node_modules/@nextcloud/vue/node_modules/@nextcloud/l10n`

### @nextcloud/password-confirmation <a href="#user-content-\@nextcloud\/password-confirmation" id="\@nextcloud\/password-confirmation">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* Affected versions: >=3.0.0
* Package usage:
  * `node_modules/@nextcloud/password-confirmation`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **moderate** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`