### PR TITLE
fix(BackgroundJob): Set expire job intervals to 30 minutes

### DIFF
--- a/lib/BackgroundJob/ExpireGroupTrash.php
+++ b/lib/BackgroundJob/ExpireGroupTrash.php
@@ -22,8 +22,8 @@ class ExpireGroupTrash extends TimedJob {
 		ITimeFactory $timeFactory,
 	) {
 		parent::__construct($timeFactory);
-		// Run once per hour
-		$this->setInterval(60 * 60);
+		// Run every 30 minutes
+		$this->setInterval(60 * 30);
 	}
 
 	protected function run(mixed $argument): void {

--- a/lib/BackgroundJob/ExpireGroupVersions.php
+++ b/lib/BackgroundJob/ExpireGroupVersions.php
@@ -26,8 +26,8 @@ class ExpireGroupVersions extends TimedJob {
 	) {
 		parent::__construct($time);
 
-		// Run once per hour
-		$this->setInterval(60 * 60);
+		// Run every 30 minutes
+		$this->setInterval(60 * 30);
 		// But don't run if still running
 		$this->setAllowParallelRuns(false);
 	}


### PR DESCRIPTION
To match the server intervals:
https://github.com/nextcloud/server/blob/363ba6b0f5b99583e789695f19dcd96db00508ef/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php#L31
https://github.com/nextcloud/server/blob/363ba6b0f5b99583e789695f19dcd96db00508ef/apps/files_versions/lib/BackgroundJob/ExpireVersions.php#L27