### PR TITLE
fix: update parent etag when changing acl rules

### DIFF
--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -236,6 +236,9 @@ class ACLPlugin extends ServerPlugin {
 				$this->ruleManager->saveRule($rule);
 			}
 
+
+			$node->getNode()->getStorage()->getPropagator()->propagateChange($fileInfo->getInternalPath(), $fileInfo->getMtime());
+
 			return true;
 		});
 	}


### PR DESCRIPTION
This ensures that sync clients can pickup on the fact that a user might have gained/lost access to a file.

It also updates the etag for users that don't have any changes, but it's better to be on the safe side here and figuring out which users are affected would add significant complexity.