### PR TITLE
fix: Override check for applying quota in wrapper

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -85,4 +85,8 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 
 		return $storage->scanner;
 	}
+
+	protected function shouldApplyQuota(string $path): bool {
+		return true;
+	}
 }


### PR DESCRIPTION
Otherwise the parent Quota class takes over and blocks applying the quota

Requires https://github.com/nextcloud/server/pull/48623

But should not break when updating groupfolders without the server patch: https://3v4l.org/eekkT