### PR TITLE
fix: include mountpoint in original location for trash items

### DIFF
--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -14,6 +14,8 @@ use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 
 class GroupTrashItem extends TrashItem {
+	private string $internalOriginalLocation;
+
 	public function __construct(
 		ITrashBackend $backend,
 		string $originalLocation,
@@ -24,7 +26,12 @@ class GroupTrashItem extends TrashItem {
 		private string $mountPoint,
 		?IUser $deletedBy,
 	) {
-		parent::__construct($backend, $originalLocation, $deletedTime, $trashPath, $fileInfo, $user, $deletedBy);
+		$this->internalOriginalLocation = $originalLocation;
+		parent::__construct($backend, $this->mountPoint . '/' . $originalLocation, $deletedTime, $trashPath, $fileInfo, $user, $deletedBy);
+	}
+
+	public function getInternalOriginalLocation(): string {
+		return $this->internalOriginalLocation;
 	}
 
 	public function isRootItem(): bool {

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -80,7 +80,7 @@ class TrashBackend implements ITrashBackend {
 
 			return new GroupTrashItem(
 				$this,
-				$folder->getOriginalLocation() . '/' . $node->getName(),
+				$folder->getInternalOriginalLocation() . '/' . $node->getName(),
 				$folder->getDeletedTime(),
 				$folder->getTrashPath() . '/' . $node->getName(),
 				$node,
@@ -118,7 +118,7 @@ class TrashBackend implements ITrashBackend {
 		$trashStorage = $node->getStorage();
 		/** @var Folder $targetFolder */
 		$targetFolder = $this->mountProvider->getFolder((int)$folderId);
-		$originalLocation = $item->getOriginalLocation();
+		$originalLocation = $item->getInternalOriginalLocation();
 		$parent = dirname($originalLocation);
 		if ($parent === '.') {
 			$parent = '';


### PR DESCRIPTION
Currently the "original location" for deleted groupfolder items don't show the path of the groupfolder itself. Making it harder for users to know what the deleted file is.

This changes it to store the "full" original location and separately keep the "interal" original location for the restore operation.