### PR TITLE
perf: Add index for group_folders table

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Folders can be configured from *Group folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more groups, control their write/sharing permissions and assign a quota for the folder.
 ]]></description>
-	<version>19.0.0-dev.3</version>
+	<version>19.0.0-dev.4</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>

--- a/lib/Migration/Version19000Date20241029123147.php
+++ b/lib/Migration/Version19000Date20241029123147.php
@@ -16,10 +16,7 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version19000Date20241029123147 extends SimpleMigrationStep {
 	/**
-	 * @param IOutput $output
 	 * @param Closure(): ISchemaWrapper $schemaClosure
-	 * @param array $options
-	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
@@ -29,9 +26,10 @@ class Version19000Date20241029123147 extends SimpleMigrationStep {
 			$table = $schema->getTable('group_folders');
 			if (!$table->hasIndex('gf_folders_folder_id')) {
 				$table->addUniqueIndex(['folder_id'], 'gf_folders_folder_id');
+				return $schema;
 			}
 		}
 
-		return $schema;
+		return null;
 	}
 }

--- a/lib/Migration/Version19000Date20241029123147.php
+++ b/lib/Migration/Version19000Date20241029123147.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version19000Date20241029123147 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('group_folders')) {
+			$table = $schema->getTable('group_folders');
+			if (!$table->hasIndex('gf_folders_folder_id')) {
+				$table->addUniqueIndex(['folder_id'], 'gf_folders_folder_id');
+			}
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
We do a lot of SELECTs on this table in the FolderManager, but there is actually no index on it at all. All SELECTs include all columns, so that's why I'm not adding one for folder_id only.
Usually not noticable when there aren't many groupfolders, but if you got a few then it can take a bit too long.