### PR TITLE
Fix labeled version autoExpire

### DIFF
--- a/lib/Versions/ExpireManager.php
+++ b/lib/Versions/ExpireManager.php
@@ -66,8 +66,11 @@ class ExpireManager {
 			while ($newInterval) {
 				if ($nextInterval === -1 || $prevTimestamp > $nextInterval) {
 					if ($version->getTimestamp() > $nextVersion) {
-						//distance between two version too small, mark to delete
-						$toDelete[] = $version;
+						// Do not expire versions with a label.
+						if (!($version instanceof IMetadataVersion) || $version->getMetadataValue('label') === null || $version->getMetadataValue('label') === '') {
+							//distance between two version too small, mark to delete
+							$toDelete[] = $version;
+						}
 					} else {
 						$nextVersion = $version->getTimestamp() - $step;
 						$prevTimestamp = $version->getTimestamp();


### PR DESCRIPTION
Fix https://github.com/nextcloud/groupfolders/issues/3095

Follow up to https://github.com/nextcloud/groupfolders/pull/3213 which did not consider labeled versions of `getAutoExpireList`.