### PR TITLE
fix: implement 'per user inherit' logic for folder delete permissions check

### DIFF
--- a/lib/ACL/Rule.php
+++ b/lib/ACL/Rule.php
@@ -82,6 +82,25 @@ class Rule implements XmlSerializable, XmlDeserializable, \JsonSerializable {
 		return $permissions | $allowMask;
 	}
 
+	/**
+	 * Apply the deny permissions this rule to an existing permission set, returning the resulting permissions
+	 *
+	 * Only the deny permissions included in the current mask will overwrite the existing permissions
+	 *
+	 * @param int $permissions
+	 * @return int
+	 */
+	public function applyDenyPermissions(int $permissions): int {
+		$invertedMask = ~$this->mask;
+		// create a bitmask that has all inherit and allow bits set to 1 and all deny bits to 0
+		$denyMask = $invertedMask | $this->permissions;
+
+		return $permissions & $denyMask;
+	}
+
+	/**
+	 * @return void
+	 */
 	public function xmlSerialize(Writer $writer): void {
 		$data = [
 			self::ACL => [

--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -193,6 +193,8 @@ class RuleManager {
 			}
 		}
 
+		ksort($result);
+
 		return $result;
 	}
 


### PR DESCRIPTION
## To test:

- Enable "per user inherit" with `occ config:app:set groupfolders acl-inherit-per-user --value true`
- Create groups `G1` and `G2`
- Create user `U1` that is a member of `G1` and `G2`
- Create groupfolder `F1` with full access for `G1`, `G2` and `admin` and enable ACL for the groupfolder
- As admin create `F1/Test`
- As admin create an ACL rule for `F1` which sets all permissions for `G1` to allow
- As admin create an ACL rule for `F1/Test` which sets the delete for `G2` to deny

At this point the output of `occ groupfolders:permissions <folder id>` should look like:

```
+------+------------+-----------------------------------------+
| Path | User/Group | Permissions                             |
+------+------------+-----------------------------------------+
| /    | group: G1  | +read, +write, +create, +delete, +share |
| Test | group: G2  | -delete                                 |
+------+------------+-----------------------------------------+
```

- As `U1` try to delete `F1/Test`

## Current behavior

Even though `U1` sees the delete option, trying to delete the folder fails

## New behavior

`U1` can successfully delete the folder.