### PR TITLE
fix(routes): Revert back to index.php routes

### DIFF
--- a/lib/Controller/DelegationController.php
+++ b/lib/Controller/DelegationController.php
@@ -12,7 +12,7 @@ use OCA\GroupFolders\Attribute\RequireGroupFolderAdmin;
 use OCA\GroupFolders\Service\DelegationService;
 use OCA\Settings\Service\AuthorizedGroupService;
 use OCP\App\IAppManager;
-use OCP\AppFramework\Http\Attribute\ApiRoute;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
@@ -42,7 +42,7 @@ class DelegationController extends OCSController {
 	 */
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/delegation/groups')]
+	#[FrontpageRoute(verb: 'GET', url: '/delegation/groups')]
 	public function getAllGroups(): DataResponse {
 		// Get all groups
 		$groups = $this->groupManager->search('');
@@ -64,7 +64,7 @@ class DelegationController extends OCSController {
 	 */
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/delegation/circles')]
+	#[FrontpageRoute(verb: 'GET', url: '/delegation/circles')]
 	public function getAllCircles(): DataResponse {
 		$circlesEnabled = $this->appManager->isEnabledForUser('circles');
 		if (!$circlesEnabled) {
@@ -104,7 +104,7 @@ class DelegationController extends OCSController {
 	 */
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/delegation/authorized-groups')]
+	#[FrontpageRoute(verb: 'GET', url: '/delegation/authorized-groups')]
 	public function getAuthorizedGroups(string $classname = ''): DataResponse {
 		$data = [];
 		$authorizedGroups = $this->authorizedGroupService->findExistingGroupsForClass($classname);

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -14,7 +14,7 @@ use OCA\GroupFolders\Mount\MountProvider;
 use OCA\GroupFolders\Service\DelegationService;
 use OCA\GroupFolders\Service\FoldersFilter;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\Attribute\ApiRoute;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
@@ -77,7 +77,7 @@ class FolderController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/folders')]
+	#[FrontpageRoute(verb: 'GET', url: '/folders')]
 	public function getFolders(bool $applicable = false): DataResponse {
 		$storageId = $this->getRootFolderStorageId();
 		if ($storageId === null) {
@@ -104,7 +104,7 @@ class FolderController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/folders/{id}')]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}')]
 	public function getFolder(int $id): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -155,7 +155,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders')]
 	public function addFolder(string $mountpoint): DataResponse {
 
 		$storageId = $this->rootFolder->getMountPoint()->getNumericStorageId();
@@ -175,7 +175,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'DELETE', url: '/folders/{id}')]
+	#[FrontpageRoute(verb: 'DELETE', url: '/folders/{id}')]
 	public function removeFolder(int $id): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -196,7 +196,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'PUT', url: '/folders/{id}')]
+	#[FrontpageRoute(verb: 'PUT', url: '/folders/{id}')]
 	public function setMountPoint(int $id, string $mountPoint): DataResponse {
 		$this->manager->renameFolder($id, trim($mountPoint));
 		return new DataResponse(['success' => true]);
@@ -205,7 +205,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/groups')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/groups')]
 	public function addGroup(int $id, string $group): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -220,7 +220,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'DELETE', url: '/folders/{id}/groups/{group}', requirements: ['group' => '.+'])]
+	#[FrontpageRoute(verb: 'DELETE', url: '/folders/{id}/groups/{group}', requirements: ['group' => '.+'])]
 	public function removeGroup(int $id, string $group): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -235,7 +235,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/groups/{group}', requirements: ['group' => '.+'])]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/groups/{group}', requirements: ['group' => '.+'])]
 	public function setPermissions(int $id, string $group, int $permissions): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -253,7 +253,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/manageACL')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/manageACL')]
 	public function setManageACL(int $id, string $mappingType, string $mappingId, bool $manageAcl): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -268,7 +268,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/quota')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/quota')]
 	public function setQuota(int $id, int $quota): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -283,7 +283,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/acl')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/acl')]
 	public function setACL(int $id, bool $acl): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -298,7 +298,7 @@ class FolderController extends OCSController {
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'POST', url: '/folders/{id}/mountpoint')]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/mountpoint')]
 	public function renameFolder(int $id, string $mountpoint): DataResponse {
 		$response = $this->checkFolderExists($id);
 		if ($response) {
@@ -346,7 +346,7 @@ class FolderController extends OCSController {
 	}
 
 	#[NoAdminRequired]
-	#[ApiRoute(verb: 'GET', url: '/folders/{id}/search')]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}/search')]
 	public function aclMappingSearch(int $id, ?int $fileId, string $search = ''): DataResponse {
 		$users = [];
 		$groups = [];

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -157,7 +157,7 @@
 <script>
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
-import { generateOcsUrl } from '@nextcloud/router'
+import { generateUrl } from '@nextcloud/router'
 import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcSelect from '@nextcloud/vue/dist/Components/NcSelect.js'
@@ -276,7 +276,7 @@ export default {
 			}
 			searchRequestCancelSource = axios.CancelToken.source()
 			this.isSearching = true
-			axios.get(generateOcsUrl(`apps/groupfolders/folders/${this.groupFolderId}/search`) + '?format=json&search=' + query, {
+			axios.get(generateUrl(`apps/groupfolders/folders/${this.groupFolderId}/search`) + '?format=json&search=' + query, {
 				cancelToken: searchRequestCancelSource.token,
 			}).then((result) => {
 				this.isSearching = false

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 // eslint-disable-next-line n/no-unpublished-import
@@ -47,7 +47,7 @@ export interface Folder {
 export class Api {
 
 	getUrl(endpoint: string): string {
-		return generateOcsUrl(`apps/groupfolders/${endpoint}`)
+		return generateUrl(`apps/groupfolders/${endpoint}`)
 	}
 
 	async listFolders(): Promise<Folder[]> {


### PR DESCRIPTION
Partially reverts https://github.com/nextcloud/groupfolders/pull/3182, but keeps the attributes.
Needed to implement https://github.com/nextcloud/groupfolders/pull/3324 without any breaking changes.
This is only present on master, so no backports needed.