### PR TITLE
build: Exclude vendor-bin from PHP lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"post-update-cmd": [
 			"@composer bin all update --ansi"
 		],
-		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n1 php -l",
+		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n1 php -l",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"psalm": "psalm --threads=$(nproc) --no-cache",


### PR DESCRIPTION
We should not check our dependencies and it takes quite some time to do this anyway.