### PR TITLE
fix(FolderController): Return folders as object with id as key

### DIFF
--- a/lib/Service/FoldersFilter.php
+++ b/lib/Service/FoldersFilter.php
@@ -22,8 +22,8 @@ class FoldersFilter {
 	}
 
 	/**
-	 * @param list<GroupFoldersFolder> $folders List of all folders
-	 * @return list<GroupFoldersFolder>
+	 * @param GroupFoldersFolder[] $folders List of all folders
+	 * @return GroupFoldersFolder[]
 	 */
 	public function getForApiUser(array $folders): array {
 		$user = $this->userSession->getUser();

--- a/openapi.json
+++ b/openapi.json
@@ -389,8 +389,8 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
+                                    "type": "object",
+                                    "additionalProperties": {
                                         "$ref": "#/components/schemas/Folder"
                                     }
                                 }

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -400,7 +400,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Folder"][];
+                    "application/json": {
+                        [key: string]: components["schemas"]["Folder"];
+                    };
                 };
             };
             /** @description Storage not found */


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/3414
Reverts a breaking change introduced by https://github.com/nextcloud/groupfolders/pull/3324