### PR TITLE
Encryption trash fixes

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -23,7 +23,7 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 	private ?ICacheEntry $rootEntry;
 	private IUserSession $userSession;
 	private ?IUser $mountOwner;
-	/** @var RootEntryCache|null */
+	/** @var ICache|null */
 	public $cache;
 
 	public function __construct($parameters) {

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -20,7 +20,7 @@ use OCP\IUserSession;
 
 class GroupFolderStorage extends Quota implements IConstructableStorage {
 	private int $folderId;
-	private ICacheEntry $rootEntry;
+	private ?ICacheEntry $rootEntry;
 	private IUserSession $userSession;
 	private ?IUser $mountOwner;
 	/** @var RootEntryCache|null */
@@ -59,7 +59,11 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 			$storage = $this;
 		}
 
-		$this->cache = new RootEntryCache(parent::getCache($path, $storage), $this->rootEntry);
+		$cache = parent::getCache($path, $storage);
+		if ($this->rootEntry !== null) {
+			$cache = new RootEntryCache($cache, $this->rootEntry);
+		}
+		$this->cache = $cache;
 
 		return $this->cache;
 	}

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -229,7 +229,7 @@ class MountProvider implements IMountProvider {
 
 		$storage = $this->getRootFolder()->getStorage();
 
-		$storage->setOwner($user?->getUID());
+		$storage->setOwner($user->getUID());
 
 		$trashPath = $this->getRootFolder()->getInternalPath() . '/trash/' . $id;
 

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -37,16 +37,16 @@ class MountProvider implements IMountProvider {
 	private ?int $rootStorageId = null;
 
 	public function __construct(
-		private FolderManager            $folderManager,
-		private \Closure                 $rootProvider,
-		private ACLManagerFactory        $aclManagerFactory,
-		private IUserSession             $userSession,
-		private IRequest                 $request,
+		private FolderManager $folderManager,
+		private \Closure $rootProvider,
+		private ACLManagerFactory $aclManagerFactory,
+		private IUserSession $userSession,
+		private IRequest $request,
 		private IMountProviderCollection $mountProviderCollection,
-		private IDBConnection            $connection,
-		private ICache                   $cache,
-		private bool                     $allowRootShare,
-		private bool                     $enableEncryption,
+		private IDBConnection $connection,
+		private ICache $cache,
+		private bool $allowRootShare,
+		private bool $enableEncryption,
 	) {
 	}
 
@@ -153,16 +153,16 @@ class MountProvider implements IMountProvider {
 	}
 
 	public function getMount(
-		int              $id,
-		string           $mountPoint,
-		int              $permissions,
-		int              $quota,
-		?ICacheEntry     $cacheEntry = null,
+		int $id,
+		string $mountPoint,
+		int $permissions,
+		int $quota,
+		?ICacheEntry $cacheEntry = null,
 		?IStorageFactory $loader = null,
-		bool             $acl = false,
-		?IUser           $user = null,
-		?ACLManager      $aclManager = null,
-		array            $rootRules = [],
+		bool $acl = false,
+		?IUser $user = null,
+		?ACLManager $aclManager = null,
+		array $rootRules = [],
 	): ?IMountPoint {
 		if (!$cacheEntry) {
 			// trigger folder creation
@@ -220,11 +220,11 @@ class MountProvider implements IMountProvider {
 	}
 
 	public function getTrashMount(
-		int             $id,
-		string          $mountPoint,
-		int             $quota,
+		int $id,
+		string $mountPoint,
+		int $quota,
 		IStorageFactory $loader,
-		IUser           $user,
+		IUser $user,
 	): IMountPoint {
 
 		$storage = $this->getRootFolder()->getStorage();
@@ -245,11 +245,11 @@ class MountProvider implements IMountProvider {
 	}
 
 	public function getGroupFolderStorage(
-		int          $id,
-		IStorage     $rootStorage,
-		?IUser       $user,
-		string       $rootPath,
-		int          $quota,
+		int $id,
+		IStorage $rootStorage,
+		?IUser $user,
+		string $rootPath,
+		int $quota,
 		?ICacheEntry $rootCacheEntry,
 	): IStorage {
 		if ($this->enableEncryption) {

--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -43,18 +43,6 @@ class GroupTrashItem extends TrashItem {
 		return $this->getGroupFolderMountPoint() . '/' . $this->getOriginalLocation();
 	}
 
-	public function getStorage(): IStorage {
-		// get the unjailed storage, since the trash item is outside the jail
-		// (the internal path is also unjailed)
-		$groupFolderStorage = parent::getStorage();
-		if ($groupFolderStorage->instanceOfStorage(Jail::class)) {
-			/** @var Jail $groupFolderStorage */
-			return $groupFolderStorage->getUnjailedStorage();
-		}
-
-		return $groupFolderStorage;
-	}
-
 	public function getMtime(): int {
 		// trashbin is currently (incorrectly) assuming these to be the same
 		return $this->getDeletedTime();

--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -6,11 +6,9 @@
 
 namespace OCA\GroupFolders\Trash;
 
-use OC\Files\Storage\Wrapper\Jail;
 use OCA\Files_Trashbin\Trash\ITrashBackend;
 use OCA\Files_Trashbin\Trash\TrashItem;
 use OCP\Files\FileInfo;
-use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 
 class GroupTrashItem extends TrashItem {

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -102,6 +102,7 @@ class TrashBackend implements ITrashBackend {
 		}
 
 		$user = $item->getUser();
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 		[, $folderId] = explode('/', $item->getTrashPath());
 		$node = $this->getNodeForTrashItem($user, $item);
 		if ($node === null) {
@@ -119,7 +120,7 @@ class TrashBackend implements ITrashBackend {
 
 		$trashStorage = $node->getStorage();
 		/** @var Folder $targetFolder */
-		$targetFolder = $this->mountProvider->getFolder((int)$folderId);
+		$targetFolder = $userFolder->get($item->getGroupFolderMountPoint());
 		$originalLocation = $item->getInternalOriginalLocation();
 		$parent = dirname($originalLocation);
 		if ($parent === '.') {

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -239,7 +239,7 @@ class TrashBackend implements ITrashBackend {
 			$folderId = $storage->getFolderId();
 			$user = $this->userSession->getUser();
 			if (!$user) {
-				throw new \Exception("file moved to trash with no user in context");
+				throw new \Exception('file moved to trash with no user in context');
 			}
 			// ensure the folder exists
 			$this->getTrashFolder($folderId);

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -6,7 +6,9 @@
 
 namespace OCA\GroupFolders\Trash;
 
+use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\Storage\Wrapper\Encryption;
+use OC\Files\Storage\Wrapper\Jail;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashBackend;
@@ -159,8 +161,19 @@ class TrashBackend implements ITrashBackend {
 		}
 
 		$targetLocation = $targetFolder->getInternalPath() . '/' . $originalLocation;
-		$targetFolder->getStorage()->moveFromStorage($trashStorage, $node->getInternalPath(), $targetLocation);
-		$targetFolder->getStorage()->getUpdater()->renameFromStorage($trashStorage, $node->getInternalPath(), $targetLocation);
+		$targetStorage = $targetFolder->getStorage();
+		$trashLocation = $node->getInternalPath();
+		try {
+			$targetStorage->moveFromStorage($trashStorage, $trashLocation, $targetLocation);
+			$targetStorage->getUpdater()->renameFromStorage($trashStorage, $trashLocation, $targetLocation);
+		} catch (DecryptionFailedException $e) {
+			// Before https://github.com/nextcloud/groupfolders/pull/3425 the key would be in the wrong place, leading to the decryption failure.
+			// for those we fall back to the old restore behavior
+			[$unwrappedTargetStorage, $unwrappedTargetLocation] = $this->unwrapJails($targetStorage, $targetLocation);
+			[$unwrappedTrashStorage, $unwrappedTrashLocation] = $this->unwrapJails($trashStorage, $trashLocation);
+			$unwrappedTargetStorage->moveFromStorage($unwrappedTrashStorage, $unwrappedTrashLocation, $unwrappedTargetLocation);
+			$unwrappedTargetStorage->getUpdater()->renameFromStorage($unwrappedTrashStorage, $unwrappedTrashLocation, $unwrappedTargetLocation);
+		}
 		$this->trashManager->removeItem((int)$folderId, $item->getName(), $item->getDeletedTime());
 		\OCP\Util::emitHook(
 			'\OCA\Files_Trashbin\Trashbin',
@@ -170,6 +183,18 @@ class TrashBackend implements ITrashBackend {
 				'trashPath' => $item->getPath(),
 			]
 		);
+	}
+
+	private function unwrapJails(IStorage $storage, string $internalPath): array {
+		$unJailedInternalPath = $internalPath;
+		$unJailedStorage = $storage;
+		while ($unJailedStorage->instanceOfStorage(Jail::class)) {
+			$unJailedStorage = $unJailedStorage->getWrapperStorage();
+			if ($unJailedStorage instanceof Jail) {
+				$unJailedInternalPath = $unJailedStorage->getUnjailedPath($unJailedInternalPath);
+			}
+		}
+		return [$unJailedStorage, $unJailedInternalPath];
 	}
 
 	/**

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -144,7 +144,7 @@ class TrashBackend implements ITrashBackend {
 				$target .= ' (' . $i . ')';
 
 				if (isset($info['extension'])) {
-					$target .= $info['extension'];
+					$target .= '.' . $info['extension'];
 				}
 
 				return $target;


### PR DESCRIPTION
Currently, the groupfolders trashbin doesn't actually support encryption. Things are only somewhat working by chance.

This is because currently the trash/restore operations for groupfolders don't go through the encryption storage wrapper. This PR makes sure the encryption storage wrappers are in effect when trashing/restoring files.

- [x] fix file names generated when restore has a filename conflict missing a `.`
- [x] make "move to trash" and "restore" operations go trough the encryption wrapper
- [x] make the encryption wrapper apply to the trashbin so files don't decrypted when being moved to trash
- [x] don't break restoring files that were deleted before this fix

To test

- setup an instance, create a groupfolder, setup encryption
- Enable groupfolder encryption `occ config:app:set groupfolders enable_encryption --value='true'`
- Upload some files to the groupfolder and delete them
- Download the delete files: it will be still encrypted
- Apply this PR
- Upload and delete some more files
- Download the newly deleted files from the trashbin, they should be decrypted
- (optional) verify that the on-disk trashed files are encrypted
- Restore all deleted files
- Ensure all restored files can be read