### PR TITLE
ignore inShare from cli

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -169,7 +169,7 @@ class MountProvider implements IMountProvider {
 
 		// apply acl before jail
 		if ($acl && $user) {
-			$inShare = $this->getCurrentUID() === null || $this->getCurrentUID() !== $user->getUID();
+			$inShare = !\OC::$CLI && ($this->getCurrentUID() === null || $this->getCurrentUID() !== $user->getUID());
 			$aclManager ??= $this->aclManagerFactory->getACLManager($user, $this->getRootStorageId());
 			$aclRootPermissions = $aclManager->getPermissionsForPathFromRules($rootPath, $rootRules);
 			$storage = new ACLStorageWrapper([


### PR DESCRIPTION
because `::currentUID()` is null when executed from occ...

This fix an issue that block access to documents if ACL denies Sharing [1], even if read/write/delete permissions are fine, when calling `IUserFolder()->getbyId();`

https://github.com/nextcloud/groupfolders/blob/master/lib/ACL/ACLCacheWrapper.php#L35