### PR TITLE
chore: Rename app to Team folders

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,7 +7,7 @@ labels: bug, 0. Needs triage
 <!--
 Thanks for reporting issues back to Nextcloud!
 
-Note: This is the **issue tracker of Nextcloud app Group Folder**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://help.nextcloud.com or, if you use Nextcloud in a large organization, ask our engineers on https://portal.nextcloud.com. See also  https://nextcloud.com/support for support options.
+Note: This is the **issue tracker of Nextcloud app Team folders**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://help.nextcloud.com or, if you use Nextcloud in a large organization, ask our engineers on https://portal.nextcloud.com. See also  https://nextcloud.com/support for support options.
 
 Nextcloud is an open source project backed by Nextcloud GmbH. Most of our volunteers are home users and thus primarily care about issues that affect home users. Our paid engineers prioritize issues of our customers. If you are neither a home user nor a customer, consider paying somebody to fix your issue, do it yourself or become a customer.
 
@@ -18,7 +18,7 @@ Guidelines for submitting issues:
     - You can also filter by appending e. g. "state:open" to the search string.
     - More info on search syntax within github: https://help.github.com/articles/searching-issues
     
-* This repository https://github.com/nextcloud/groupfolders/issues is *only* for issues within the Group folders code.
+* This repository https://github.com/nextcloud/groupfolders/issues is *only* for issues within the Team folders code.
   
 * SECURITY: Report any potential security bug to us via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/) instead of filing an issue in our bug tracker.
 
@@ -59,7 +59,7 @@ Tell us what happens instead
 
 **Nextcloud version:** (see Nextcloud admin page)
 
-**Group folders version:**
+**Team folders version:**
 
 **Updated from an older Nextcloud/ownCloud or fresh install:**
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -7,7 +7,7 @@ labels: enhancement, 0. Needs triage
 <!--
 Thanks for reporting issues back to Nextcloud!
 
-Note: This is the **issue tracker of Nextcloud Group folders**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://help.nextcloud.com or, if you use Nextcloud in a large organization, ask our engineers on https://portal.nextcloud.com. See also  https://nextcloud.com/support for support options.
+Note: This is the **issue tracker of Nextcloud Team folders**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://help.nextcloud.com or, if you use Nextcloud in a large organization, ask our engineers on https://portal.nextcloud.com. See also  https://nextcloud.com/support for support options.
 
 Nextcloud is an open source project backed by Nextcloud GmbH. Most of our volunteers are home users and thus primarily care about issues that affect home users. Our paid engineers prioritize issues of our customers. If you are neither a home user nor a customer, consider paying somebody to fix your issue, do it yourself or become a customer.
 
@@ -18,7 +18,7 @@ Guidelines for submitting issues:
     - You can also filter by appending e. g. "state:open" to the search string.
     - More info on search syntax within github: https://help.github.com/articles/searching-issues
     
-* This repository https://github.com/nextcloud/groupfolders/issues is *only* for issues within the Nextcloud Group folders code.
+* This repository https://github.com/nextcloud/groupfolders/issues is *only* for issues within the Nextcloud Team folders code.
   
 * SECURITY: Report any potential security bug to us via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/) instead of filing an issue in our bug tracker.  
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   - SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-# Group Folders
+# Team folders
 
 [![REUSE status](https://api.reuse.software/badge/github.com/nextcloud/groupfolders)](https://api.reuse.software/info/github.com/nextcloud/groupfolders)
 
@@ -16,22 +16,22 @@
 
 [^1]: The releases are now managed in a [dedicated release repository](https://github.com/nextcloud-releases/groupfolders/releases). The releases in this repository may be outdated.
 
-## Configuring Group Folders
+## Configuring Team folder
 
-Group Folders can be configured through *Group Folders* under *Administration settings*.
+Team folders can be configured through *Team folders* under *Administration settings*.
 
 After a folder is created, the admin can give access to the folder to one or more groups, a quota can be assigned for the folder and advanced permissions can be activated and configured.
 
 
 ![edit](screenshots/edit.png)
 
-Permissions to the content of a group folder can be configured on a per-group basis.
+Permissions to the content of a Team folder can be configured on a per-group basis.
 
 ![permissions](screenshots/permissions.png)
 
 The configuration options include the _Write_, _Share_ and _Delete_ permissions for each group.
 
-## Using Group Folders
+## Using Team folders
 
 Once configured, the folders will show up in the home folder for each user in the configured groups.
 
@@ -39,13 +39,13 @@ Once configured, the folders will show up in the home folder for each user in th
 
 ## Setting Advanced Permissions
 
-_Advanced Permissions_ allows entitled users to configure permissions inside groupfolders on a per file and folder basis.
+_Advanced Permissions_ allows entitled users to configure permissions inside Team folders on a per file and folder basis.
 
-Permissions are configured by setting one or more of "Read", "Write", "Create", "Delete" or "Share" permissions to "allow" or "deny". Any permission not explicitly set will inherit the permissions from the parent folder. If multiple configured advanced permissions for a single file or folder apply for a single user (such as when a user belongs to multiple groups), the "allow" permission will overwrite any "deny" permission. Denied permissions configured for the group folder itself cannot be overwritten to "allow" permissions by the advanced permission rules.
+Permissions are configured by setting one or more of "Read", "Write", "Create", "Delete" or "Share" permissions to "allow" or "deny". Any permission not explicitly set will inherit the permissions from the parent folder. If multiple configured advanced permissions for a single file or folder apply for a single user (such as when a user belongs to multiple groups), the "allow" permission will overwrite any "deny" permission. Denied permissions configured for the Team folder itself cannot be overwritten to "allow" permissions by the advanced permission rules.
 
 ![advanced permissions](screenshots/acl.png)
 
-Users or whole groups can be entitled to set advanced permissions for each group folder separately on the group folders admin page.
+Users or whole groups can be entitled to set advanced permissions for each Team folder separately on the Team folders admin page.
 For entitlements, only users from those groups are selectable which have to be configured selected in the Groups column.
 
 ![advanced permission entitlement](screenshots/aclAdmin.png)
@@ -54,7 +54,7 @@ For entitlements, only users from those groups are selectable which have to be c
 
 Some settings are currently only exposed via `config/config.php`:
 
-### Default quota for new groupfolders
+### Default quota for new Team folders
 
 ```injectablephp
 'groupfolders.quota.default' => -3,
@@ -64,24 +64,24 @@ The special value `-3` means unlimited and any other value is the quota limit in
 
 ## Command-line interface management and configuration (via `occ`)
 
-Group folders can be configured and managed from the command-line interface (CLI). This is accomplished by using the `occ` command. 
+Team folders can be configured and managed from the command-line interface (CLI). This is accomplished by using the `occ` command. 
 
-The `occ` command is utilized throughout Nextcloud for many operations and is not specific to Group Folders. When the Group Folders app is enabled, the `occ` command gains additional functionality specific to Group Folders.
+The `occ` command is utilized throughout Nextcloud for many operations and is not specific to Team folders. When the Team folders app is enabled, the `occ` command gains additional functionality specific to Team folders.
 
 If you're unfamiliar with `occ` see [Using the occ command](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html) in the Nextcloud Server Administration Guide for general guidance.
 
 ### Commands Available
 
-- `occ groupfolders:create <name>` &rarr; create a group folder
-- `occ groupfolders:delete <folder_id> [-f|--force]` &rarr; delete a group folder and all its contents
+- `occ groupfolders:create <name>` &rarr; create a Team folder
+- `occ groupfolders:delete <folder_id> [-f|--force]` &rarr; delete a Team folder and all its contents
 - `occ groupfolders:expire` &rarr; trigger file version and trashbin expiration (see [Nextcloud docs for versioning](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/file_versioning.html) and [Nextcloud docs for the trash bin](https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/trashbin_configuration.html) for details)
-- `occ groupfolders:group <folder_id> <group_id> [-d|--delete] [write|share|delete]` &rarr; assign groups and their rights to a group folder
-- `occ groupfolders:list` &rarr; list configured group folders
+- `occ groupfolders:group <folder_id> <group_id> [-d|--delete] [write|share|delete]` &rarr; assign groups and their rights to a Team folder
+- `occ groupfolders:list` &rarr; list configured Team folders
 - `occ groupfolders:permissions` &rarr; configure advanced permissions (see below for details)
-- `occ groupfolders:quota <folder_id> [<quota>|unlimited]` &rarr; set a quota for a group folder
-- `occ groupfolders:rename <folder_id> <name>` &rarr; rename a group folder
-- `occ groupfolders:scan <folder_id>` &rarr; trigger a filescan for a group folder
-- `occ groupfolders:trashbin:cleanup` &rarr; empty the trashbin of all group folders
+- `occ groupfolders:quota <folder_id> [<quota>|unlimited]` &rarr; set a quota for a Team folder
+- `occ groupfolders:rename <folder_id> <name>` &rarr; rename a Team folder
+- `occ groupfolders:scan <folder_id>` &rarr; trigger a filescan for a Team folder
+- `occ groupfolders:trashbin:cleanup` &rarr; empty the trashbin of all Team folders
 - `occ config:app:set groupfolders enable_encryption --value="true"` &rarr; activate encryption (server-side) support
 
 ### Configuring Advanced Permissions via `occ`
@@ -90,7 +90,7 @@ Advanced permissions can also be configured through the `occ groupfolders:permis
 
 #### Enabling
 
-Before configuring any advanced permissions you'll first have to enable advanced permissions for the folder using `occ groupfolders:permissions <folder_id> --enable`. To do this you'll first need to find the `folder_id` of the groupfolder you're trying to configure. You can use `occ groupfolders:list` to find the `folder_id` of the target folder.
+Before configuring any advanced permissions you'll first have to enable advanced permissions for the folder using `occ groupfolders:permissions <folder_id> --enable`. To do this you'll first need to find the `folder_id` of the Team folder you're trying to configure. You can use `occ groupfolders:list` to find the `folder_id` of the target folder.
 
 #### Using
 
@@ -120,7 +120,7 @@ To manage the users or groups entitled to set advanced permissions, use `occ gro
 
 #### Disabling
 
-To disable the advanced permissions feature for a group folder, use `occ groupfolders:permissions <folder_id> --disable`.
+To disable the advanced permissions feature for a Team folder, use `occ groupfolders:permissions <folder_id> --disable`.
 
 ## APIs
 
@@ -130,7 +130,7 @@ See the [OpenAPI specification](openapi.json) to learn about all available API e
 
 ### WebDAV API
 
-Group folders are also exposed through a separate [WebDAV API](https://docs.nextcloud.com/server/latest/user_manual/en/files/access_webdav.html) at `/remote.php/dav/groupfolders/<user id>`.
+Team folders are also exposed through a separate [WebDAV API](https://docs.nextcloud.com/server/latest/user_manual/en/files/access_webdav.html) at `/remote.php/dav/groupfolders/<user id>`.
 
-In addition to browsing the contents of the group folders, you can also request the mount point for the group folder by requesting the `{http://nextcloud.org/ns}mount-point` property.
+In addition to browsing the contents of the Team folders, you can also request the mount point for the Team folder by requesting the `{http://nextcloud.org/ns}mount-point` property.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,13 +5,13 @@
 -->
 <info>
 	<id>groupfolders</id>
-	<name>Group folders</name>
-	<summary>Admin configured folders shared with everyone in a group</summary>
-	<description><![CDATA[Admin configured folders shared with everyone in a group.
+	<name>Team folders</name>
+	<summary>Admin configured folders shared with everyone in a team</summary>
+	<description><![CDATA[Admin configured folders shared with everyone in a team.
 
-Folders can be configured from *Group folders* in the admin settings.
+Folders can be configured from *Team folders* in the admin settings.
 
-After a folder is created, the admin can give access to the folder to one or more groups, control their write/sharing permissions and assign a quota for the folder.
+After a folder is created, the admin can give access to the folder to one or more teams, control their write/sharing permissions and assign a quota for the folder.
 ]]></description>
 	<version>19.0.0-alpha.1</version>
 	<licence>agpl</licence>

--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -38,7 +38,7 @@ class ACL extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:permissions')
-			->setDescription('Configure advanced permissions for a configured group folder')
+			->setDescription('Configure advanced permissions for a configured Team folder')
 			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to configure')
 			->addOption('enable', 'e', InputOption::VALUE_NONE, 'Enable advanced permissions for the folder')
 			->addOption('disable', 'd', InputOption::VALUE_NONE, 'Disable advanced permissions for the folder')

--- a/lib/Command/Create.php
+++ b/lib/Command/Create.php
@@ -24,7 +24,7 @@ class Create extends Base {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:create')
-			->setDescription('Create a new group folder')
+			->setDescription('Create a new Team folder')
 			->addArgument('name', InputArgument::REQUIRED, 'Name of the new folder');
 		parent::configure();
 	}

--- a/lib/Command/Delete.php
+++ b/lib/Command/Delete.php
@@ -18,7 +18,7 @@ class Delete extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:delete')
-			->setDescription('Delete group folder')
+			->setDescription('Delete Team folder')
 			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to rename')
 			->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip confirmation');
 		parent::configure();
@@ -31,7 +31,7 @@ class Delete extends FolderCommand {
 		}
 
 		$helper = $this->getHelper('question');
-		$question = new ConfirmationQuestion('Are you sure you want to delete the group folder ' . $folder['mount_point'] . ' and all files within, this cannot be undone (y/N).', false);
+		$question = new ConfirmationQuestion('Are you sure you want to delete the Team folder ' . $folder['mount_point'] . ' and all files within, this cannot be undone (y/N).', false);
 		if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
 			$folderMount = $this->mountProvider->getFolder($folder['id']);
 			$this->folderManager->removeFolder($folder['id']);

--- a/lib/Command/ExpireGroupVersionsPlaceholder.php
+++ b/lib/Command/ExpireGroupVersionsPlaceholder.php
@@ -16,12 +16,12 @@ class ExpireGroupVersionsPlaceholder extends Base {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:expire')
-			->setDescription('Trigger expiry of versions for files stored in group folders');
+			->setDescription('Trigger expiry of versions for files stored in Team folders');
 		parent::configure();
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$output->writeln('<error>groupfolder version handling is only supported with Nextcloud 15 and up</error>');
+		$output->writeln('<error>Team folder version handling is only supported with Nextcloud 15 and up</error>');
 		return 0;
 	}
 }

--- a/lib/Command/Group.php
+++ b/lib/Command/Group.php
@@ -38,7 +38,7 @@ class Group extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:group')
-			->setDescription('Edit the groups that have access to a group folder')
+			->setDescription('Edit the groups that have access to a Team folder')
 			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to configure')
 			->addArgument('group', InputArgument::REQUIRED, 'The group to configure')
 			->addArgument('permissions', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The permissions to set for the group, leave empty for read only')

--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -41,8 +41,8 @@ class ListCommand extends Base {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:list')
-			->setDescription('List the configured group folders')
-			->addOption('user', 'u', InputArgument::OPTIONAL, 'List group folders applicable for a user');
+			->setDescription('List the configured Team folders')
+			->addOption('user', 'u', InputArgument::OPTIONAL, 'List Team folders applicable for a user');
 		parent::configure();
 	}
 

--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -17,7 +17,7 @@ class Quota extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:quota')
-			->setDescription('Edit the quota of a configured group folder')
+			->setDescription('Edit the quota of a configured Team folder')
 			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to configure')
 			->addArgument('quota', InputArgument::REQUIRED, 'New value for the quota of the folder');
 		parent::configure();

--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -16,7 +16,7 @@ class Rename extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:rename')
-			->setDescription('Rename group folder')
+			->setDescription('Rename Team folder')
 			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to rename')
 			->addArgument('name', InputArgument::REQUIRED, 'New value name of the folder');
 		parent::configure();

--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -21,16 +21,16 @@ class Scan extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:scan')
-			->setDescription('Scan a group folder for outside changes')
+			->setDescription('Scan a Team folder for outside changes')
 			->addArgument(
 				'folder_id',
 				InputArgument::OPTIONAL,
-				'Id of the group folder to scan.'
+				'Id of the Team folder to scan.'
 			)->addOption(
 				'all',
 				null,
 				InputOption::VALUE_NONE,
-				'Scan all the group folders.'
+				'Scan all the Team folders.'
 			)
 			->addOption(
 				'path',
@@ -50,12 +50,12 @@ class Scan extends FolderCommand {
 		$folderId = $input->getArgument('folder_id');
 		$all = $input->getOption('all');
 		if ($folderId === null && !$all) {
-			$output->writeln('Either a group folder id or --all needs to be provided');
+			$output->writeln('Either a Team folder id or --all needs to be provided');
 			return -1;
 		}
 
 		if ($folderId !== null && $all) {
-			$output->writeln('Specifying a group folder id and --all are mutually exclusive');
+			$output->writeln('Specifying a Team folder id and --all are mutually exclusive');
 			return -1;
 		}
 
@@ -87,9 +87,9 @@ class Scan extends FolderCommand {
 			/** @var IScanner&\OC\Hooks\BasicEmitter $scanner */
 			$scanner = $mount->getStorage()->getScanner();
 
-			$output->writeln("Scanning group folder with id\t<info>{$folder['id']}</info>", OutputInterface::VERBOSITY_VERBOSE);
+			$output->writeln("Scanning Team folder with id\t<info>{$folder['id']}</info>", OutputInterface::VERBOSITY_VERBOSE);
 			if ($scanner instanceof ObjectStoreScanner) {
-				$output->writeln('Scanning group folders using an object store as primary storage is not supported.');
+				$output->writeln('Scanning Team folders using an object store as primary storage is not supported.');
 				return -1;
 			}
 

--- a/lib/Command/Trashbin/Cleanup.php
+++ b/lib/Command/Trashbin/Cleanup.php
@@ -35,15 +35,15 @@ class Cleanup extends Base {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:trashbin:cleanup')
-			->setDescription('Empty the groupfolder trashbin')
-			->addArgument('folder_id', InputArgument::OPTIONAL, 'Id of the groupfolder')
+			->setDescription('Empty the Team folder trashbin')
+			->addArgument('folder_id', InputArgument::OPTIONAL, 'Id of the Team folder')
 			->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip confirmation');
 		parent::configure();
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->trashBackend) {
-			$output->writeln('<error>files_trashbin is disabled: group folders trashbin is not available</error>');
+			$output->writeln('<error>files_trashbin is disabled: Team folders trashbin is not available</error>');
 			return -1;
 		}
 
@@ -56,7 +56,7 @@ class Cleanup extends Base {
 
 			foreach ($folders as $folder) {
 				if ($folder['id'] === $folderId) {
-					$question = new ConfirmationQuestion('Are you sure you want to empty the trashbin of your group folder with id ' . $folderId . ', this can not be undone (y/N).', false);
+					$question = new ConfirmationQuestion('Are you sure you want to empty the trashbin of your Team folder with id ' . $folderId . ', this can not be undone (y/N).', false);
 					if (!$input->getOption('force') && !$helper->ask($input, $output, $question)) {
 						return -1;
 					}
@@ -71,7 +71,7 @@ class Cleanup extends Base {
 
 			return -1;
 		} else {
-			$question = new ConfirmationQuestion('Are you sure you want to empty the trashbin of your group folders, this can not be undone (y/N).', false);
+			$question = new ConfirmationQuestion('Are you sure you want to empty the trashbin of your Team folders, this can not be undone (y/N).', false);
 			if (!$input->getOption('force') && !$helper->ask($input, $output, $question)) {
 				return -1;
 			}

--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -205,13 +205,13 @@ class ACLPlugin extends ServerPlugin {
 			$formattedRules = array_map(fn (Rule $rule): string => $rule->getUserMapping()->getType() . ' ' . $rule->getUserMapping()->getDisplayName() . ': ' . $rule->formatPermissions(), $rules);
 			if (count($formattedRules)) {
 				$formattedRules = implode(', ', $formattedRules);
-				$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The advanced permissions for "%s" in groupfolder with id %d was set to "%s"', [
+				$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The advanced permissions for "%s" in Team folder with id %d was set to "%s"', [
 					$fileInfo->getInternalPath(),
 					$mount->getFolderId(),
 					$formattedRules,
 				]));
 			} else {
-				$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The advanced permissions for "%s" in groupfolder with id %d was cleared', [
+				$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The advanced permissions for "%s" in Team folder with id %d was cleared', [
 					$fileInfo->getInternalPath(),
 					$mount->getFolderId(),
 				]));

--- a/lib/Migration/Version104000Date20180918132853.php
+++ b/lib/Migration/Version104000Date20180918132853.php
@@ -18,7 +18,7 @@ class Version104000Date20180918132853 extends SimpleMigrationStep {
 	}
 
 	public function description(): string {
-		return 'Adds table to store trashbin information for group folders';
+		return 'Adds table to store trashbin information for Team folders';
 	}
 
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {

--- a/lib/Migration/Version201000Date20190111132839.php
+++ b/lib/Migration/Version201000Date20190111132839.php
@@ -18,7 +18,7 @@ class Version201000Date20190111132839 extends SimpleMigrationStep {
 	}
 
 	public function description(): string {
-		return 'Adds table to store ACL information for group folders';
+		return 'Adds table to store ACL information for Team folders';
 	}
 
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {

--- a/lib/Settings/Section.php
+++ b/lib/Settings/Section.php
@@ -23,7 +23,7 @@ class Section implements IIconSection {
 	}
 
 	public function getName(): string {
-		return $this->l->t('Group folders');
+		return $this->l->t('Team folders');
 	}
 
 	public function getPriority(): int {

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -101,7 +101,7 @@ class TrashBackend implements ITrashBackend {
 	 */
 	public function restoreItem(ITrashItem $item): void {
 		if (!($item instanceof GroupTrashItem)) {
-			throw new \LogicException('Trying to restore normal trash item in group folder trash backend');
+			throw new \LogicException('Trying to restore normal trash item in Team folder trash backend');
 		}
 
 		$user = $item->getUser();
@@ -203,7 +203,7 @@ class TrashBackend implements ITrashBackend {
 	 */
 	public function removeItem(ITrashItem $item): void {
 		if (!($item instanceof GroupTrashItem)) {
-			throw new \LogicException('Trying to remove normal trash item in group folder trash backend');
+			throw new \LogicException('Trying to remove normal trash item in Team folder trash backend');
 		}
 
 		$user = $item->getUser();
@@ -268,7 +268,7 @@ class TrashBackend implements ITrashBackend {
 					$storage->getCache()->remove($internalPath);
 				}
 			} else {
-				throw new \Exception('Failed to move groupfolder item to trash');
+				throw new \Exception('Failed to move Team folder item to trash');
 			}
 
 			return true;

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -63,7 +63,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 			/** @var GroupFolderStorage $storage */
 			return $storage->getFolderId();
 		}
-		throw new \LogicException('groupfolder version backend called for non groupfolder file');
+		throw new \LogicException('Team folder version backend called for non Team folder file');
 	}
 
 	public function getVersionFolderForFile(FileInfo $file): Folder {
@@ -106,7 +106,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 			$versionsOnFS = $versionsFolder->getDirectoryListing();
 			foreach ($versionsOnFS as $version) {
 				if ($version instanceof Folder) {
-					$this->logger->error('Found an unexpected subfolder inside the groupfolder version folder.');
+					$this->logger->error('Found an unexpected subfolder inside the Team folder version folder.');
 				}
 
 				$versionEntity = new GroupVersionEntity();
@@ -205,7 +205,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 
 	public function rollback(IVersion $version): void {
 		if (!($version instanceof GroupVersion)) {
-			throw new \LogicException('Trying to restore a version from a file not in a group folder');
+			throw new \LogicException('Trying to restore a version from a file not in a Team folder');
 		}
 
 		if (!$this->currentUserHasPermissions($version->getSourceFile(), \OCP\Constants::PERMISSION_UPDATE)) {

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "groupfolders",
         "version": "0.0.1",
-        "description": "Admin configured folders shared with everyone in a group",
+        "description": "Admin configured folders shared with everyone in a team",
         "license": {
             "name": "agpl"
         }

--- a/src/actions/openGroupfolderAction.ts
+++ b/src/actions/openGroupfolderAction.ts
@@ -9,7 +9,7 @@ import { t } from '@nextcloud/l10n'
 
 export const action = new FileAction({
 	id: 'open-group-folders',
-	displayName: () => t('files', 'Open group folder'),
+	displayName: () => t('files', 'Open Team folder'),
 	iconSvgInline: () => '',
 
 	enabled: (files, view) => view.id === appName,

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -12,7 +12,7 @@
 			<thead>
 				<tr>
 					<th />
-					<th>{{ t('groupfolders', 'Group folder') }}</th>
+					<th>{{ t('groupfolders', 'Team folder') }}</th>
 					<th v-tooltip="t('groupfolders', 'Read')" class="state-column">
 						{{ t('groupfolders', 'Read') }}
 					</th>

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,11 +15,11 @@ registerFileAction(openGroupfolderAction)
 const Navigation = getNavigation()
 Navigation.register(new View({
 	id: appName,
-	name: t('groupfolders', 'Group folders'),
-	caption: t('groupfolders', 'List of group folders.'),
+	name: t('groupfolders', 'Team folders'),
+	caption: t('groupfolders', 'List of Team folders.'),
 
-	emptyTitle: t('groupfolders', 'No group folders yet'),
-	emptyCaption: t('groupfolders', 'Group folders will show up here'),
+	emptyTitle: t('groupfolders', 'No Team folders yet'),
+	emptyCaption: t('groupfolders', 'Team folders will show up here'),
 
 	icon: GroupFolderSvg,
 	order: 20,

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -184,16 +184,16 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 	showAdminDelegationForms() {
 		if (this.state.isAdminNextcloud && this.state.checkAppsInstalled) {
 			return <div id="groupfolders-admin-delegation">
-				<h3>{ t('groupfolders', 'Group folder admin delegation') }</h3>
-				<p><em>{ t('groupfolders', 'Nextcloud allows you to delegate the administration of group folders to non-admin users.') }</em></p>
-				<p><em>{ t('groupfolders', 'Specify below the groups that will be allowed to manage group folders and use its API/REST.') }</em></p>
-				<p className="end-description-delegation"><em>{ t('groupfolders', 'They will have access to all group folders.') }</em></p>
+				<h3>{ t('groupfolders', 'Team folder admin delegation') }</h3>
+				<p><em>{ t('groupfolders', 'Nextcloud allows you to delegate the administration of Team folders to non-admin users.') }</em></p>
+				<p><em>{ t('groupfolders', 'Specify below the groups that will be allowed to manage Team folders and use its API/REST.') }</em></p>
+				<p className="end-description-delegation"><em>{ t('groupfolders', 'They will have access to all Team folders.') }</em></p>
 				<AdminGroupSelect
 					groups={this.state.groups}
 					allGroups={this.state.groups}
 					delegatedAdminGroups={this.state.delegatedAdminGroups} />
-				<p><em>{ t('groupfolders', 'Specify below the groups that will be allowed to manage group folders and use its API/REST only.') }</em></p>
-				<p className="end-description-delegation"><em>{ t('groupfolders', 'They will only have access to group folders for which they have advanced permissions.') }</em></p>
+				<p><em>{ t('groupfolders', 'Specify below the groups that will be allowed to manage Team folders and use its API/REST only.') }</em></p>
+				<p className="end-description-delegation"><em>{ t('groupfolders', 'They will only have access to Team folders for which they have advanced permissions.') }</em></p>
 				<SubAdminGroupSelect
 					groups={this.state.groups}
 					allGroups={this.state.groups}

--- a/templates/index.php
+++ b/templates/index.php
@@ -7,7 +7,7 @@
 <div id="searchresults" style="display: none"></div>
 <div id="groupfolders-wrapper">
 	<h2>
-		<?php p($l->t('Group folders')); ?>
+		<?php p($l->t('Team folders')); ?>
 	</h2>
 	<div id="groupfolders-root"/>
 </div>


### PR DESCRIPTION
Closes https://github.com/nextcloud/groupfolders/issues/3524

I hope I found all the user-facing strings.
I also made the names for consistent, so all variations of "groupfolders", "group folders", "Group folders" and "Groupfolders" are just "Team folders" now.