### PR TITLE
fix: Prefer mount owner over current user as owner of the storage

### DIFF
--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -39,12 +39,16 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 	}
 
 	public function getOwner(string $path): string|false {
+		if ($this->mountOwner !== null) {
+			return $this->mountOwner->getUID();
+		}
+
 		$user = $this->userSession->getUser();
 		if ($user !== null) {
 			return $user->getUID();
 		}
 
-		return $this->mountOwner !== null ? $this->mountOwner->getUID() : false;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/40090#issuecomment-2365144379

This pull request fixes an issue where the current user is wrongly assumed as the storage owner. This then may lead to the files_versions app not being able to store a version properly, ending up with a file that cannot be saved in a rather specific scenario:

Steps to reproduce:

- user A has access to the group folder, creates a share link with write permission
- user B has no access to the group folder and opens the share link, edits and tries to save with Collabora 

I'm not sure if there is a case where this could also be triggered without collabora.

We set userB in richdocuments as the active user
https://github.com/nextcloud/richdocuments/blob/b4b76b4b326005eb469b13643bfe7e2d9fdcb580/lib/Controller/WopiController.php#L436

This then later on fails when files_versions tries to get  path for the node:
https://github.com/nextcloud/server/blob/369274c9ee82eed6010a1a3b9cc5bac1a9926e2c/apps/files_versions/lib/Listener/FileEventsListener.php#L374-L383

For the mountpoint of a share we should still assume the mount owner as the storage owner instead of always taking the current user. Using the user from the session used to be the fallback for any storage that does have shared ownership, but we can be more specific here with the mount owner.