### PR TITLE
include circles to acl

### DIFF
--- a/lib/ACL/UserMapping/IUserMapping.php
+++ b/lib/ACL/UserMapping/IUserMapping.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\ACL\UserMapping;
 
 interface IUserMapping {
-	/** @return 'user'|'group'|'dummy' */
+	/** @return 'user'|'group'|'dummy'|'circle' */
 	public function getType(): string;
 
 	public function getId(): string;

--- a/lib/ACL/UserMapping/IUserMapping.php
+++ b/lib/ACL/UserMapping/IUserMapping.php
@@ -15,4 +15,6 @@ interface IUserMapping {
 	public function getId(): string;
 
 	public function getDisplayName(): string;
+
+	public function getKey(): string;
 }

--- a/lib/ACL/UserMapping/IUserMappingManager.php
+++ b/lib/ACL/UserMapping/IUserMappingManager.php
@@ -18,4 +18,13 @@ interface IUserMappingManager {
 	public function getMappingsForUser(IUser $user, bool $userAssignable = true): array;
 
 	public function mappingFromId(string $type, string $id): ?IUserMapping;
+
+	/**
+	 * Check if a user is a member of one of the provided user mappings
+	 *
+	 * @param IUser $user
+	 * @param IUserMapping[] $mappings
+	 * @return bool
+	 */
+	public function userInMappings(IUser $user, array $mappings): bool;
 }

--- a/lib/ACL/UserMapping/UserMapping.php
+++ b/lib/ACL/UserMapping/UserMapping.php
@@ -33,4 +33,8 @@ class UserMapping implements IUserMapping {
 	public function getDisplayName(): string {
 		return $this->displayName;
 	}
+
+	public function getKey(): string {
+		return $this->getType() . ':' . $this->getId();
+	}
 }

--- a/lib/ACL/UserMapping/UserMapping.php
+++ b/lib/ACL/UserMapping/UserMapping.php
@@ -12,7 +12,7 @@ class UserMapping implements IUserMapping {
 	private readonly string $displayName;
 
 	/**
-	 * @param 'user'|'group'|'dummy' $type
+	 * @param 'user'|'group'|'dummy'|'circle' $type
 	 */
 	public function __construct(
 		private readonly string $type,

--- a/lib/ACL/UserMapping/UserMappingManager.php
+++ b/lib/ACL/UserMapping/UserMappingManager.php
@@ -8,33 +8,109 @@ declare(strict_types=1);
 
 namespace OCA\GroupFolders\ACL\UserMapping;
 
+use OCA\Circles\CirclesManager;
+use OCA\Circles\Exceptions\CircleNotFoundException;
+use OCA\Circles\Model\Circle;
+use OCA\Circles\Model\Probes\CircleProbe;
+use OCP\AutoloadNotAllowedException;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Log\LoggerInterface;
 
 class UserMappingManager implements IUserMappingManager {
 	public function __construct(
 		private readonly IGroupManager $groupManager,
 		private readonly IUserManager $userManager,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
 	public function getMappingsForUser(IUser $user, bool $userAssignable = true): array {
 		$groupMappings = array_values(array_map(fn (IGroup $group): UserMapping => new UserMapping('group', $group->getGID(), $group->getDisplayName()), $this->groupManager->getUserGroups($user)));
+		$circleMappings = array_values(array_map(fn (Circle $circle): UserMapping => new UserMapping('circle', $circle->getSingleId(), $circle->getDisplayName()), $this->getUserCircles($user->getUID())));
 
 		return array_merge([
 			new UserMapping('user', $user->getUID(), $user->getDisplayName()),
-		], $groupMappings);
+		], $groupMappings, $circleMappings);
 	}
 
 	public function mappingFromId(string $type, string $id): ?IUserMapping {
-		$mappingObject = ($type === 'group' ? $this->groupManager : $this->userManager)->get($id);
-		if ($mappingObject) {
-			$displayName = $mappingObject->getDisplayName();
-			/** @var 'user'|'group' $type */
-			return new UserMapping($type, $id, $displayName);
-		} else {
+		switch ($type) {
+			case 'group':
+				$displayName = $this->groupManager->get($id)?->getDisplayName();
+				break;
+			case 'user':
+				$displayName = $this->userManager->get($id)?->getDisplayName();
+				break;
+			case 'circle':
+				$displayName = $this->getCircle($id)?->getDisplayName();
+				break;
+			default:
+				return null;
+		}
+		if ($displayName === null) {
+			return null;
+		}
+
+		return new UserMapping($type, $id, $displayName);
+	}
+
+
+
+	/**
+	 * returns the Circle from its single Id, or NULL if not available
+	 */
+	private function getCircle(string $groupId): ?Circle {
+		$circlesManager = $this->getCirclesManager();
+		if ($circlesManager === null) {
+			return null;
+		}
+
+		$circlesManager->startSuperSession();
+		$probe = new CircleProbe();
+		$probe->includeSystemCircles();
+		$probe->includeSingleCircles();
+		try {
+			return $circlesManager->getCircle($groupId, $probe);
+		} catch (CircleNotFoundException) {
+		} catch (\Exception $e) {
+			$this->logger->warning('', ['exception' => $e]);
+		} finally {
+			$circlesManager->stopSession();
+		}
+
+		return null;
+	}
+
+	/**
+	 * returns list of circles a user is member of
+	 */
+	private function getUserCircles(string $userId): array {
+		$circlesManager = $this->getCirclesManager();
+		if ($circlesManager === null) {
+			return [];
+		}
+
+		$circlesManager->startSession($circlesManager->getLocalFederatedUser($userId));
+		try {
+			return $circlesManager->probeCircles();
+		} catch (\Exception $e) {
+			$this->logger->warning('', ['exception' => $e]);
+		} finally {
+			$circlesManager->stopSession();
+		}
+
+		return [];
+	}
+
+	public function getCirclesManager(): ?CirclesManager {
+		try {
+			return Server::get(CirclesManager::class);
+		} catch (ContainerExceptionInterface|AutoloadNotAllowedException) {
 			return null;
 		}
 	}

--- a/lib/ACL/UserMapping/UserMappingManager.php
+++ b/lib/ACL/UserMapping/UserMappingManager.php
@@ -114,4 +114,22 @@ class UserMappingManager implements IUserMappingManager {
 			return null;
 		}
 	}
+
+	public function userInMappings(IUser $user, array $mappings): bool {
+		foreach ($mappings as $mapping) {
+			if ($mapping->getType() === 'user' && $mapping->getId() === $user->getUID()) {
+				return true;
+			}
+		}
+
+		$mappingKeys = array_map(fn (IUserMapping $mapping) => $mapping->getKey(), $mappings);
+
+		$userMappings = $this->getMappingsForUser($user);
+		foreach ($userMappings as $userMapping) {
+			if (in_array($userMapping->getKey(), $mappingKeys, true)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -106,7 +106,7 @@ class ListCommand extends Base {
 				}, array_keys($folder['groups']), array_values($folder['groups']));
 				$folder['groups'] = implode("\n", $groupStrings);
 				$folder['acl'] = $folder['acl'] ? 'Enabled' : 'Disabled';
-				$manageStrings = array_map(fn (array $manage): string => $manage['id'] . ' (' . $manage['type'] . ')', $folder['manage']);
+				$manageStrings = array_map(fn (array $manage): string => $manage['displayname'] . ' (' . $manage['type'] . ')', $folder['manage']);
 				$folder['manage'] = implode("\n", $manageStrings);
 
 				return $folder;

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -30,6 +30,7 @@ use OCP\IUserSession;
 
 /**
  * @psalm-import-type GroupFoldersGroup from ResponseDefinitions
+ * @psalm-import-type GroupFoldersCircle from ResponseDefinitions
  * @psalm-import-type GroupFoldersUser from ResponseDefinitions
  * @psalm-import-type GroupFoldersFolder from ResponseDefinitions
  * @psalm-import-type InternalFolderOut from FolderManager
@@ -474,7 +475,7 @@ class FolderController extends OCSController {
 	 *
 	 * @param int $id The ID of the Groupfolder
 	 * @param string $search String to search by
-	 * @return DataResponse<Http::STATUS_OK, array{users: list<GroupFoldersUser>, groups: list<GroupFoldersGroup>}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{users: list<GroupFoldersUser>, groups: list<GroupFoldersGroup>, circles: list<GroupFoldersCircle>}, array{}>
 	 * @throws OCSForbiddenException Not allowed to search
 	 *
 	 * 200: ACL Mappings returned
@@ -482,8 +483,7 @@ class FolderController extends OCSController {
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}/search')]
 	public function aclMappingSearch(int $id, string $search = ''): DataResponse {
-		$users = [];
-		$groups = [];
+		$users = $groups = $circles = [];
 
 		if ($this->user === null) {
 			throw new OCSForbiddenException();
@@ -492,11 +492,13 @@ class FolderController extends OCSController {
 		if ($this->manager->canManageACL($id, $this->user) === true) {
 			$groups = $this->manager->searchGroups($id, $search);
 			$users = $this->manager->searchUsers($id, $search);
+			$circles = $this->manager->searchCircles($id, $search);
 		}
 
 		return new DataResponse([
 			'users' => $users,
 			'groups' => $groups,
+			'circles' => $circles
 		]);
 	}
 }

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -23,6 +23,11 @@ namespace OCA\GroupFolders;
  *     displayname: string,
  * }
  *
+ * @psalm-type GroupFoldersCircle = array{
+ *     sid: string,
+ *     displayname: string,
+ * }
+ *
  * @psalm-type GroupFoldersUser = array{
  *     uid: string,
  *     displayname: string,
@@ -31,7 +36,7 @@ namespace OCA\GroupFolders;
  * @psalm-type GroupFoldersAclManage = array{
  *     displayname: string,
  *     id: string,
- *     type: 'user'|'group',
+ *     type: 'user'|'group'|'circle',
  * }
  *
  * @psalm-type GroupFoldersApplicable = array{

--- a/openapi.json
+++ b/openapi.json
@@ -38,7 +38,8 @@
                         "type": "string",
                         "enum": [
                             "user",
-                            "group"
+                            "group",
+                            "circle"
                         ]
                     }
                 }
@@ -84,6 +85,21 @@
                                 "type": "boolean"
                             }
                         }
+                    }
+                }
+            },
+            "Circle": {
+                "type": "object",
+                "required": [
+                    "sid",
+                    "displayname"
+                ],
+                "properties": {
+                    "sid": {
+                        "type": "string"
+                    },
+                    "displayname": {
+                        "type": "string"
                     }
                 }
             },
@@ -1939,7 +1955,8 @@
                                                     "type": "object",
                                                     "required": [
                                                         "users",
-                                                        "groups"
+                                                        "groups",
+                                                        "circles"
                                                     ],
                                                     "properties": {
                                                         "users": {
@@ -1952,6 +1969,12 @@
                                                             "type": "array",
                                                             "items": {
                                                                 "$ref": "#/components/schemas/Group"
+                                                            }
+                                                        },
+                                                        "circles": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "$ref": "#/components/schemas/Circle"
                                                             }
                                                         }
                                                     }

--- a/psalm.xml
+++ b/psalm.xml
@@ -66,11 +66,13 @@
 		<file name="tests/stubs/oca_circles_exceptions_federateditemexception.php" />
 		<file name="tests/stubs/oca_circles_exceptions_federateditemnotfoundexception.php" />
 		<file name="tests/stubs/oca_circles_ientity.php" />
+		<file name="tests/stubs/oca_circles_ifederatedmodel.php" />
 		<file name="tests/stubs/oca_circles_ifederateduser.php" />
 		<file name="tests/stubs/oca_circles_iqueryprobe.php" />
 		<file name="tests/stubs/oca_circles_model_circle.php" />
 		<file name="tests/stubs/oca_circles_model_federateduser.php" />
 		<file name="tests/stubs/oca_circles_model_managedmodel.php" />
+		<file name="tests/stubs/oca_circles_model_member.php" />
 		<file name="tests/stubs/oca_circles_model_probes_basicprobe.php" />
 		<file name="tests/stubs/oca_circles_model_probes_circleprobe.php" />
 		<file name="tests/stubs/oca_circles_model_probes_memberprobe.php" />

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -267,6 +267,9 @@ export default {
 			if (type === 'group') {
 				return `${displayName} (${t('groupfolders', 'Group')})`
 			}
+			if (type === 'circle') {
+				return `${displayName} (${t('groupfolders', 'Team')})`
+			}
 
 			return displayName
 		},
@@ -298,7 +301,16 @@ export default {
 						label: this.getFullDisplayName(user.displayname, 'user'),
 					}
 				})
-				this.options = [...groups, ...users].filter((entry) => {
+				const circles = Object.values(result.data.ocs.data.circles).map((user) => {
+					return {
+						unique: 'circle:' + user.sid,
+						type: 'circle',
+						id: user.sid,
+						displayname: user.displayname,
+						label: this.getFullDisplayName(user.displayname, 'circle'),
+					}
+				})
+				this.options = [...groups, ...users, ...circles].filter((entry) => {
 					// filter out existing acl rules
 					return !this.list.find((existingAcl) => entry.unique === existingAcl.getUniqueMappingIdentifier())
 				})

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -7,7 +7,7 @@ import axios from '@nextcloud/axios'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 // eslint-disable-next-line n/no-unpublished-import
 import type { OCSResponse } from '@nextcloud/typings/lib/ocs'
-import type { Folder, Group, User, AclManage, DelegationCircle, DelegationGroup } from '../types'
+import type {Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle} from '../types'
 
 export class Api {
 
@@ -109,9 +109,10 @@ export class Api {
 
 	async aclMappingSearch(folderId: number, search: string): Promise<{
 		groups: AclManage[],
-		users: AclManage[]
+		users: AclManage[],
+		circles: AclManage[],
 	}> {
-		const response = await axios.get<OCSResponse<{groups: Group[], users: User[]}>>(this.getUrl(`folders/${folderId}/search`), { params: { search } })
+		const response = await axios.get<OCSResponse<{groups: Group[], users: User[], circles: Circle[]}>>(this.getUrl(`folders/${folderId}/search`), { params: { search } })
 		return {
 			groups: Object.values(response.data.ocs.data.groups).map((item) => {
 				return {
@@ -124,6 +125,13 @@ export class Api {
 				return {
 					type: 'user',
 					id: item.uid,
+					displayname: item.displayname,
+				}
+			}),
+			circles: Object.values(response.data.ocs.data.circles).map((item) => {
+				return {
+					type: 'circle',
+					id: item.sid,
 					displayname: item.displayname,
 				}
 			}),

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -7,7 +7,7 @@ import axios from '@nextcloud/axios'
 import { confirmPassword } from '@nextcloud/password-confirmation'
 // eslint-disable-next-line n/no-unpublished-import
 import type { OCSResponse } from '@nextcloud/typings/lib/ocs'
-import type {Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle} from '../types'
+import type { Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle } from '../types'
 
 export class Api {
 

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -369,18 +369,27 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 interface ManageAclSelectProps {
 	folder: Folder;
 	onChange: (type: string, id: string, manageAcl: boolean) => void;
-	onSearch: (name: string) => Promise<{ groups: AclManage[]; users: AclManage[]; }>;
+	onSearch: (name: string) => Promise<{ groups: AclManage[]; users: AclManage[]; circles: AclManage[] }>;
 }
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 function ManageAclSelect({ onChange, onSearch, folder }: ManageAclSelectProps) {
 	const handleSearch = async (inputValue: string) => {
 		const result = await onSearch(inputValue)
-		return [...result.groups, ...result.users]
+		return [...result.groups, ...result.users, ...result.circles]
 	}
 
-	const typeLabel = (item) => {
-		return item.type === 'user' ? t('groupfolders', 'User') : t('groupfolders', 'Group')
+	const typeLabel = (item: AclManage) => {
+		switch (item.type) {
+			case "circle":
+				return t('groupfolders', 'Team');
+			case "group":
+				return t('groupfolders', 'Group');
+			case "user":
+				return t('groupfolders', 'User');
+			default:
+				return t('groupfolders', 'Unknown');
+		}
 	}
 
 	return <AsyncSelect

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -381,14 +381,14 @@ function ManageAclSelect({ onChange, onSearch, folder }: ManageAclSelectProps) {
 
 	const typeLabel = (item: AclManage) => {
 		switch (item.type) {
-			case "circle":
-				return t('groupfolders', 'Team');
-			case "group":
-				return t('groupfolders', 'Group');
-			case "user":
-				return t('groupfolders', 'User');
-			default:
-				return t('groupfolders', 'Unknown');
+		case 'circle':
+			return t('groupfolders', 'Team')
+		case 'group':
+			return t('groupfolders', 'Group')
+		case 'user':
+			return t('groupfolders', 'User')
+		default:
+			return t('groupfolders', 'Unknown')
 		}
 	}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,5 +10,6 @@ export type DelegationCircle = components['schemas']['DelegationCircle'];
 export type Folder = components['schemas']['Folder'];
 export type Group = components['schemas']['Group'];
 export type User = components['schemas']['User'];
+export type Circle = components['schemas']['Circle'];
 export type AclManage = components['schemas']['AclManage'];
 export type Applicable = components['schemas']['Applicable'];

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -250,7 +250,7 @@ export type components = {
             displayname: string;
             id: string;
             /** @enum {string} */
-            type: "user" | "group";
+            type: "user" | "group" | "circle";
         };
         Applicable: {
             displayName: string;
@@ -264,6 +264,10 @@ export type components = {
                 appVersion: string;
                 hasGroupFolders: boolean;
             };
+        };
+        Circle: {
+            sid: string;
+            displayname: string;
         };
         DelegationCircle: {
             singleId: string;
@@ -1053,6 +1057,7 @@ export interface operations {
                             data: {
                                 users: components["schemas"]["User"][];
                                 groups: components["schemas"]["Group"][];
+                                circles: components["schemas"]["Circle"][];
                             };
                         };
                     };

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -6,6 +6,7 @@
 
 namespace OCA\GroupFolders\Tests\Folder;
 
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCP\Constants;
@@ -33,6 +34,7 @@ class FolderManagerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 	private IEventDispatcher&MockObject $eventDispatcher;
 	private IConfig&MockObject $config;
+	private IUserMappingManager&MockObject $userMappingManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,6 +44,7 @@ class FolderManagerTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->userMappingManager = $this->createMock(IUserMappingManager::class);
 		$this->manager = new FolderManager(
 			Server::get(IDBConnection::class),
 			$this->groupManager,
@@ -49,6 +52,7 @@ class FolderManagerTest extends TestCase {
 			$this->logger,
 			$this->eventDispatcher,
 			$this->config,
+			$this->userMappingManager,
 		);
 		$this->clean();
 	}
@@ -368,7 +372,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserSimple(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -390,7 +394,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -425,7 +429,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFolderPermissionsForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 

--- a/tests/stubs/oca_circles_ifederatedmodel.php
+++ b/tests/stubs/oca_circles_ifederatedmodel.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+namespace OCA\Circles;
+
+use OCA\Circles\Model\Circle;
+
+/**
+ * Interface IFederatedUser
+ *
+ * @package OCA\Circles
+ */
+interface IFederatedModel {
+	public function getInstance(): string {
+	}
+	public function isLocal(): bool{
+	}
+}

--- a/tests/stubs/oca_circles_model_member.php
+++ b/tests/stubs/oca_circles_model_member.php
@@ -1,0 +1,620 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+namespace OCA\Circles\Model;
+
+use DateTime;
+use JsonSerializable;
+use OCA\Circles\AppInfo\Capabilities;
+use OCA\Circles\Exceptions\MemberNotFoundException;
+use OCA\Circles\Exceptions\MembershipNotFoundException;
+use OCA\Circles\Exceptions\ParseMemberLevelException;
+use OCA\Circles\Exceptions\RequestBuilderException;
+use OCA\Circles\Exceptions\UnknownInterfaceException;
+use OCA\Circles\Exceptions\UserTypeNotFoundException;
+use OCA\Circles\IEntity;
+use OCA\Circles\IFederatedUser;
+use OCA\Circles\Model\Federated\RemoteInstance;
+use OCA\Circles\Tools\Db\IQueryRow;
+use OCA\Circles\Tools\Exceptions\InvalidItemException;
+use OCA\Circles\Tools\IDeserializable;
+use OCA\Circles\Tools\Traits\TArrayTools;
+use OCA\Circles\Tools\Traits\TDeserialize;
+
+/**
+ * Class Member
+ *
+ * @package OCA\Circles\Model
+ */
+class Member extends ManagedModel implements
+	IEntity,
+	IFederatedUser,
+	IDeserializable,
+	IQueryRow,
+	JsonSerializable {
+	use TArrayTools;
+	use TDeserialize;
+
+
+	public const LEVEL_NONE = 0;
+	public const LEVEL_MEMBER = 1;
+	public const LEVEL_MODERATOR = 4;
+	public const LEVEL_ADMIN = 8;
+	public const LEVEL_OWNER = 9;
+
+	public const TYPE_SINGLE = 0;
+	public const TYPE_USER = 1;
+	public const TYPE_GROUP = 2;
+	public const TYPE_MAIL = 4;
+	public const TYPE_CONTACT = 8;
+	public const TYPE_CIRCLE = 16;
+	public const TYPE_APP = 10000;
+
+	public const ALLOWING_ALL_TYPES = 31;
+
+	public const APP_CIRCLES = 10001;
+	public const APP_OCC = 10002;
+	public const APP_DEFAULT = 11000;
+
+
+	public static $TYPE = [
+		0 => 'single',
+		1 => 'user',
+		2 => 'group',
+		4 => 'mail',
+		8 => 'contact',
+		16 => 'circle',
+		10000 => 'app'
+	];
+
+	/**
+	 * Note: When editing those values, update lib/Application/Capabilities.php
+	 *
+	 * @see Capabilities::generateConstantsMember()
+	 */
+	public const STATUS_INVITED = 'Invited';
+	public const STATUS_REQUEST = 'Requesting';
+	public const STATUS_MEMBER = 'Member';
+	public const STATUS_BLOCKED = 'Blocked';
+
+
+	/**
+	 * Note: When editing those values, update lib/Application/Capabilities.php
+	 *
+	 * @see Capabilities::generateConstantsMember()
+	 * @var array
+	 */
+	public static $DEF_LEVEL = [
+		1 => 'Member',
+		4 => 'Moderator',
+		8 => 'Admin',
+		9 => 'Owner'
+	];
+
+
+	public static $DEF_TYPE_MAX = 31;
+
+	/**
+	 * Member constructor.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * @param string $id
+	 *
+	 * @return $this
+	 */
+	public function setId(string $id): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getId(): string {
+	}
+
+
+	/**
+	 * @param string $circleId
+	 *
+	 * @return Member
+	 */
+	public function setCircleId(string $circleId): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCircleId(): string {
+	}
+
+
+	/**
+	 * This should replace user_id, user_type and instance; and will use the data from Circle with
+	 * Config=CFG_SINGLE
+	 *
+	 * @param string $singleId
+	 *
+	 * @return $this
+	 */
+	public function setSingleId(string $singleId): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSingleId(): string {
+	}
+
+
+	/**
+	 * @param string $userId
+	 *
+	 * @return Member
+	 */
+	public function setUserId(string $userId): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getUserId(): string {
+	}
+
+
+	/**
+	 * @param int $userType
+	 *
+	 * @return Member
+	 */
+	public function setUserType(int $userType): self {
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getUserType(): int {
+	}
+
+	/**
+	 * @return int
+	 * @deprecated 22.0.0 Use `getUserType()` instead
+	 */
+	public function getType(): int {
+	}
+
+
+	/**
+	 * @param string $instance
+	 *
+	 * @return Member
+	 */
+	public function setInstance(string $instance): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getInstance(): string {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function isLocal(): bool {
+	}
+
+
+	/**
+	 * @param FederatedUser $invitedBy
+	 *
+	 * @return Member
+	 */
+	public function setInvitedBy(FederatedUser $invitedBy): Member {
+	}
+
+	/**
+	 * @return FederatedUser
+	 */
+	public function getInvitedBy(): FederatedUser {
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasInvitedBy(): bool {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasRemoteInstance(): bool {
+	}
+
+	/**
+	 * @param RemoteInstance $remoteInstance
+	 *
+	 * @return Member
+	 */
+	public function setRemoteInstance(RemoteInstance $remoteInstance): self {
+	}
+
+	/**
+	 * @return RemoteInstance
+	 */
+	public function getRemoteInstance(): RemoteInstance {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasBasedOn(): bool {
+	}
+
+	/**
+	 * @param Circle $basedOn
+	 *
+	 * @return $this
+	 */
+	public function setBasedOn(Circle $basedOn): self {
+	}
+
+	/**
+	 * @return Circle
+	 */
+	public function getBasedOn(): Circle {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasInheritedBy(): bool {
+	}
+
+	/**
+	 * @param FederatedUser $inheritedBy
+	 *
+	 * @return $this
+	 */
+	public function setInheritedBy(FederatedUser $inheritedBy): self {
+	}
+
+	/**
+	 * @return FederatedUser
+	 */
+	public function getInheritedBy(): FederatedUser {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasInheritanceFrom(): bool {
+	}
+
+	/**
+	 * @param Member $inheritanceFrom
+	 *
+	 * @return $this
+	 */
+	public function setInheritanceFrom(Member $inheritanceFrom): self {
+	}
+
+	/**
+	 * @return Member|null
+	 */
+	public function getInheritanceFrom(): ?Member {
+	}
+
+
+	/**
+	 * @param int $level
+	 *
+	 * @return Member
+	 */
+	public function setLevel(int $level): self {
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getLevel(): int {
+	}
+
+
+	/**
+	 * @param string $status
+	 *
+	 * @return Member
+	 */
+	public function setStatus(string $status): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getStatus(): string {
+	}
+
+
+	/**
+	 * @param array $notes
+	 *
+	 * @return Member
+	 */
+	public function setNotes(array $notes): self {
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getNotes(): array {
+	}
+
+
+	/**
+	 * @param string $key
+	 *
+	 * @return string
+	 */
+	public function getNote(string $key): string {
+	}
+
+	/**
+	 * @param string $key
+	 *
+	 * @return array
+	 */
+	public function getNoteArray(string $key): array {
+	}
+
+	/**
+	 * @param string $key
+	 * @param string $note
+	 *
+	 * @return $this
+	 */
+	public function setNote(string $key, string $note): self {
+	}
+
+	/**
+	 * @param string $key
+	 * @param array $note
+	 *
+	 * @return $this
+	 */
+	public function setNoteArray(string $key, array $note): self {
+	}
+
+	/**
+	 * @param string $key
+	 * @param JsonSerializable $obj
+	 *
+	 * @return $this
+	 */
+	public function setNoteObj(string $key, JsonSerializable $obj): self {
+	}
+
+
+	/**
+	 * @param string $displayName
+	 *
+	 * @return Member
+	 */
+	public function setDisplayName(string $displayName): self {
+	}
+
+
+	/**
+	 * @param int $displayUpdate
+	 *
+	 * @return Member
+	 */
+	public function setDisplayUpdate(int $displayUpdate): self {
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getDisplayUpdate(): int {
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getDisplayName(): string {
+	}
+
+
+	/**
+	 * @param string $contactId
+	 *
+	 * @return Member
+	 */
+	public function setContactId(string $contactId): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getContactId(): string {
+	}
+
+
+	/**
+	 * @param string $contactMeta
+	 *
+	 * @return Member
+	 */
+	public function setContactMeta(string $contactMeta): self {
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getContactMeta(): string {
+	}
+
+
+	/**
+	 * @param Circle $circle
+	 *
+	 * @return self
+	 */
+	public function setCircle(Circle $circle): self {
+	}
+
+	/**
+	 * @return Circle
+	 */
+	public function getCircle(): Circle {
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasCircle(): bool {
+	}
+
+
+	/**
+	 * @param int $joined
+	 *
+	 * @return Member
+	 */
+	public function setJoined(int $joined): self {
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getJoined(): int {
+	}
+
+
+	/**
+	 * @return bool
+	 */
+	public function hasMemberships(): bool {
+	}
+
+	/**
+	 * @param array $memberships
+	 *
+	 * @return self
+	 */
+	public function setMemberships(array $memberships): IEntity {
+	}
+
+	/**
+	 * @return Membership[]
+	 */
+	public function getMemberships(): array {
+	}
+
+
+	/**
+	 * @param string $singleId
+	 * @param bool $detailed
+	 *
+	 * @return Membership
+	 * @throws MembershipNotFoundException
+	 * @throws RequestBuilderException
+	 */
+	public function getLink(string $singleId, bool $detailed = false): Membership {
+	}
+
+	/**
+	 * @param string $circleId
+	 * @param bool $detailed
+	 *
+	 * @return Membership
+	 * @throws MembershipNotFoundException
+	 * @throws RequestBuilderException
+	 * @deprecated - use getLink();
+	 */
+	public function getMembership(string $circleId, bool $detailed = false): Membership {
+	}
+
+
+	/**
+	 * @param Member $member
+	 * @param bool $full
+	 *
+	 * @return bool
+	 */
+	public function compareWith(Member $member, bool $full = true): bool {
+	}
+
+
+	/**
+	 * @param array $data
+	 *
+	 * @return $this
+	 * @throws InvalidItemException
+	 */
+	public function import(array $data): IDeserializable {
+	}
+
+
+	/**
+	 * @param array $data
+	 * @param string $prefix
+	 *
+	 * @return IQueryRow
+	 * @throws MemberNotFoundException
+	 */
+	public function importFromDatabase(array $data, string $prefix = ''): IQueryRow {
+	}
+
+
+	/**
+	 * @return string[]
+	 * @throws UnknownInterfaceException
+	 */
+	public function jsonSerialize(): array {
+	}
+
+
+	/**
+	 * @param int $level
+	 *
+	 * @return int
+	 * @throws ParseMemberLevelException
+	 */
+	public static function parseLevelInt(int $level): int {
+	}
+
+
+	/**
+	 * @param string $levelString
+	 *
+	 * @return int
+	 * @throws ParseMemberLevelException
+	 */
+	public static function parseLevelString(string $levelString): int {
+	}
+
+	/**
+	 * @param string $typeString
+	 *
+	 * @return int
+	 * @throws UserTypeNotFoundException
+	 */
+	public static function parseTypeString(string $typeString): int {
+	}
+}


### PR DESCRIPTION
This adds Teams to the ACL management:

- search will now returns Teams and Teams' members so that Circles can be added to the list of ACL Manager in the admin settings of the app,
- ACL rights about Teams and Teams' members can be set in the right panel when navigating a groupfolders' files,
- ACL set regarding a Teams and Teams' members are applied to files and folders.

Missing front-end:
- [x] In the admin part, while the Teams' member are displayed, the Teams are missing in the dropdown list when adding ACL Manager. This is due to the fact that the data stored behind the array key 'circles' are not managed by the javascript.
- [x] In the admin part, when displaying a Team, it is shown as 'Group' instead of 'Team'
- [x] In the Files' right panel, while the Teams' member are displayed, the Teams are not in the dropdown list when adding ACL Permissions. 