### PR TITLE
lighter request on circle memberships

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -634,9 +634,15 @@ class FolderManager {
 				'group_folders_groups',
 				'a',
 				$query->expr()->eq('f.folder_id', 'a.folder_id')
-			);
+			)
+			->where($query->expr()->neq('a.circle_id', $query->createNamedParameter('')));
 
-		$queryHelper->limitToInheritedMembers('a', 'circle_id', $federatedUser);
+		/** @psalm-suppress RedundantCondition */
+		if (method_exists($queryHelper, 'limitToMemberships')) {
+			$queryHelper->limitToMemberships('a', 'circle_id', $federatedUser);
+		} else {
+			$queryHelper->limitToInheritedMembers('a', 'circle_id', $federatedUser);
+		}
 		$this->joinQueryWithFileCache($query, $rootStorageId);
 
 		return array_map(fn (array $folder): array => [

--- a/lib/Migration/Version2000000Date20250128110101.php
+++ b/lib/Migration/Version2000000Date20250128110101.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+#[AddIndex('group_folders_groups', IndexType::INDEX, 'adding index on single circle id for better select')]
+class Version2000000Date20250128110101 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		// we recreate the unique key, including circle_id
+		$table = $schema->getTable('group_folders_groups');
+		if (!$table->hasIndex('groups_folder_circle')) {
+			$table->addIndex(['circle_id'], 'groups_folder_circle');
+		}
+
+		return $schema;
+	}
+}

--- a/tests/stubs/oca_circles_circlesqueryhelper.php
+++ b/tests/stubs/oca_circles_circlesqueryhelper.php
@@ -74,6 +74,10 @@ class CirclesQueryHelper {
  {
  }
 
+	public function limitToMemberships(string $alias, string $field, IFederatedUser $federatedUser): void
+ {
+ }
+
 
 	/**
 	 * @param string $field


### PR DESCRIPTION
linked to https://github.com/nextcloud/circles/pull/1851

- add index to `group_folders_groups`.`circle_id` alone
- avoid useless LEFT JOIN on request (if https://github.com/nextcloud/circles/pull/1851 applied)
- filters on empty circle_id to not search circles on _'group'_ groupfolders

new request:
```
SELECT
    `f`.`folder_id`,
[...]
    `a`.`permissions` AS `group_permissions`,
    `c`.`permissions` AS `permissions`
FROM
    `oc_group_folders` `f`
INNER JOIN `oc_group_folders_groups` `a` ON
    `f`.`folder_id` = `a`.`folder_id`
LEFT JOIN `oc_filecache` `c` ON
    (`c`.`name` = CONCAT(`f`.`folder_id`, '')) AND(`c`.`parent` = '185') AND(`c`.`storage` = '2')
INNER JOIN `oc_circles_membership` `w_j` ON
    (
        `w_j`.`single_id` = 'ysdjkgfhdslkjghalkj'
    ) AND(`w_j`.`circle_id` = `a`.`circle_id`)
WHERE
    `a`.`circle_id` <> ''
```