### PR TITLE
fix: catch some acl errors when listing trashbin

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -330,8 +330,13 @@ class TrashBackend implements ITrashBackend {
 		string $path,
 		int $permission = Constants::PERMISSION_READ,
 	): bool {
-		$activePermissions = $this->aclManagerFactory->getACLManager($user)
-			->getACLPermissionsForPath($path);
+		try {
+			$activePermissions = $this->aclManagerFactory->getACLManager($user)
+				->getACLPermissionsForPath($path);
+		} catch (\Exception $e) {
+			$this->logger->warning("Failed to get permissions for {$path}", ['exception' => $e]);
+			return false;
+		}
 
 		return (bool)($activePermissions & $permission);
 	}


### PR DESCRIPTION
Instead of fully breaking just don't show the failing item