### PR TITLE
[stable29] fix(trash): Fix deleting items from public share with write access

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -260,10 +260,7 @@ class TrashBackend implements ITrashBackend {
 			$name = basename($internalPath);
 			$fileEntry = $storage->getCache()->get($internalPath);
 			$folderId = $storage->getFolderId();
-			$user = $this->userSession->getUser();
-			if (!$user) {
-				throw new \Exception("file moved to trash with no user in context");
-			}
+
 			// ensure the folder exists
 			$this->getTrashFolder($folderId);
 


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/groupfolders/pull/3604

In 29 we don't have the `deleted_by` column we add, so I only had to remove the check for the user.