### PR TITLE
fix: add mount type to node info

### DIFF
--- a/src/services/groupfolders.ts
+++ b/src/services/groupfolders.ts
@@ -63,8 +63,9 @@ const resultToNode = function(node: FileStat): File | Folder {
 		attributes: {
 			...node,
 			...node.props,
-			previewUrl,
+			'mount-type': 'group',
 			mountPoint,
+			previewUrl,
 		},
 	}
 


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/groupfolders/issues/3650

This ensures the correct folder overlay icon is shown.