### PR TITLE
fix(ACLPlugin): Use correct path to test new permissions

### DIFF
--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -227,7 +227,7 @@ class ACLPlugin extends ServerPlugin {
 			}
 
 			$aclManager = $this->aclManagerFactory->getACLManager($this->user);
-			$newPermissions = $aclManager->testACLPermissionsForPath($fileInfo->getPath(), $rules);
+			$newPermissions = $aclManager->testACLPermissionsForPath($path, $rules);
 			if (!($newPermissions & Constants::PERMISSION_READ)) {
 				throw new BadRequest($this->l10n->t('You cannot remove your own read permission.'));
 			}


### PR DESCRIPTION
The rules are checked with the source path, but this was passing the path from the user storage.
This lead to the existing rules not being considered, so if you had one rule that gave you access to a folder and you changed another rule to deny you access, an error was thrown because only the changed rule was considered.