### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d8f9b556898f11d26f5884ea6754b840fa02335e"
+                "reference": "f54b33ec39e71dfd8376e5be4e9d97cc55245a48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d8f9b556898f11d26f5884ea6754b840fa02335e",
-                "reference": "d8f9b556898f11d26f5884ea6754b840fa02335e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f54b33ec39e71dfd8376e5be4e9d97cc55245a48",
+                "reference": "f54b33ec39e71dfd8376e5be4e9d97cc55245a48",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-03-07T00:46:02+00:00"
+            "time": "2025-03-20T00:45:48+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency