### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "e4789222e646a31e17ca8f982f7a1b31d0d45573"
+                "reference": "7e54c6d7f0f3880b3af30b58e0730d3da87c99e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e4789222e646a31e17ca8f982f7a1b31d0d45573",
-                "reference": "e4789222e646a31e17ca8f982f7a1b31d0d45573",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/7e54c6d7f0f3880b3af30b58e0730d3da87c99e0",
+                "reference": "7e54c6d7f0f3880b3af30b58e0730d3da87c99e0",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-03-29T00:46:25+00:00"
+            "time": "2025-04-02T00:48:32+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency