### PR TITLE
fix(dav): only list top-level groupfolders

### DIFF
--- a/lib/DAV/GroupFoldersHome.php
+++ b/lib/DAV/GroupFoldersHome.php
@@ -103,6 +103,12 @@ class GroupFoldersHome implements ICollection {
 		}
 
 		$folders = $this->folderManager->getFoldersForUser($this->user, $storageId);
+
+		// Filter out top-level folders only
+		$folders = array_filter($folders, function (array $folder) {
+			return !str_contains($folder['mount_point'], '/');
+		});
+
 		return array_map($this->getDirectoryForFolder(...), $folders);
 	}
 

--- a/lib/DAV/GroupFoldersHome.php
+++ b/lib/DAV/GroupFoldersHome.php
@@ -104,7 +104,7 @@ class GroupFoldersHome implements ICollection {
 
 		$folders = $this->folderManager->getFoldersForUser($this->user, $storageId);
 
-		// Filter out top-level folders only
+		// Filter out non top-level folders
 		$folders = array_filter($folders, function (array $folder) {
 			return !str_contains($folder['mount_point'], '/');
 		});


### PR DESCRIPTION
You can have multiple folders with the same name
You can also have many of those same names nested into other sub-groupfolders.
Example:

```
├── TeamFolder1
│   ├── TeamFolder1
│   ├── TeamFolder2
│   ├── TeamFolder3
│   ├── TeamFolder4
│   └── TeamFolder5
└── TeamFolder2
    ├── TeamFolder1
    ├── TeamFolder2
    ├── TeamFolder3
    ├── TeamFolder4
    └── TeamFolder5
```

## Resolution:
1. We now only show top-level groupfolders, as clicking one will show the children anyway
2. We now group them by source name, and use the groupfolder ID instead of the mountpoint to generate their source. Making them truly unique
