### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4683,9 +4683,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.25.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
-      "integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
+      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -13325,9 +13325,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 20 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/password-confirmation](#user-content-\@nextcloud\/password-confirmation)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [@vue/test-utils](#user-content-\@vue\/test-utils)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/password-confirmation <a href="#user-content-\@nextcloud\/password-confirmation" id="\@nextcloud\/password-confirmation">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
* Affected versions: >=3.0.0
* Package usage:
  * `node_modules/@nextcloud/password-confirmation`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### @vue/test-utils <a href="#user-content-\@vue\/test-utils" id="\@vue\/test-utils">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=1.3.6
* Package usage:
  * `node_modules/@vue/test-utils`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* http-proxy-middleware allows fixRequestBody to proceed even if bodyParser has failed
* Severity: **moderate** (CVSS 4)
* Reference: [https://github.com/advisories/GHSA-9gqv-wp59-fq42](https://github.com/advisories/GHSA-9gqv-wp59-fq42)
* Affected versions: <=2.0.8
* Package usage:
  * `node_modules/http-proxy-middleware`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`