### PR TITLE
fix: scan command not reporting scanned files and folders

### DIFF
--- a/lib/Command/Scan.php
+++ b/lib/Command/Scan.php
@@ -98,7 +98,7 @@ class Scan extends FolderCommand {
 				return -1;
 			}
 
-			$scanner->listen(\OC\Files\Cache\Scanner::class, 'scanFile', function (string $path) use ($output, &$statsRow): void {
+			$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function (string $path) use ($output, &$statsRow): void {
 				$output->writeln("\tFile\t<info>/$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 				$statsRow[2]++;
 				// abortIfInterrupted doesn't exist in nc14
@@ -107,7 +107,7 @@ class Scan extends FolderCommand {
 				}
 			});
 
-			$scanner->listen(\OC\Files\Cache\Scanner::class, 'scanFolder', function (string $path) use ($output, &$statsRow): void {
+			$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function (string $path) use ($output, &$statsRow): void {
 				$output->writeln("\tFolder\t<info>/$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 				$statsRow[1]++;
 				// abortIfInterrupted doesn't exist in nc14


### PR DESCRIPTION
The scan command did not log scanned files and folders and did not report stats corretly. Now, it does.

**Problem:** The `::class` path is not starting with a slash while the event is emitted with a slash.

Ref https://github.com/nextcloud/server/blob/bb4cf2830aca984c001542b3cdc2ebc78bba6941/lib/private/Files/Cache/Scanner.php#L156