### PR TITLE
[31] fix: only add storage to filecache join when sharding is used

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -126,12 +126,16 @@ class FolderManager {
 	}
 
 	private function joinQueryWithFileCache(IQueryBuilder $query, int $rootStorageId): void {
-		$query->leftJoin('f', 'filecache', 'c', $query->expr()->andX(
+		$conditions = [
 			// concat with empty string to work around missing cast to string
 			$query->expr()->eq('c.name', $query->func()->concat('f.folder_id', $query->expr()->literal(''))),
 			$query->expr()->eq('c.parent', $query->createNamedParameter($this->getGroupFolderRootId($rootStorageId))),
-			$query->expr()->eq('c.storage', $query->createNamedParameter($rootStorageId)),
-		));
+		];
+		if ($this->connection->getShardDefinition('filecache')) {
+			$conditions[] = $query->expr()->eq('c.storage', $query->createNamedParameter($rootStorageId));
+		}
+
+		$query->leftJoin('f', 'filecache', 'c', $query->expr()->andX(...$conditions));
 	}
 
 	/**

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,7 @@
 		<file name="tests/stubs/oc_appframework_ocs_v1response.php" />
 		<file name="tests/stubs/oc_appframework_utility_simplecontainer.php" />
 		<file name="tests/stubs/oc_core_command_base.php" />
+		<file name="tests/stubs/oc_db_querybuilder_sharded_sharddefinition.php" />
 		<file name="tests/stubs/oc_files_cache_cache.php" />
 		<file name="tests/stubs/oc_files_cache_cacheentry.php" />
 		<file name="tests/stubs/oc_files_cache_scanner.php" />

--- a/tests/stubs/oc_db_querybuilder_sharded_sharddefinition.php
+++ b/tests/stubs/oc_db_querybuilder_sharded_sharddefinition.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\DB\QueryBuilder\Sharded;
+
+class ShardDefinition {
+}


### PR DESCRIPTION
Backport friendly alternative for https://github.com/nextcloud/groupfolders/pull/3826/