### PR TITLE
fix(ACL): Apply folder permissions mask when testing path permission

### DIFF
--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -77,7 +77,7 @@ class ACL extends FolderCommand {
 				$path = $input->getArgument('path');
 				$aclManager = $this->aclManagerFactory->getACLManager($user);
 				$permissions = $aclManager->getACLPermissionsForPath($jailPath . rtrim('/' . $path, '/'));
-				$permissionString = Rule::formatRulePermissions(Constants::PERMISSION_ALL, $permissions);
+				$permissionString = Rule::formatRulePermissions($this->folderManager->getFolderPermissionsForUser($user, $folder['id']), $permissions);
 				$output->writeln($permissionString);
 
 				return 0;


### PR DESCRIPTION
If a user has no access to a Team folder, no rules are returned and it is assumed that this user has all permissions.
Instead of applying the folder permissions as a mask, it would also be possible to just check if the folder permissions are 0 and then use 0 as the path permissions directly, but in the end this results in the same output.