### PR TITLE
fix(versions): Avoid new version entity if it exists on DB

### DIFF
--- a/lib/Versions/GroupVersionsMapper.php
+++ b/lib/Versions/GroupVersionsMapper.php
@@ -45,6 +45,9 @@ class GroupVersionsMapper extends QBMapper {
 		return $this->findEntity($qb);
 	}
 
+	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 */
 	public function findVersionForFileId(int $fileId, int $timestamp): GroupVersionEntity {
 		$qb = $this->db->getQueryBuilder();
 

--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -20,6 +20,7 @@ use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
 use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCA\GroupFolders\Mount\MountProvider;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
@@ -332,13 +333,19 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 	}
 
 	public function createVersionEntity(File $file): void {
-		$versionEntity = new GroupVersionEntity();
-		$versionEntity->setFileId($file->getId());
-		$versionEntity->setTimestamp($file->getMTime());
-		$versionEntity->setSize($file->getSize());
-		$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
-		$versionEntity->setDecodedMetadata([]);
-		$this->groupVersionsMapper->insert($versionEntity);
+		$fileId = $file->getId();
+		$timestamp = $file->getMTime();
+		try {
+			$this->groupVersionsMapper->findVersionForFileId($fileId, $timestamp);
+		} catch (DoesNotExistException) {
+			$versionEntity = new GroupVersionEntity();
+			$versionEntity->setFileId($fileId);
+			$versionEntity->setTimestamp($timestamp);
+			$versionEntity->setSize($file->getSize());
+			$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
+			$versionEntity->setDecodedMetadata([]);
+			$this->groupVersionsMapper->insert($versionEntity);
+		}
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {


### PR DESCRIPTION
Fix for:

```
{
  "reqId": "Y80wj3Be1EpAiwheDPId",
  "level": 3,
  "time": "2025-06-27T12:13:09+02:00",
  "user": "asaquer",
  "app": "no app in context",
  "method": "PUT",
  "url": "/remote.php/dav/files/file.xls",
  "message": "Exception thrown: OC\\DB\\Exceptions\\DbalException",
  "userAgent": "Mozilla/5.0 (Windows) mirall/3.15.3 (build 20250107) (Nextcloud, windows-10.0.26100 ClientArchitecture: x86_64 OsArchitecture: x86_64)",
  "version": "30.0.12.2",
  "clientReqId": "f23d7773-5d7d-47e1-8140-ca459d88ac33",
  "exception": {
    "Exception": "OC\\DB\\Exceptions\\DbalException",
    "Message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1815096-1742889112' for key 'gf_versions_uniq_index'",
    "Code": 1062,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
        "line": 69,
        "function": "wrap",
        "class": "OC\\DB\\Exceptions\\DbalException",
        "type": "::",
        "args": [
          {
            "__class__": "Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException"
          },
          "",
          "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
        "line": 306,
        "function": "executeStatement",
        "class": "OC\\DB\\ConnectionAdapter",
        "type": "->",
        "args": [
          "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
          {
            "dcValue1": 1815096,
            "dcValue2": 1742889112,
            "dcValue3": 125952,
            "dcValue4": 25,
            "dcValue5": "[]"
          },
          {
            "dcValue1": 2,
            "dcValue2": 1,
            "dcValue3": 1,
            "dcValue4": 1,
            "dcValue5": 2
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
        "line": 115,
        "function": "executeStatement",
        "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/apps/groupfolders/lib/Versions/VersionsBackend.php",
        "line": 339,
        "function": "insert",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\GroupFolders\\Versions\\GroupVersionEntity",
            "id": "*** sensitive parameters replaced ***"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/VersionManager.php",
        "line": 122,
        "function": "createVersionEntity",
        "class": "OCA\\GroupFolders\\Versions\\VersionsBackend",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 186,
        "function": "createVersionEntity",
        "class": "OCA\\Files_Versions\\Versions\\VersionManager",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 247,
        "function": "created",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 84,
        "function": "post_write_hook",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 68,
        "function": "handle",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeWrittenEvent"
          }
        ]
      },
    ...
}
```