### PR TITLE
remove trashbin layout assumptions from ACL handling

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -259,8 +259,8 @@ class ACLManager {
 		}
 	}
 
-	public function preloadRulesForFolder(int $storageId, string $path): void {
-		$this->ruleManager->getRulesForFilesByParent($this->user, $storageId, $path);
+	public function preloadRulesForFolder(int $storageId, int $parentId): void {
+		$this->ruleManager->getRulesForFilesByParent($this->user, $storageId, $parentId);
 	}
 
 	/**

--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -93,45 +93,18 @@ class ACLManager {
 	 *
 	 * @return string[]
 	 */
-	private function getRelevantPaths(string $path): array {
+	private function getRelevantPaths(string $path, string $basePath = ''): array {
 		$paths = [];
-		$fromTrashbin = str_starts_with($path, '__groupfolders/trash/');
-		if ($fromTrashbin) {
-			/* Exploded path will look like ["__groupfolders", "trash", "1", "folderName.d2345678", "rest/of/the/path.txt"] */
-			$parts = explode('/', $path, 5);
-			if (count($parts) < 4) {
-				// path is the root of the groupfolder trash
-				return [];
-			}
-			[, , $groupFolderId, $rootTrashedItemName] = $parts;
-			$groupFolderId = (int)$groupFolderId;
-			/* Remove the date part */
-			$separatorPos = strrpos($rootTrashedItemName, '.d');
-			if ($separatorPos === false) {
-				throw new RuntimeException('Invalid trash item name ' . $rootTrashedItemName);
-			}
-			$rootTrashedItemDate = (int)substr($rootTrashedItemName, $separatorPos + 2);
-			$rootTrashedItemName = substr($rootTrashedItemName, 0, $separatorPos);
-		}
-
 		while ($path !== '') {
 			$paths[] = $path;
 			$path = dirname($path);
-			if ($fromTrashbin && ($path === '__groupfolders/trash')) {
-				/* We are in trash and hit the root folder, continue looking for ACLs on parent folders in original location */
-				/** @psalm-suppress PossiblyUndefinedVariable Variables are defined above */
-				$trashItemRow = $this->trashManager->getTrashItemByFileName($groupFolderId, $rootTrashedItemName, $rootTrashedItemDate);
-				$fromTrashbin = false;
-				if ($trashItemRow) {
-					$path = dirname('__groupfolders/' . $groupFolderId . '/' . $trashItemRow['original_location']);
-					continue;
-				} else {
-					$this->logger->warning("failed to find trash item for $rootTrashedItemName deleted at $rootTrashedItemDate in folder $groupFolderId", ['app' => 'groupfolders']);
-				}
-			}
 
 			if ($path === '.' || $path === '/') {
 				$path = '';
+			}
+
+			if ($path === $basePath) {
+				break;
 			}
 		}
 
@@ -155,9 +128,9 @@ class ACLManager {
 		return $this->getRules($storageId, $allPaths, $cache);
 	}
 
-	public function getACLPermissionsForPath(int $storageId, string $path): int {
+	public function getACLPermissionsForPath(int $storageId, string $path, string $basePath = ''): int {
 		$path = ltrim($path, '/');
-		$rules = $this->getRules($storageId, $this->getRelevantPaths($path));
+		$rules = $this->getRules($storageId, $this->getRelevantPaths($path, $basePath));
 
 		return $this->calculatePermissionsForPath($rules);
 	}

--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -136,13 +136,8 @@ class RuleManager {
 	/**
 	 * @return array<string, Rule[]>
 	 */
-	public function getRulesForFilesByParent(IUser $user, int $storageId, string $parent): array {
+	public function getRulesForFilesByParent(IUser $user, int $storageId, int $parentId): array {
 		$userMappings = $this->userMappingManager->getMappingsForUser($user);
-
-		$parentId = $this->getId($storageId, $parent);
-		if (!$parentId) {
-			return [];
-		}
 
 		$query = $this->connection->getQueryBuilder();
 		$query->select(['f.fileid', 'a.mapping_type', 'a.mapping_id', 'a.mask', 'a.permissions', 'f.path'])

--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -11,6 +11,7 @@ namespace OCA\GroupFolders\Mount;
 use OC\Files\Storage\Wrapper\Jail;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
 use OCA\GroupFolders\ACL\ACLStorageWrapper;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -52,7 +53,7 @@ class FolderStorageManager {
 	/**
 	 * @param 'files'|'trash'|'versions' $type
 	 */
-	public function getBaseStorageForFolder(int $folderId, ?\OCA\GroupFolders\Folder\FolderDefinition $folder = null, ?IUser $user = null, bool $inShare = false, string $type = 'files'): IStorage {
+	public function getBaseStorageForFolder(int $folderId, ?FolderDefinition $folder = null, ?IUser $user = null, bool $inShare = false, string $type = 'files'): IStorage {
 		try {
 			/** @var Folder $parentFolder */
 			$parentFolder = $this->rootFolder->get('__groupfolders');
@@ -78,8 +79,8 @@ class FolderStorageManager {
 		$rootStorage = $storageFolder->getStorage();
 		$rootPath = $storageFolder->getInternalPath();
 
-		// apply acl before jail
-		if ($folder && $folder->acl && $user) {
+		// apply acl before jail, trash doesn't get the ACL wrapper as it does its own ACL filtering
+		if ($folder && $folder->acl && $user && $type !== 'trash') {
 			$aclManager = $this->aclManagerFactory->getACLManager($user);
 			$rootStorage = new ACLStorageWrapper([
 				'storage' => $rootStorage,

--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -12,6 +12,7 @@ use OCA\Files_Trashbin\Trash\ITrashBackend;
 use OCA\Files_Trashbin\Trash\TrashItem;
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCP\Files\FileInfo;
+use OCP\Files\Node;
 use OCP\IUser;
 
 class GroupTrashItem extends TrashItem {
@@ -20,7 +21,7 @@ class GroupTrashItem extends TrashItem {
 		private readonly string $internalOriginalLocation,
 		int $deletedTime,
 		string $trashPath,
-		FileInfo $fileInfo,
+		protected Node $fileInfo,
 		IUser $user,
 		private readonly string $mountPoint,
 		?IUser $deletedBy,
@@ -55,6 +56,10 @@ class GroupTrashItem extends TrashItem {
 		$path = parent::getInternalPath();
 
 		return rtrim($path, '.d' . $this->getDeletedTime());
+	}
+
+	public function getTrashNode(): Node {
+		return $this->fileInfo;
 	}
 
 	public function getGroupFolderStorageId(): int {

--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -11,6 +11,7 @@ namespace OCA\GroupFolders\Trash;
 use OCA\Files_Trashbin\Trash\ITrashBackend;
 use OCA\Files_Trashbin\Trash\TrashItem;
 use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCP\Files\FileInfo;
 use OCP\Files\Node;
 use OCP\IUser;
@@ -25,7 +26,7 @@ class GroupTrashItem extends TrashItem {
 		IUser $user,
 		private readonly string $mountPoint,
 		?IUser $deletedBy,
-		public readonly FolderDefinition $folder,
+		public readonly FolderDefinitionWithPermissions $folder,
 	) {
 		parent::__construct($backend, $this->mountPoint . '/' . $this->internalOriginalLocation, $deletedTime, $trashPath, $fileInfo, $user, $deletedBy);
 	}

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -9,6 +9,7 @@ declare (strict_types=1);
 namespace OCA\GroupFolders\Trash;
 
 use OC\Encryption\Exceptions\DecryptionFailedException;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\Storage\Wrapper\Jail;
 use OCA\Files_Trashbin\Expiration;
@@ -83,14 +84,10 @@ class TrashBackend implements ITrashBackend {
 		}
 
 		$content = $folderNode->getDirectoryListing();
-		$this->aclManagerFactory->getACLManager($user)->preloadRulesForFolder($folder->getGroupFolderStorageId(), $folder->getPath());
+		$this->aclManagerFactory->getACLManager($user)->preloadRulesForFolder($folder->getGroupFolderStorageId(), $folder->getId());
 
 		return array_values(array_filter(array_map(function (Node $node) use ($folder, $user): ?GroupTrashItem {
-			if (!$this->userHasAccessToPath($folder->getGroupFolderStorageId(), $user, $this->getUnJailedPath($node))) {
-				return null;
-			}
-
-			return new GroupTrashItem(
+			$item = new GroupTrashItem(
 				$this,
 				$folder->getInternalOriginalLocation() . '/' . $node->getName(),
 				$folder->getDeletedTime(),
@@ -101,6 +98,12 @@ class TrashBackend implements ITrashBackend {
 				$folder->getDeletedBy(),
 				$folder->folder,
 			);
+
+			if (!$this->userHasAccessToItem($item)) {
+				return null;
+			}
+
+			return $item;
 		}, $content)));
 	}
 
@@ -120,7 +123,7 @@ class TrashBackend implements ITrashBackend {
 			throw new NotFoundException();
 		}
 
-		if (!$this->userHasAccessToPath($item->getGroupFolderStorageId(), $item->getUser(), $item->getPath(), Constants::PERMISSION_UPDATE)) {
+		if (!$this->userHasAccessToItem($item, Constants::PERMISSION_UPDATE)) {
 			throw new NotPermittedException();
 		}
 
@@ -189,7 +192,7 @@ class TrashBackend implements ITrashBackend {
 			[
 				'filePath' => '/' . $item->getGroupFolderMountPoint() . '/' . $originalLocation,
 				'trashPath' => $item->getPath(),
-			]
+			],
 		);
 	}
 
@@ -221,7 +224,7 @@ class TrashBackend implements ITrashBackend {
 			throw new NotFoundException();
 		}
 
-		if (!$this->userHasAccessToPath($item->folder->storageId, $item->getUser(), $item->getPath(), Constants::PERMISSION_DELETE)) {
+		if (!$this->userHasAccessToItem($item, Constants::PERMISSION_DELETE)) {
 			throw new NotPermittedException();
 		}
 
@@ -335,6 +338,22 @@ class TrashBackend implements ITrashBackend {
 		return in_array($folderId, $folderIds);
 	}
 
+	private function userHasAccessToItem(
+		GroupTrashItem $item,
+		int $permission = Constants::PERMISSION_READ,
+		string $pathInsideItem = '',
+	): bool {
+		try {
+			$activePermissions = $this->aclManagerFactory->getACLManager($item->getUser())
+				->getACLPermissionsForPath($item->getGroupFolderStorageId(), $this->getUnJailedPath($item->getTrashNode()) . $pathInsideItem);
+		} catch (\Exception $e) {
+			$this->logger->warning("Failed to get permissions for {$item->getPath()}", ['exception' => $e]);
+			return false;
+		}
+
+		return (bool)($activePermissions & $permission);
+	}
+
 	private function userHasAccessToPath(
 		int $storageId,
 		IUser $user,
@@ -365,7 +384,7 @@ class TrashBackend implements ITrashBackend {
 				$trashRoot = $this->rootFolder->get('/' . $user->getUID() . '/files_trashbin/groupfolders/' . $folderId);
 				try {
 					$node = $trashRoot->get($path);
-					if (!$this->userHasAccessToPath($trashItem->getGroupFolderStorageId(), $user, $trashItem->getPath())) {
+					if (!$this->userHasAccessToItem($trashItem)) {
 						return null;
 					}
 
@@ -439,92 +458,91 @@ class TrashBackend implements ITrashBackend {
 		$folderIds = array_map(fn (FolderDefinitionWithPermissions $folder): int => $folder->id, $folders);
 		$rows = $this->trashManager->listTrashForFolders($folderIds);
 		$indexedRows = [];
-		$trashItemsByOriginalLocation = [];
 		foreach ($rows as $row) {
 			$key = $row['folder_id'] . '/' . $row['name'] . '/' . $row['deleted_time'];
 			$indexedRows[$key] = $row;
-			$trashItemsByOriginalLocation[$row['original_location']] = $row;
 		}
 
 		$items = [];
 		foreach ($folders as $folder) {
-			$folderId = $folder->id;
-			$folderHasAcl = $folder->acl;
-			$mountPoint = $folder->mountPoint;
-
 			// ensure the trash folder exists
 			$this->setupTrashFolder($folder, $user);
 
-			$trashFolder = $this->rootFolder->get('/' . $user->getUID() . '/files_trashbin/groupfolders/' . $folderId);
+			$trashFolder = $this->rootFolder->get('/' . $user->getUID() . '/files_trashbin/groupfolders/' . $folder->id);
 			$content = $trashFolder->getDirectoryListing();
-			$userCanManageAcl = $this->folderManager->canManageACL($folderId, $user);
-			$this->aclManagerFactory->getACLManager($user)->preloadRulesForFolder($folder->storageId, $this->getUnJailedPath($trashFolder));
-			foreach ($content as $item) {
-				/** @var \OC\Files\Node\Node $item */
+			$userCanManageAcl = $this->folderManager->canManageACL($folder->id, $user);
+			$this->aclManagerFactory->getACLManager($user)->preloadRulesForFolder($folder->storageId, $trashFolder->getId());
+
+			$itemsForFolder = array_map(function (Node $item) use ($user, $folder, $indexedRows) {
 				$pathParts = pathinfo($item->getName());
 				$timestamp = (int)substr($pathParts['extension'], 1);
 				$name = $pathParts['filename'];
-				$key = $folderId . '/' . $name . '/' . $timestamp;
+				$key = $folder->id . '/' . $name . '/' . $timestamp;
 
 				$originalLocation = isset($indexedRows[$key]) ? $indexedRows[$key]['original_location'] : '';
 				$deletedBy = isset($indexedRows[$key]) ? $indexedRows[$key]['deleted_by'] : '';
 
-				if ($folderHasAcl) {
-					// if we for any reason lost track of the original location, hide the item for non-managers as a fail-safe
-					if ($originalLocation === '' && !$userCanManageAcl) {
-						continue;
-					}
-
-					if (!$this->userHasAccessToPath($folder->storageId, $user, $this->getUnJailedPath($item))) {
-						continue;
-					}
-
-					// if a parent of the original location has also been deleted, we also need to check it based on the now-deleted parent path
-					foreach ($this->getParentOriginalPaths($originalLocation, $trashItemsByOriginalLocation) as $parentOriginalPath) {
-						$parentTrashItem = $trashItemsByOriginalLocation[$parentOriginalPath];
-						$relativePath = substr($originalLocation, strlen($parentOriginalPath));
-						$parentTrashItemPath = "__groupfolders/trash/{$parentTrashItem['folder_id']}/{$parentTrashItem['name']}.d{$parentTrashItem['deleted_time']}";
-						if (!$this->userHasAccessToPath($folder->storageId, $user, $parentTrashItemPath . $relativePath)) {
-							continue 2;
-						}
-					}
-				}
-
-				$info = $item->getFileInfo();
-				$info['name'] = $name;
-				$items[] = new GroupTrashItem(
+				return new GroupTrashItem(
 					$this,
 					$originalLocation,
 					$timestamp,
-					'/' . $folderId . '/' . $item->getName(),
-					$info,
+					'/' . $folder->id . '/' . $item->getName(),
+					$item,
 					$user,
-					$mountPoint,
+					$folder->mountPoint,
 					$this->userManager->get($deletedBy),
 					$folder,
 				);
+			}, $content);
+			$originalLocations = array_map(fn (GroupTrashItem $item): string => $item->getOriginalLocation(), $itemsForFolder);
+			$itemsByOriginalLocation = array_combine($originalLocations, $itemsForFolder);
+
+			// perform per-item ACL checks if the user doesn't have manage permissions
+			if ($folder->acl && !$userCanManageAcl) {
+				$itemsForFolder = array_filter($itemsForFolder, function (GroupTrashItem $item) use ($itemsByOriginalLocation) {
+					// if we for any reason lost track of the original location, hide the item for non-managers as a fail-safe
+					if ($item->getInternalOriginalLocation() === '') {
+						return false;
+					}
+
+					if (!$this->userHasAccessToItem($item)) {
+						return false;
+					}
+
+					// if a parent of the original location has also been deleted, we also need to check it based on the now-deleted parent path
+					foreach ($this->getParentOriginalPaths($item->getOriginalLocation(), $itemsByOriginalLocation) as $parentItem) {
+						$pathInsideParentItem = dirname(substr($item->getInternalOriginalLocation(), strlen($parentItem->getInternalOriginalLocation())));
+						if (!$this->userHasAccessToItem($parentItem, Constants::PERMISSION_READ, $pathInsideParentItem)) {
+							return false;
+						}
+					}
+
+					return true;
+				});
 			}
+			$items = array_merge($items, $itemsForFolder);
 		}
 
 		return $items;
 	}
 
 	/**
-	 * @return list<string>
+	 * @param array<string, GroupTrashItem> $trashItemsByOriginalPath
+	 * @return list<GroupTrashItem>
 	 */
 	private function getParentOriginalPaths(string $path, array $trashItemsByOriginalPath): array {
-		$parentPaths = [];
+		$parentItems = [];
 		while ($path !== '') {
 			$path = dirname($path);
 
 			if ($path === '.' || $path === '/') {
 				break;
 			} elseif (isset($trashItemsByOriginalPath[$path])) {
-				$parentPaths[] = $path;
+				$parentItems[] = $trashItemsByOriginalPath[$path];
 			}
 		}
 
-		return $parentPaths;
+		return $parentItems;
 	}
 
 	public function getTrashNodeById(IUser $user, int $fileId): ?Node {

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -344,14 +344,17 @@ class TrashBackend implements ITrashBackend {
 		string $pathInsideItem = '',
 	): bool {
 		try {
-			$activePermissions = $this->aclManagerFactory->getACLManager($item->getUser())
-				->getACLPermissionsForPath($item->getGroupFolderStorageId(), $this->getUnJailedPath($item->getTrashNode()) . $pathInsideItem);
+			$aclManager = $this->aclManagerFactory->getACLManager($item->getUser());
+			$trashPath = $this->getUnJailedPath($item->getTrashNode()) . $pathInsideItem;
+			$activePermissions = $aclManager->getACLPermissionsForPath($item->getGroupFolderStorageId(), $trashPath, '__groupfolders/trash');
+			$originalPath = $item->folder->rootCacheEntry->getPath() . '/' . $item->getInternalOriginalLocation() . $pathInsideItem;
+			$originalLocationPermissions = $aclManager->getACLPermissionsForPath($item->getGroupFolderStorageId(), $originalPath);
 		} catch (\Exception $e) {
 			$this->logger->warning("Failed to get permissions for {$item->getPath()}", ['exception' => $e]);
 			return false;
 		}
 
-		return (bool)($activePermissions & $permission);
+		return (bool)($activePermissions & $permission & $originalLocationPermissions);
 	}
 
 	private function userHasAccessToPath(

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -117,17 +117,6 @@ class ACLManagerTest extends TestCase {
 			]
 		];
 
-		$this->trashManager
-			->expects($this->once())
-			->method('getTrashItemByFileName')
-			->with(1, 'subfolder2', 1700752274)
-			->willReturn([
-				'trash_id' => 3,
-				'name' => 'subfolder2',
-				'deleted_time' => '1700752274',
-				'original_location' => 'subfolder/subfolder2',
-				'folder_id' => '1',
-			]);
 		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath(0, '__groupfolders/trash/1/subfolder2.d1700752274/coucou.md'));
 	}
 

--- a/tests/ACL/RuleManagerTest.php
+++ b/tests/ACL/RuleManagerTest.php
@@ -203,8 +203,9 @@ class RuleManagerTest extends TestCase {
 		$storage->mkdir('foo/asd');
 		$storage->getScanner()->scan('');
 		$cache = $storage->getCache();
-		$id2 = (int)$cache->getId('foo/bar');
-		$id3 = (int)$cache->getId('foo/asd');
+		$parentId = $cache->getId('foo');
+		$id2 = $cache->getId('foo/bar');
+		$id3 = $cache->getId('foo/asd');
 		$storageId = $cache->getNumericStorageId();
 
 		$mapping = new UserMapping('user', '1');
@@ -218,7 +219,7 @@ class RuleManagerTest extends TestCase {
 		$this->ruleManager->saveRule($rule1);
 		$this->ruleManager->saveRule($rule2);
 
-		$result = $this->ruleManager->getRulesForFilesByParent($this->user, $storageId, 'foo');
+		$result = $this->ruleManager->getRulesForFilesByParent($this->user, $storageId, $parentId);
 		$this->assertEquals(['foo/bar' => [$rule1], 'foo/asd' => [$rule2]], $result);
 
 		// cleanup


### PR DESCRIPTION
The current ACL code has explicit logic for dealing with trashbin paths, encoding assumptions about how the groupfolders trash is laid out.

This reworks how ACLs are checked in the trashbin to remove these assumptions and allow for changing how the trash is stored in the future.