### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d89e05b08fc204c8d6b7fe4a777b93c8b8fc9231"
+                "reference": "abd32429d794ede1d92b7b0a88a1070371c907b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d89e05b08fc204c8d6b7fe4a777b93c8b8fc9231",
-                "reference": "d89e05b08fc204c8d6b7fe4a777b93c8b8fc9231",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/abd32429d794ede1d92b7b0a88a1070371c907b5",
+                "reference": "abd32429d794ede1d92b7b0a88a1070371c907b5",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2025-07-23T00:57:14+00:00"
+            "time": "2025-07-31T00:57:37+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency