### PR TITLE
fix(trashbackend): Fix type in userHasAccessToFolder

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -16,6 +16,7 @@ use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashBackend;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
@@ -330,7 +331,7 @@ class TrashBackend implements ITrashBackend {
 
 	private function userHasAccessToFolder(IUser $user, int $folderId): bool {
 		$folders = $this->folderManager->getFoldersForUser($user);
-		$folderIds = array_map(fn (array $folder): int => $folder->id, $folders);
+		$folderIds = array_map(fn (FolderDefinition $folder): int => $folder->id, $folders);
 
 		return in_array($folderId, $folderIds);
 	}


### PR DESCRIPTION
Fix crash caused by the following exception:

OCA\\GroupFolders\\Trash\\TrashBackend::OCA\\GroupFolders\\Trash\\{closure}(): Argument #1 ($folder) must be of type array,
OCA\\GroupFolders\\Folder\\FolderDefinitionWithPermissions given in file '/var/www/html/apps-extra/groupfolders/lib/Trash/TrashBackend.php' line 333