### PR TITLE
[31] store the fileid of the root of groupfolders

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@ Folders can be configured from *Team folders* in the admin settings.
 
 After a folder is created, the admin can give access to the folder to one or more teams, control their write/sharing permissions and assign a quota for the folder.
 ]]></description>
-	<version>19.1.3</version>
+	<version>19.1.4</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -129,9 +129,7 @@ class FolderManager {
 
 	private function joinQueryWithFileCache(IQueryBuilder $query, int $rootStorageId): void {
 		$conditions = [
-			// concat with empty string to work around missing cast to string
-			$query->expr()->eq('c.name', $query->func()->concat('f.folder_id', $query->expr()->literal(''))),
-			$query->expr()->eq('c.parent', $query->createNamedParameter($this->getGroupFolderRootId($rootStorageId))),
+			$query->expr()->eq('c.fileid', 'f.root_id'),
 		];
 		if ($this->connection->getShardDefinition('filecache')) {
 			$conditions[] = $query->expr()->eq('c.storage', $query->createNamedParameter($rootStorageId));

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -17,6 +17,7 @@ use OCA\Circles\Model\Probes\CircleProbe;
 use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
 use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\ACL\UserMapping\UserMapping;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCP\AutoloadNotAllowedException;
@@ -78,6 +79,7 @@ class FolderManager {
 		private IEventDispatcher $eventDispatcher,
 		private IConfig $config,
 		private IUserMappingManager $userMappingManager,
+		private readonly FolderStorageManager $folderStorageManager,
 	) {
 	}
 
@@ -757,6 +759,13 @@ class FolderManager {
 			]);
 		$query->executeStatement();
 		$id = $query->getLastInsertId();
+
+		['storage_id' => $storageId, 'root_id' => $rootId] = $this->folderStorageManager->getRootAndStorageIdForFolder($id);
+		$query->update('group_folders')
+			->set('root_id', $query->createNamedParameter($rootId))
+			->set('storage_id', $query->createNamedParameter($storageId))
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($id)));
+		$query->executeStatement();
 
 		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('A new groupfolder "%s" was created with id %d', [$mountPoint, $id]));
 

--- a/lib/Migration/Version102020Date20180806161449.php
+++ b/lib/Migration/Version102020Date20180806161449.php
@@ -8,6 +8,7 @@
 namespace OCA\GroupFolders\Migration;
 
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -33,6 +34,12 @@ class Version102020Date20180806161449 extends SimpleMigrationStep {
 				// Removed in migration Version19000Date20240903062631
 				//'default' => -3,
 			]);
+
+			// from Version20000Date20250612140256.php
+			$table->addColumn('root_id', Types::BIGINT, ['notnull' => false]);
+			$table->addColumn('storage_id', Types::BIGINT, ['notnull' => false]);
+			$table->addColumn('options', Types::TEXT, ['notnull' => false]);
+
 			$table->setPrimaryKey(['folder_id']);
 		}
 

--- a/lib/Migration/Version20000Date20250612140256.php
+++ b/lib/Migration/Version20000Date20250612140256.php
@@ -49,9 +49,12 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 
 	#[Override]
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		$rootIds = $this->getJailedRootIds();
 		$storageId = $this->getJailedGroupFolderStorageId();
-		if (empty($rootIds) || $storageId === null) {
+		if ($storageId === null) {
+			return;
+		}
+		$rootIds = $this->getJailedRootIds($storageId);
+		if (count($rootIds) === 0) {
 			return;
 		}
 
@@ -62,7 +65,8 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 			$query->update('group_folders')
 				->set('root_id', $query->createParameter('root_id'))
 				->set('storage_id', $query->createNamedParameter($storageId))
-				->where($query->expr()->eq('folder_id', $query->createParameter('folder_id')));
+				->where($query->expr()->eq('folder_id', $query->createParameter('folder_id')))
+				->andWhere($query->expr()->isNull('storage_id'));
 
 			foreach ($rootIds as $folderId => $rootId) {
 				$query->setParameter('root_id', $rootId);
@@ -80,8 +84,8 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 	/**
 	 * @return array<int, int>
 	 */
-	private function getJailedRootIds(): array {
-		$parentFolderId = $this->getJailedGroupFolderRootId();
+	private function getJailedRootIds(int $storageId): array {
+		$parentFolderId = $this->getJailedGroupFolderRootId($storageId);
 		if ($parentFolderId === null) {
 			return [];
 		}
@@ -89,7 +93,8 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('name', 'fileid')
 			->from('filecache')
-			->where($query->expr()->eq('parent', $query->createNamedParameter($parentFolderId)));
+			->where($query->expr()->eq('parent', $query->createNamedParameter($parentFolderId)))
+			->andWhere($query->expr()->eq('storage', $query->createNamedParameter($storageId)));
 		$result = $query->executeQuery();
 
 		$rootIds = [];
@@ -101,14 +106,15 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 		return $rootIds;
 	}
 
-	private function getJailedGroupFolderRootId(): ?int {
+	private function getJailedGroupFolderRootId(int $storageId): ?int {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('fileid')
 			->from('filecache')
-			->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5('__groupfolders'))));
+			->where($query->expr()->eq('path_hash', $query->createNamedParameter(md5('__groupfolders'))))
+			->andWhere($query->expr()->eq('storage', $query->createNamedParameter($storageId)));
 
 		$id = $query->executeQuery()->fetchOne();
-		if ($id === null) {
+		if ($id === false) {
 			return null;
 		} else {
 			return (int)$id;
@@ -119,10 +125,11 @@ class Version20000Date20250612140256 extends SimpleMigrationStep {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('storage')
 			->from('filecache')
+			->runAcrossAllShards()
 			->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5('__groupfolders'))));
 
 		$id = $query->executeQuery()->fetchOne();
-		if ($id === null) {
+		if ($id === false) {
 			return null;
 		} else {
 			return (int)$id;

--- a/lib/Migration/Version20000Date20250612140256.php
+++ b/lib/Migration/Version20000Date20250612140256.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Adds root_id and options to the group folders table
+ */
+class Version20000Date20250612140256 extends SimpleMigrationStep {
+	public function __construct(
+		private readonly IDBConnection $connection,
+	) {
+	}
+
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('group_folders')) {
+			$table = $schema->getTable('group_folders');
+			if (!$table->hasColumn('root_id')) {
+				$table->addColumn('root_id', Types::BIGINT, ['notnull' => false]);
+			}
+			if (!$table->hasColumn('storage_id')) {
+				$table->addColumn('storage_id', Types::BIGINT, ['notnull' => false]);
+			}
+			if (!$table->hasColumn('options')) {
+				$table->addColumn('options', Types::TEXT, ['notnull' => false]);
+			}
+			return $schema;
+		}
+		return null;
+	}
+
+	#[Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$rootIds = $this->getJailedRootIds();
+		$storageId = $this->getJailedGroupFolderStorageId();
+		if (empty($rootIds) || $storageId === null) {
+			return;
+		}
+
+		try {
+			$this->connection->beginTransaction();
+
+			$query = $this->connection->getQueryBuilder();
+			$query->update('group_folders')
+				->set('root_id', $query->createParameter('root_id'))
+				->set('storage_id', $query->createNamedParameter($storageId))
+				->where($query->expr()->eq('folder_id', $query->createParameter('folder_id')));
+
+			foreach ($rootIds as $folderId => $rootId) {
+				$query->setParameter('root_id', $rootId);
+				$query->setParameter('folder_id', $folderId);
+				$query->executeStatement();
+			}
+
+			$this->connection->commit();
+		} catch (\Exception $e) {
+			$this->connection->rollBack();
+			throw $e;
+		}
+	}
+
+	/**
+	 * @return array<int, int>
+	 */
+	private function getJailedRootIds(): array {
+		$parentFolderId = $this->getJailedGroupFolderRootId();
+		if ($parentFolderId === null) {
+			return [];
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('name', 'fileid')
+			->from('filecache')
+			->where($query->expr()->eq('parent', $query->createNamedParameter($parentFolderId)));
+		$result = $query->executeQuery();
+
+		$rootIds = [];
+		while ($row = $result->fetch()) {
+			if (is_numeric($row['name'])) {
+				$rootIds[(int)$row['name']] = $row['fileid'];
+			}
+		}
+		return $rootIds;
+	}
+
+	private function getJailedGroupFolderRootId(): ?int {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('fileid')
+			->from('filecache')
+			->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5('__groupfolders'))));
+
+		$id = $query->executeQuery()->fetchOne();
+		if ($id === null) {
+			return null;
+		} else {
+			return (int)$id;
+		}
+	}
+
+	private function getJailedGroupFolderStorageId(): ?int {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('storage')
+			->from('filecache')
+			->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5('__groupfolders'))));
+
+		$id = $query->executeQuery()->fetchOne();
+		if ($id === null) {
+			return null;
+		} else {
+			return (int)$id;
+		}
+	}
+}

--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Robin Appelman <robin@icewind.nl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Mount;
+
+use OC\Files\Storage\Wrapper\Jail;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\Storage\IStorage;
+use OCP\IAppConfig;
+
+class FolderStorageManager {
+	private readonly bool $enableEncryption;
+
+	public function __construct(
+		private readonly IRootFolder $rootFolder,
+		private readonly IAppConfig $appConfig,
+	) {
+		$this->enableEncryption = $this->appConfig->getValueBool('groupfolders', 'enable_encryption');
+	}
+
+	/**
+	 * @return array{storage_id: int, root_id: int}
+	 */
+	public function getRootAndStorageIdForFolder(int $folderId): array {
+		$storage = $this->getBaseStorageForFolder($folderId);
+		$cache = $storage->getCache();
+		$id = $cache->getId('');
+		if ($id === -1) {
+			$storage->getScanner()->scan('');
+			$id = $cache->getId('');
+			if ($id === -1) {
+				throw new \Exception('Group folder root is not in cache even after scanning for folder ' . $folderId);
+			}
+		}
+		return [
+			'storage_id' => $cache->getNumericStorageId(),
+			'root_id' => $id,
+		];
+	}
+
+	public function getBaseStorageForFolder(int $folderId): IStorage {
+		try {
+			/** @var Folder $parentFolder */
+			$parentFolder = $this->rootFolder->get('__groupfolders');
+		} catch (NotFoundException) {
+			$parentFolder = $this->rootFolder->newFolder('__groupfolders');
+		}
+
+		try {
+			/** @var Folder $folder */
+			$folder = $parentFolder->get((string)$folderId);
+		} catch (NotFoundException) {
+			$folder = $parentFolder->newFolder((string)$folderId);
+		}
+		$rootStorage = $folder->getStorage();
+		$rootPath = $folder->getInternalPath();
+
+		if ($this->enableEncryption) {
+			return new GroupFolderEncryptionJail([
+				'storage' => $rootStorage,
+				'root' => $rootPath,
+			]);
+		} else {
+			return new Jail([
+				'storage' => $rootStorage,
+				'root' => $rootPath,
+			]);
+		}
+	}
+}

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -8,6 +8,7 @@ namespace OCA\GroupFolders\Tests\Folder;
 
 use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\FileInfo;
@@ -32,6 +33,7 @@ class FolderManagerTest extends TestCase {
 	private IEventDispatcher&MockObject $eventDispatcher;
 	private IConfig&MockObject $config;
 	private IUserMappingManager&MockObject $userMappingManager;
+	private FolderStorageManager $folderStorageManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,6 +44,8 @@ class FolderManagerTest extends TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->userMappingManager = $this->createMock(IUserMappingManager::class);
+		$this->folderStorageManager = Server::get(FolderStorageManager::class);
+
 		$this->manager = new FolderManager(
 			Server::get(IDBConnection::class),
 			$this->groupManager,
@@ -50,6 +54,7 @@ class FolderManagerTest extends TestCase {
 			$this->eventDispatcher,
 			$this->config,
 			$this->userMappingManager,
+			$this->folderStorageManager,
 		);
 		$this->clean();
 	}
@@ -97,7 +102,7 @@ class FolderManagerTest extends TestCase {
 		$this->manager->createFolder('foo');
 
 		$this->assertHasFolders([
-			['mount_point' => 'foo', 'groups' => []]
+			['mount_point' => 'foo', 'groups' => []],
 		]);
 	}
 
@@ -114,7 +119,7 @@ class FolderManagerTest extends TestCase {
 
 		$this->assertHasFolders([
 			['mount_point' => 'foo2', 'groups' => []],
-			['mount_point' => 'bar', 'groups' => []]
+			['mount_point' => 'bar', 'groups' => []],
 		]);
 	}
 
@@ -139,13 +144,13 @@ class FolderManagerTest extends TestCase {
 						[
 							'g1' => [
 								'displayName' => 'g1',
-								'permissions' => Constants::PERMISSION_ALL, 'type' => 'group'
+								'permissions' => Constants::PERMISSION_ALL, 'type' => 'group',
 							],
 							'g2' => [
 								'displayName' => 'g2',
-								'permissions' => Constants::PERMISSION_ALL, 'type' => 'group'
-							]
-						]
+								'permissions' => Constants::PERMISSION_ALL, 'type' => 'group',
+							],
+						],
 				],
 				[
 					'mount_point' => 'bar',
@@ -155,16 +160,16 @@ class FolderManagerTest extends TestCase {
 
 								'displayName' => 'g1',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
+								'type' => 'group',
 							],
 							'g3' => [
 								'displayName' => 'g3',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
-							]
-						]
-				]
-			]
+								'type' => 'group',
+							],
+						],
+				],
+			],
 		);
 	}
 
@@ -188,16 +193,16 @@ class FolderManagerTest extends TestCase {
 							'g1' => [
 								'displayName' => 'g1',
 								'permissions' => 2,
-								'type' => 'group'
+								'type' => 'group',
 							],
 							'g2' => [
 								'displayName' => 'g2',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
-							]
-						]
-				]
-			]
+								'type' => 'group',
+							],
+						],
+				],
+			],
 		);
 	}
 
@@ -225,9 +230,9 @@ class FolderManagerTest extends TestCase {
 							'g2' => [
 								'displayName' => 'g2',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
-							]
-						]
+								'type' => 'group',
+							],
+						],
 				],
 				[
 					'mount_point' => 'bar',
@@ -236,16 +241,16 @@ class FolderManagerTest extends TestCase {
 							'g1' => [
 								'displayName' => 'g1',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
+								'type' => 'group',
 							],
 							'g3' => [
 								'displayName' => 'g3',
 								'permissions' => Constants::PERMISSION_ALL,
-								'type' => 'group'
-							]
-						]
-				]
-			]
+								'type' => 'group',
+							],
+						],
+				],
+			],
 		);
 	}
 
@@ -261,7 +266,7 @@ class FolderManagerTest extends TestCase {
 		$this->manager->removeFolder($folderId1);
 
 		$this->assertHasFolders([
-			['mount_point' => 'bar', 'groups' => []]
+			['mount_point' => 'bar', 'groups' => []],
 		]);
 	}
 
@@ -366,7 +371,16 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserSimple(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
+			->setConstructorArgs([
+				$db,
+				$this->groupManager,
+				$this->mimeLoader,
+				$this->logger,
+				$this->eventDispatcher,
+				$this->config,
+				$this->userMappingManager,
+				$this->folderStorageManager,
+			])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -388,7 +402,16 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
+			->setConstructorArgs([
+				$db,
+				$this->groupManager,
+				$this->mimeLoader,
+				$this->logger,
+				$this->eventDispatcher,
+				$this->config,
+				$this->userMappingManager,
+				$this->folderStorageManager,
+			])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -396,13 +419,13 @@ class FolderManagerTest extends TestCase {
 			'folder_id' => 1,
 			'mount_point' => 'foo',
 			'permissions' => 3,
-			'quota' => 1000
+			'quota' => 1000,
 		];
 		$folder2 = [
 			'folder_id' => 1,
 			'mount_point' => 'foo',
 			'permissions' => 8,
-			'quota' => 1000
+			'quota' => 1000,
 		];
 
 		$manager->expects($this->any())
@@ -415,15 +438,24 @@ class FolderManagerTest extends TestCase {
 				'folder_id' => 1,
 				'mount_point' => 'foo',
 				'permissions' => 11,
-				'quota' => 1000
-			]
+				'quota' => 1000,
+			],
 		], $folders);
 	}
 
 	public function testGetFolderPermissionsForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager])
+			->setConstructorArgs([
+				$db,
+				$this->groupManager,
+				$this->mimeLoader,
+				$this->logger,
+				$this->eventDispatcher,
+				$this->config,
+				$this->userMappingManager,
+				$this->folderStorageManager,
+			])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -431,13 +463,13 @@ class FolderManagerTest extends TestCase {
 			'folder_id' => 1,
 			'mount_point' => 'foo',
 			'permissions' => 3,
-			'quota' => 1000
+			'quota' => 1000,
 		];
 		$folder2 = [
 			'folder_id' => 1,
 			'mount_point' => 'foo',
 			'permissions' => 8,
-			'quota' => 1000
+			'quota' => 1000,
 		];
 
 		$manager->expects($this->any())


### PR DESCRIPTION
Partial backport of https://github.com/nextcloud/groupfolders/pull/3849 + https://github.com/nextcloud/groupfolders/pull/3886

This doesn't attempt to allow for multiple storages to be used, but uses the storage fileid of the groupfolder root to optimize getting the file metadata for groupfolders, as it can now simply join by fileid instead of having to do a parent+name.