### PR TITLE
per groupfolder storage

### DIFF
--- a/.github/workflows/phpunit-sqlite-s3.yml
+++ b/.github/workflows/phpunit-sqlite-s3.yml
@@ -1,0 +1,210 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+#
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: PHPUnit SQLite - S3
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpunit-sqlite-s3-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest-low
+    outputs:
+      php-version: ${{ steps.versions.outputs.php-available-list }}
+      server-max: ${{ steps.versions.outputs.branches-max-list }}
+    steps:
+      - name: Checkout app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Get version matrix
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
+  phpunit-sqlite:
+    runs-on: ubuntu-latest
+
+    needs: [changes, matrix]
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      matrix:
+        php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
+        server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+
+    name: SQLite PHP S3 ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
+
+    services:
+      minio:
+        image: bitnami/minio@sha256:50cec18ac4184af4671a78aedd5554942c8ae105d51a465fa82037949046da01 # v2025.4.22
+        env:
+          MINIO_ROOT_USER: nextcloud
+          MINIO_ROOT_PASSWORD: bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ=
+          MINIO_DEFAULT_BUCKETS: nextcloud
+        ports:
+          - "9000:9000"
+
+    steps:
+      - name: Set app env
+        if: ${{ env.APP_NAME == '' }}
+        run: |
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          ref: ${{ matrix.server-versions }}
+
+      - name: Checkout Circles
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          repository: nextcloud/circles
+          ref: master
+          path: apps/circles
+
+      - name: Checkout app
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
+        with:
+          php-version: ${{ matrix.php-versions }}
+          # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          coverage: none
+          ini-file: development
+          # Temporary workaround for missing pcntl_* in PHP 8.3
+          ini-values: disable_functions=
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up Circles dependencies
+        working-directory: apps/circles
+        run: composer i
+
+      - name: Set up dependencies
+        # Only run if phpunit config file exists
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          echo '<?php $CONFIG=["objectstore" => ["class" => "OC\Files\ObjectStore\S3", "arguments" => ["bucket" => "nextcloud", "autocreate" => true, "key" => "nextcloud", "secret" => "bWluaW8tc2VjcmV0LWtleS1uZXh0Y2xvdWQ=", "hostname" => "localhost", "port" => 9000, "use_ssl" => false, "use_path_style" => true, "uploadPartSize" => 52428800]]];' > config/config.php
+          ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
+          ./occ app:enable --force circles
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Check PHPUnit script is defined
+        id: check_phpunit
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:unit ' | wc -l | grep 1
+
+      - name: PHPUnit
+        # Only run if phpunit config file exists
+        if: steps.check_phpunit.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:unit
+
+      - name: Check PHPUnit integration script is defined
+        id: check_integration
+        continue-on-error: true
+        working-directory: apps/${{ env.APP_NAME }}
+        run: |
+          composer run --list | grep '^  test:integration ' | wc -l | grep 1
+
+      - name: Run Nextcloud
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        run: php -S localhost:8080 &
+
+      - name: PHPUnit integration
+        # Only run if phpunit integration config file exists
+        if: steps.check_integration.outcome == 'success'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer run test:integration
+
+      - name: Print logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
+
+      - name: Skipped
+        # Fail the action when neither unit nor integration tests ran
+        if: steps.check_phpunit.outcome == 'failure' && steps.check_integration.outcome == 'failure'
+        run: |
+          echo 'Neither PHPUnit nor PHPUnit integration tests are specified in composer.json scripts'
+          exit 1
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, phpunit-sqlite]
+
+    if: always()
+
+    name: phpunit-sqlite-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.phpunit-sqlite.result != 'success' }}; then exit 1; fi

--- a/lib/Folder/FolderDefinition.php
+++ b/lib/Folder/FolderDefinition.php
@@ -16,6 +16,11 @@ class FolderDefinition {
 		public readonly bool $acl,
 		public readonly int $storageId,
 		public readonly int $rootId,
+		public readonly array $options,
 	) {
+	}
+
+	public function useSeparateStorage(): bool {
+		return $this->options['separate-storage'] ?? false;
 	}
 }

--- a/lib/Folder/FolderDefinitionWithMappings.php
+++ b/lib/Folder/FolderDefinitionWithMappings.php
@@ -26,10 +26,11 @@ class FolderDefinitionWithMappings extends FolderDefinition {
 		bool $acl,
 		int $storageId,
 		int $rootId,
+		array $options,
 		public readonly array $groups,
 		public readonly array $manage,
 	) {
-		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId);
+		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId, $options);
 	}
 
 	/**
@@ -44,6 +45,7 @@ class FolderDefinitionWithMappings extends FolderDefinition {
 			$folder->acl,
 			$folder->storageId,
 			$folder->rootId,
+			$folder->options,
 			$groups,
 			$manage,
 		);

--- a/lib/Folder/FolderDefinitionWithPermissions.php
+++ b/lib/Folder/FolderDefinitionWithPermissions.php
@@ -27,10 +27,11 @@ class FolderDefinitionWithPermissions extends FolderDefinition {
 		bool $acl,
 		int $storageId,
 		int $rootId,
+		array $options,
 		public readonly ICacheEntry $rootCacheEntry,
 		public readonly int $permissions,
 	) {
-		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId);
+		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId, $options);
 	}
 
 	/**
@@ -45,6 +46,7 @@ class FolderDefinitionWithPermissions extends FolderDefinition {
 			$folder->acl,
 			$folder->storageId,
 			$folder->rootId,
+			$folder->options,
 			$rootCacheEntry,
 			$permissions,
 		);
@@ -71,6 +73,7 @@ class FolderDefinitionWithPermissions extends FolderDefinition {
 			$this->acl,
 			$this->storageId,
 			$this->rootId,
+			$this->options,
 			$this->rootCacheEntry,
 			$this->permissions | $permissions,
 		);

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -77,7 +77,7 @@ class FolderManager {
 
 		$query = $this->connection->getQueryBuilder();
 
-		$query->select('folder_id', 'mount_point', 'quota', 'acl', 'storage_id', 'root_id')
+		$query->select('folder_id', 'mount_point', 'quota', 'acl', 'storage_id', 'root_id', 'options')
 			->from('group_folders', 'f');
 
 		$rows = $query->executeQuery()->fetchAll();
@@ -108,6 +108,7 @@ class FolderManager {
 			'acl',
 			'storage_id',
 			'root_id',
+			'options',
 			'c.fileid',
 			'c.storage',
 			'c.path',
@@ -549,6 +550,7 @@ class FolderManager {
 	}
 
 	private function rowToFolder(array $row): FolderDefinition {
+		$options = json_decode($row['options'], true);
 		return new FolderDefinition(
 			(int)$row['folder_id'],
 			(string)$row['mount_point'],
@@ -556,6 +558,7 @@ class FolderManager {
 			(bool)$row['acl'],
 			(int)$row['storage_id'],
 			(int)$row['root_id'],
+			is_array($options) ? $options : [],
 		);
 	}
 
@@ -660,11 +663,14 @@ class FolderManager {
 			->values([
 				'mount_point' => $query->createNamedParameter($mountPoint),
 				'quota' => self::SPACE_DEFAULT,
+				'options' => $query->createNamedParameter(json_encode([
+					'separate-storage' => true,
+				]))
 			]);
 		$query->executeStatement();
 		$id = $query->getLastInsertId();
 
-		['storage_id' => $storageId, 'root_id' => $rootId] = $this->folderStorageManager->getRootAndStorageIdForFolder($id);
+		['storage_id' => $storageId, 'root_id' => $rootId] = $this->folderStorageManager->getRootAndStorageIdForFolder($id, true);
 		$query->update('group_folders')
 			->set('root_id', $query->createNamedParameter($rootId))
 			->set('storage_id', $query->createNamedParameter($storageId))

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -670,7 +670,7 @@ class FolderManager {
 		$query->executeStatement();
 		$id = $query->getLastInsertId();
 
-		['storage_id' => $storageId, 'root_id' => $rootId] = $this->folderStorageManager->getRootAndStorageIdForFolder($id, true);
+		['storage_id' => $storageId, 'root_id' => $rootId] = $this->folderStorageManager->initRootAndStorageForFolder($id, true);
 		$query->update('group_folders')
 			->set('root_id', $query->createNamedParameter($rootId))
 			->set('storage_id', $query->createNamedParameter($storageId))

--- a/lib/Folder/FolderWithMappingsAndCache.php
+++ b/lib/Folder/FolderWithMappingsAndCache.php
@@ -27,11 +27,12 @@ class FolderWithMappingsAndCache extends FolderDefinitionWithMappings {
 		bool $acl,
 		int $storageId,
 		int $rootId,
+		array $options,
 		array $groups,
 		array $manage,
 		public readonly ICacheEntry $rootCacheEntry,
 	) {
-		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId, $groups, $manage);
+		parent::__construct($id, $mountPoint, $quota, $acl, $storageId, $rootId, $options, $groups, $manage);
 	}
 
 	/**
@@ -46,6 +47,7 @@ class FolderWithMappingsAndCache extends FolderDefinitionWithMappings {
 			$folder->acl,
 			$folder->storageId,
 			$folder->rootId,
+			$folder->options,
 			$folder->groups,
 			$folder->manage,
 			$rootCacheEntry,

--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\Mount;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Storage\Local;
 use OC\Files\Storage\Wrapper\Jail;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
 use OCA\GroupFolders\ACL\ACLStorageWrapper;
@@ -18,6 +19,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\IAppConfig;
+use OCP\IConfig;
 use OCP\IUser;
 
 class FolderStorageManager {
@@ -27,6 +29,7 @@ class FolderStorageManager {
 		private readonly IRootFolder $rootFolder,
 		private readonly IAppConfig $appConfig,
 		private readonly ACLManagerFactory $aclManagerFactory,
+		private readonly IConfig $config,
 	) {
 		$this->enableEncryption = $this->appConfig->getValueString('groupfolders', 'enable_encryption', 'false') === 'true';
 	}
@@ -34,8 +37,8 @@ class FolderStorageManager {
 	/**
 	 * @return array{storage_id: int, root_id: int}
 	 */
-	public function getRootAndStorageIdForFolder(int $folderId): array {
-		$storage = $this->getBaseStorageForFolder($folderId);
+	public function getRootAndStorageIdForFolder(int $folderId, bool $separateStorage): array {
+		$storage = $this->getBaseStorageForFolder($folderId, $separateStorage);
 		$cache = $storage->getCache();
 		$id = $cache->getId('');
 		if ($id === -1) {
@@ -54,7 +57,72 @@ class FolderStorageManager {
 	/**
 	 * @param 'files'|'trash'|'versions' $type
 	 */
-	public function getBaseStorageForFolder(int $folderId, ?FolderDefinition $folder = null, ?IUser $user = null, bool $inShare = false, string $type = 'files'): IStorage {
+	public function getBaseStorageForFolder(
+		int $folderId,
+		bool $separateStorage,
+		?FolderDefinition $folder = null,
+		?IUser $user = null,
+		bool $inShare = false,
+		string $type = 'files',
+	): IStorage {
+		if ($separateStorage) {
+			return $this->getBaseStorageForFolderSeparateStorageLocal($folderId, $folder, $user, $inShare, $type);
+		} else {
+			return $this->getBaseStorageForFolderRootJail($folderId, $folder, $user, $inShare, $type);
+		}
+	}
+
+	/**
+	 * @param 'files'|'trash'|'versions' $type
+	 */
+	public function getBaseStorageForFolderSeparateStorageLocal(
+		int $folderId,
+		?FolderDefinition $folder = null,
+		?IUser $user = null,
+		bool $inShare = false,
+		string $type = 'files',
+	): IStorage {
+		$dataDirectory = $this->config->getSystemValue('datadirectory');
+		$rootPath = $dataDirectory . '/__groupfolders/' . $folderId;
+		$init = !is_dir($rootPath);
+		if ($init) {
+			mkdir($rootPath, 0777, true);
+			mkdir($rootPath . '/files');
+			mkdir($rootPath . '/trash');
+			mkdir($rootPath . '/versions');
+		}
+
+		$storage = new Local([
+			'datadir' => $rootPath,
+		]);
+
+		if ($init) {
+			$storage->getScanner()->scan('');
+		}
+
+		if ($folder && $folder->acl && $user) {
+			$aclManager = $this->aclManagerFactory->getACLManager($user);
+			return new ACLStorageWrapper([
+				'storage' => $storage,
+				'acl_manager' => $aclManager,
+				'in_share' => $inShare,
+				'storage_id' => $storage->getCache()->getNumericStorageId(),
+			]);
+		} else {
+			return $storage;
+		}
+	}
+
+	/**
+	 * @param 'files'|'trash'|'versions' $type
+	 */
+	public function getBaseStorageForFolderRootJail(
+		int $folderId,
+		?FolderDefinition $folder = null,
+		?IUser $user = null,
+		bool $inShare = false,
+		string $type = 'files',
+	): IStorage {
 		try {
 			/** @var Folder $parentFolder */
 			$parentFolder = $this->rootFolder->get('__groupfolders');
@@ -106,7 +174,7 @@ class FolderStorageManager {
 
 	public function deleteStoragesForFolder(FolderDefinition $folder): void {
 		foreach (['files', 'trash', 'versions'] as $type) {
-			$storage = $this->getBaseStorageForFolder($folder->id, $folder, null, false, $type);
+			$storage = $this->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder, null, false, $type);
 			/** @var Cache $cache */
 			$cache = $storage->getCache();
 			$cache->clear();

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -160,7 +160,7 @@ class MountProvider implements IMountProvider {
 		?ICacheEntry $cacheEntry = null,
 	): IMountPoint {
 
-		$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, null, false, 'trash');
+		$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder, null, false, 'trash');
 
 		if ($user) {
 			$storage->setOwner($user->getUID());
@@ -184,7 +184,7 @@ class MountProvider implements IMountProvider {
 		?ICacheEntry $cacheEntry = null,
 	): IMountPoint {
 		if (!$cacheEntry) {
-			$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, null, false, 'versions');
+			$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder, null, false, 'versions');
 			$cacheEntry = $storage->getCache()->get('');
 			if (!$cacheEntry) {
 				$storage->getScanner()->scan('');
@@ -221,9 +221,9 @@ class MountProvider implements IMountProvider {
 	): IStorage {
 		if ($user) {
 			$inShare = !\OC::$CLI && ($this->getCurrentUID() === null || $this->getCurrentUID() !== $user->getUID());
-			$baseStorage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, $user, $inShare, $type);
+			$baseStorage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder, $user, $inShare, $type);
 		} else {
-			$baseStorage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, null, false, $type);
+			$baseStorage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder, null, false, $type);
 		}
 
 		if ($user) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,6 +38,7 @@
 		<file name="tests/stubs/oc_files_node_node.php" />
 		<file name="tests/stubs/oc_files_objectstore_objectstorescanner.php" />
 		<file name="tests/stubs/oc_files_objectstore_objectstorestorage.php" />
+		<file name="tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php" />
 		<file name="tests/stubs/oc_files_setupmanager.php" />
 		<file name="tests/stubs/oc_files_storage_common.php" />
 		<file name="tests/stubs/oc_files_storage_local.php" />

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -376,6 +376,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			31,
 		);
@@ -404,6 +405,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			3,
 		);
@@ -414,6 +416,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			8,
 		);
@@ -424,6 +427,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			8 + 3,
 		);
@@ -452,6 +456,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			3,
 		);
@@ -462,6 +467,7 @@ class FolderManagerTest extends TestCase {
 			false,
 			1,
 			2,
+			[],
 			$cacheEntry,
 			8,
 		);

--- a/tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php
+++ b/tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OC\Files\ObjectStore;
+
+/**
+ * @psalm-type ObjectStoreConfig array{class: class-string<IObjectStore>, arguments: array{multibucket: bool, ...}}
+ */
+class PrimaryObjectStoreConfig
+{
+    public function __construct(private readonly \OCP\IConfig $config, private readonly \OCP\App\IAppManager $appManager)
+    {
+    }
+    /**
+     * @param ObjectStoreConfig $config
+     */
+    public function buildObjectStore(array $config): \OCP\Files\ObjectStore\IObjectStore
+    {
+    }
+    /**
+     * @return ?ObjectStoreConfig
+     */
+    public function getObjectStoreConfigForRoot(): ?array
+    {
+    }
+    /**
+     * @return ?ObjectStoreConfig
+     */
+    public function getObjectStoreConfigForUser(\OCP\IUser $user): ?array
+    {
+    }
+    /**
+     * @param string $name
+     * @return ObjectStoreConfig
+     */
+    public function getObjectStoreConfiguration(string $name): array
+    {
+    }
+    public function resolveAlias(string $name): string
+    {
+    }
+    public function hasObjectStore(): bool
+    {
+    }
+    public function hasMultipleObjectStorages(): bool
+    {
+    }
+    /**
+     * @return ?array<string, ObjectStoreConfig|string>
+     * @throws InvalidObjectStoreConfigurationException
+     */
+    public function getObjectStoreConfigs(): ?array
+    {
+    }
+    public function getBucketForUser(\OCP\IUser $user, array $config): string
+    {
+    }
+    public function getSetBucketForUser(\OCP\IUser $user): ?string
+    {
+    }
+    public function getObjectStoreForUser(\OCP\IUser $user): string
+    {
+    }
+}


### PR DESCRIPTION
- [x] https://github.com/nextcloud/groupfolders/pull/3849
- [x] https://github.com/nextcloud/groupfolders/pull/3887
- [x] https://github.com/nextcloud/groupfolders/pull/3941
- [x] https://github.com/nextcloud/groupfolders/pull/3921
- [x] https://github.com/nextcloud/groupfolders/pull/3943
- [x] actually setup different storages per groupfolder (this PR)

Currently groupfolders are stored under `__groupfolders` in the root storage, using jail mounts to mount the individual groupfolders for the users. This was done to simplify the app's code (no need for special object store handling etc) but comes with the limitation that, in multi-bucket object store setups, all groupfolder files are still stored on the same bucket.

This changes things to instead create a single storage per groupfolder (jails are still being used to separate out the files, trash and versions as separate mounts, while keeping those stored together logically).

For local primary storage, the files are now stored in `$datadir/__groupfolders/$folderId/files` (and `$datadir/__groupfolders/$folderId/trash`/`$datadir/__groupfolders/$folderId/versions` for trashbin/versions) where `$datadir/__groupfolders/$folderId` is the root of the per-groupfolder local storage.

For object store, similar logic to home storage is used to support multi-instance and multi-bucket object store but with folder ids instead of user ids.

All the new logic only affects newly created groupfolders, existing ones keep the old storage layout