### PR TITLE
fix: make version backend storage location agnostic

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,7 +35,6 @@ use OCA\GroupFolders\Mount\MountProvider;
 use OCA\GroupFolders\Trash\TrashBackend;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCA\GroupFolders\Versions\GroupVersionsExpireManager;
-use OCA\GroupFolders\Versions\GroupVersionsMapper;
 use OCA\GroupFolders\Versions\VersionsBackend;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -47,7 +46,6 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Folder;
-use OCP\Files\IMimeTypeLoader;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\NotFoundException;
@@ -144,16 +142,6 @@ class Application extends App implements IBootstrap {
 
 			return $trashBackend;
 		});
-
-		$context->registerService(VersionsBackend::class, fn (ContainerInterface $c): VersionsBackend => new VersionsBackend(
-			$c->get(IRootFolder::class),
-			$c->get('GroupAppFolder'),
-			$c->get(MountProvider::class),
-			$c->get(LoggerInterface::class),
-			$c->get(GroupVersionsMapper::class),
-			$c->get(IMimeTypeLoader::class),
-			$c->get(IUserSession::class),
-		));
 
 		$context->registerService(ExpireGroupBase::class, function (ContainerInterface $c): ExpireGroupBase {
 			// Multiple implementation of this class exists depending on if the trash and versions

--- a/lib/Mount/GroupMountPoint.php
+++ b/lib/Mount/GroupMountPoint.php
@@ -10,6 +10,7 @@ namespace OCA\GroupFolders\Mount;
 
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Storage;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCP\Files\Mount\IShareOwnerlessMount;
 use OCP\Files\Mount\ISystemMountPoint;
 use OCP\Files\Storage\IStorage;
@@ -17,7 +18,7 @@ use OCP\Files\Storage\IStorageFactory;
 
 class GroupMountPoint extends MountPoint implements ISystemMountPoint, IShareOwnerlessMount {
 	public function __construct(
-		private readonly int $folderId,
+		private readonly FolderDefinition $folder,
 		IStorage $storage,
 		string $mountpoint,
 		?array $arguments = null,
@@ -36,10 +37,15 @@ class GroupMountPoint extends MountPoint implements ISystemMountPoint, IShareOwn
 	}
 
 	public function getFolderId(): int {
-		return $this->folderId;
+		return $this->folder->id;
+	}
+
+	public function getFolder(): FolderDefinition {
+		return $this->folder;
 	}
 
 	public function getSourcePath(): string {
+		// todo
 		return '/__groupfolders/' . $this->getFolderId();
 	}
 }

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -11,6 +11,7 @@ namespace OCA\GroupFolders\Mount;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OCA\GroupFolders\ACL\ACLManager;
 use OCA\GroupFolders\ACL\ACLManagerFactory;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCP\Constants;
@@ -90,7 +91,7 @@ class MountProvider implements IMountProvider {
 				$loader,
 				$user,
 				$aclManager,
-				$rootRules
+				$rootRules,
 			);
 		}, $folders));
 	}
@@ -150,7 +151,7 @@ class MountProvider implements IMountProvider {
 		}
 
 		return new GroupMountPoint(
-			$folder->id,
+			$folder,
 			$maskedStore,
 			$mountPoint,
 			null,
@@ -168,18 +169,51 @@ class MountProvider implements IMountProvider {
 		?ICacheEntry $cacheEntry = null,
 	): IMountPoint {
 
-		$storage = $this->getRootFolder()->getStorage();
+		$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, null, false, 'trash');
 
 		$storage->setOwner($user->getUID());
 
 		$trashStorage = $this->getGroupFolderStorage($folder, $user, $cacheEntry, 'trash');
 
 		return new GroupMountPoint(
-			$folder->id,
+			$folder,
 			$trashStorage,
 			$mountPoint,
 			null,
-			$loader
+			$loader,
+		);
+	}
+
+	public function getVersionsMount(
+		FolderDefinition $folder,
+		string $mountPoint,
+		IStorageFactory $loader,
+		?ICacheEntry $cacheEntry = null,
+	): IMountPoint {
+		if (!$cacheEntry) {
+			$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder, null, false, 'versions');
+			$cacheEntry = $storage->getCache()->get('');
+			if (!$cacheEntry) {
+				$storage->getScanner()->scan('');
+				$cacheEntry = $storage->getCache()->get('');
+				if (!$cacheEntry) {
+					throw new \Exception('Group folder version root is not in cache even after scanning for folder ' . $folder->id);
+				}
+			}
+		}
+
+		$versionStorage = $this->getGroupFolderStorage(
+			FolderDefinitionWithPermissions::fromFolder($folder, $cacheEntry, Constants::PERMISSION_ALL),
+			null, $cacheEntry,
+			'versions'
+		);
+
+		return new GroupMountPoint(
+			$folder,
+			$versionStorage,
+			$mountPoint,
+			null,
+			$loader,
 		);
 	}
 

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -631,7 +631,7 @@ class TrashBackend implements ITrashBackend {
 					$node->getStorage()->getCache()->remove($node->getInternalPath());
 					$this->trashManager->removeItem($folderId, $groupTrashItem['name'], $groupTrashItem['deleted_time']);
 					if (!is_null($groupTrashItem['file_id']) && !is_null($this->versionsBackend)) {
-						$this->versionsBackend->deleteAllVersionsForFile($folderId, $groupTrashItem['file_id']);
+						$this->versionsBackend->deleteAllVersionsForFile($folder, $groupTrashItem['file_id']);
 					}
 				} else {
 					$this->logger->debug($node->getPath() . " isn't set to be expired yet, stopping expiry");

--- a/lib/Versions/GroupVersion.php
+++ b/lib/Versions/GroupVersion.php
@@ -10,6 +10,7 @@ namespace OCA\GroupFolders\Versions;
 
 use OCA\Files_Versions\Versions\IVersionBackend;
 use OCA\Files_Versions\Versions\Version;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IUser;
@@ -27,7 +28,7 @@ class GroupVersion extends Version {
 		IUser $user,
 		array $metadata,
 		private readonly File $versionFile,
-		private readonly int $folderId,
+		private readonly FolderDefinition $folder,
 	) {
 		parent::__construct($timestamp, $revisionId, $name, $size, $mimetype, $path, $sourceFileInfo, $backend, $user, $metadata);
 	}
@@ -37,6 +38,6 @@ class GroupVersion extends Version {
 	}
 
 	public function getFolderId(): int {
-		return $this->folderId;
+		return $this->folder->id;
 	}
 }


### PR DESCRIPTION
Removes assumptions from how groupfolders are stored from the versions backend, instead always go trough a version mount.

In preparation of supporting per-groupfolder storages.