### PR TITLE
[stable29] fix: Return folder id correctly after creating it

### DIFF
--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -87,8 +87,8 @@ export class Api {
 	async createFolder(mountPoint: string): Promise<number> {
 		await confirmPassword()
 
-		const response = await axios.post<OCSResponse<number>>(this.getUrl('folders'), { mountpoint: mountPoint })
-		return response.data.ocs.data
+		const response = await axios.post<OCSResponse<{ id: number }>>(this.getUrl('folders'), { mountpoint: mountPoint })
+		return response.data.ocs.data.id
 	}
 
 	async deleteFolder(id: number): Promise<void> {


### PR DESCRIPTION
The folder ID is wrapped in an object: https://github.com/nextcloud/groupfolders/blob/9ab5ed1cfe5cc62fe9629caed09e7bbed22216ba/lib/Controller/FolderController.php#L167

On 30+ this is fixed already.