### PR TITLE
chore: 20.0.0

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ Folders can be configured from *Team folders* in the admin settings.
 After a folder is created, the admin can give access to the folder to one or more teams, control their write/sharing permissions and assign a quota for the folder.
 As of Hub 10/Nextcloud 31, the admin needs to be a part of the team to be able to assign it a Teamfolder.
 ]]></description>
-	<version>20.0.0-dev.1</version>
+	<version>20.0.0</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>


### PR DESCRIPTION
# 20.0.0
## What's Changed
### Features
* feat: ACL on nested teams by @ArtificialOwl in https://github.com/nextcloud/groupfolders/pull/3735
* feat: add "team" in description of app functionality by @alexanderdd in https://github.com/nextcloud/groupfolders/pull/3879
* feat: Add pagination for admin interface by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3808
* feat: Allow per-groupfolder storage by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3849
* feat: Use Delete icon instead of Close icon by @solracsf in https://github.com/nextcloud/groupfolders/pull/3705
* feat: replace icons with outline versions by @skjnldsv in https://github.com/nextcloud/groupfolders/pull/3895
* feat: setup acl for teams from occ by @ArtificialOwl in https://github.com/nextcloud/groupfolders/pull/3785
* feat(Commands): Improve descriptions of `permissions` arguments by @artonge in https://github.com/nextcloud/groupfolders/pull/3822

### Fixes
* fix: add `orderby` to pagination to prevent sorting issues by @susnux in https://github.com/nextcloud/groupfolders/pull/3837
* fix: add mount type to node info by @susnux in https://github.com/nextcloud/groupfolders/pull/3651
* fix: catch some acl errors when listing trashbin by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3592
* fix: don't error in getRelevantPaths if the root of the trash is passed by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3753
* fix: Enforce strict types everywhere by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3234
* fix: make migration for storing gf root and storage id compatible with sharding by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3886
* fix: prevent duplicate mount points by @skjnldsv in https://github.com/nextcloud/groupfolders/pull/3752
* fix: scan command not reporting scanned files and folders by @st3iny in https://github.com/nextcloud/groupfolders/pull/3850
* fix(ACL): Don't check ACL permissions if user doesn't have access to the folder in the first place by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3867
* fix(ACLPlugin): Use correct path to test new permissions by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3699
* fix(dav): only list top-level groupfolders by @skjnldsv in https://github.com/nextcloud/groupfolders/pull/3751
* fix(settings): use natural sorting by @skjnldsv in https://github.com/nextcloud/groupfolders/pull/3750
* fix(trash): Fix deleting items from public share with write access by @come-nc in https://github.com/nextcloud/groupfolders/pull/3604
* fix(trashbackend): Fix type in userHasAccessToFolder by @CarlSchwan in https://github.com/nextcloud/groupfolders/pull/3912
* fix(versions): Avoid new version entity if it exists on DB by @solracsf in https://github.com/nextcloud/groupfolders/pull/3874
* fix(VersionsBackend): Add missing getRevision method by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3885
* lighter request on circle memberships by @ArtificialOwl in https://github.com/nextcloud/groupfolders/pull/3571
* OCS API Returns updated groupfolder data after modifications by @aaronsegura in https://github.com/nextcloud/groupfolders/pull/3666
* only setup trash mount when required by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3672
* perf(FolderManager): Allow filtering getFoldersForUser by userId directly by @provokateurin in https://github.com/nextcloud/groupfolders/pull/3883
* remove storage to switch to a better index by @ArtificialOwl in https://github.com/nextcloud/groupfolders/pull/3826
* Test with sharding in ci by @icewind1991 in https://github.com/nextcloud/groupfolders/pull/3497

## New Contributors
* @aaronsegura made their first contribution in https://github.com/nextcloud/groupfolders/pull/3666
* @st3iny made their first contribution in https://github.com/nextcloud/groupfolders/pull/3850
* @alexanderdd made their first contribution in https://github.com/nextcloud/groupfolders/pull/3879

**Full Changelog**: https://github.com/nextcloud/groupfolders/compare/v19.0.0...v20.0.0