### PR TITLE
fix: Reuse already known rootId

### DIFF
--- a/lib/Mount/GroupMountPoint.php
+++ b/lib/Mount/GroupMountPoint.php
@@ -24,9 +24,11 @@ class GroupMountPoint extends MountPoint implements ISystemMountPoint, IShareOwn
 		?IStorageFactory $loader = null,
 		?array $mountOptions = null,
 		?int $mountId = null,
+		?int $rootId = null,
 	) {
 		/** @var Storage $storage */
 		parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId, MountProvider::class);
+		$this->rootId = $rootId;
 	}
 
 	public function getMountType(): string {

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -154,7 +154,8 @@ class MountProvider implements IMountProvider {
 			$maskedStore,
 			$mountPoint,
 			null,
-			$loader
+			$loader,
+			rootId: $folder->rootId,
 		);
 	}
 


### PR DESCRIPTION
When setting up the file system, we check for `storageRootId` of `-1`:

https://github.com/nextcloud/server/blob/4d65b91b0672fd2ef160a59ef91947eaccfb13a7/lib/private/Files/Config/UserMountCache.php#L66-L69

If there's no `rootId` set on the MountPoint, we try to create the storage and retrieve the `rootId`:

https://github.com/nextcloud/server/blob/4d65b91b0672fd2ef160a59ef91947eaccfb13a7/lib/private/Files/Mount/MountPoint.php#L269-L280

In worst case, if the information is not cached yet, we do a DB query to get the `rootId`