### PR TITLE
fix(RuleManager): Filter empty rules

### DIFF
--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -62,12 +62,9 @@ class RuleManager {
 
 		$result = [];
 		foreach ($rows as $row) {
-			if (!isset($result[$row['fileid']])) {
-				$result[$row['fileid']] = [];
-			}
-
 			$rule = $this->createRule($row);
 			if ($rule) {
+				$result[$row['fileid']] ??= [];
 				$result[$row['fileid']][] = $rule;
 			}
 		}
@@ -162,13 +159,10 @@ class RuleManager {
 
 		$result = [];
 		foreach ($rows as $row) {
-			if (!isset($result[$row['path']])) {
-				$result[$row['path']] = [];
-			}
-
 			if ($row['mapping_type'] !== null) {
 				$rule = $this->createRule($row);
 				if ($rule) {
+					$result[$row['path']] ??= [];
 					$result[$row['path']][] = $rule;
 				}
 			}
@@ -207,12 +201,9 @@ class RuleManager {
 
 	private function rulesByPath(array $rows, array $result = []): array {
 		foreach ($rows as $row) {
-			if (!isset($result[$row['path']])) {
-				$result[$row['path']] = [];
-			}
-
 			$rule = $this->createRule($row);
 			if ($rule) {
+				$result[$row['path']] ??= [];
 				$result[$row['path']][] = $rule;
 			}
 		}
@@ -225,12 +216,9 @@ class RuleManager {
 	private function rulesByFileId(array $rows): array {
 		$result = [];
 		foreach ($rows as $row) {
-			if (!isset($result[$row['path']])) {
-				$result[$row['path']] = [];
-			}
-
 			$rule = $this->createRule($row);
 			if ($rule) {
+				$result[$row['path']] ??= [];
 				$result[$row['path']][] = $rule;
 			}
 		}


### PR DESCRIPTION
`createRule` might return `null` if the mapping doesn't exist anymore. If the affected rule was the only rule for the path/fileid, the array would be empty and result in empty rows in `occ groupfolders:permissions`.