### PR TITLE
fix: ensure user id is string in search result

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -516,7 +516,7 @@ class FolderManager {
 				foreach ($foundUsers as $uid => $displayName) {
 					if (!isset($users[$uid])) {
 						$users[$uid] = [
-							'uid' => $uid,
+							'uid' => (string)$uid,
 							'displayname' => $displayName,
 						];
 					}


### PR DESCRIPTION
Ensures that numeric user ids can be assigned as ACL manager