### PR TITLE
[stable31] fix: ensure user id is string in search result

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -541,7 +541,7 @@ class FolderManager {
 				foreach ($foundUsers as $uid => $displayName) {
 					if (!isset($users[$uid])) {
 						$users[$uid] = [
-							'uid' => $uid,
+							'uid' => (string)$uid,
 							'displayname' => $displayName
 						];
 					}


### PR DESCRIPTION
Backport of https://github.com/nextcloud/groupfolders/pull/3953