### PR TITLE
fix: Make group permissions strings translatable

### DIFF
--- a/src/settings/FolderGroups.tsx
+++ b/src/settings/FolderGroups.tsx
@@ -78,9 +78,9 @@ export function FolderGroups({ groups, allGroups = [], allCircles = [], onAddGro
 			<thead>
 				<tr>
 					<th>{groupHeader}</th>
-					<th>Write</th>
-					<th>Share</th>
-					<th>Delete</th>
+					<th>{t('groupfolders', 'Write')}</th>
+					<th>{t('groupfolders', 'Share')}</th>
+					<th>{t('groupfolders', 'Delete')}</th>
 					<th/>
 				</tr>
 			</thead>


### PR DESCRIPTION
<img width="1013" height="334" alt="image" src="https://github.com/user-attachments/assets/497ebabe-9e7d-4c03-8da1-3f2a8b800d85" />