### PR TITLE
fix: Stop overwriting scan_permissions

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -44,7 +44,7 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	protected function formatCacheEntry($entry, array $rules = []): ICacheEntry|false {
 		if (isset($entry['permissions'])) {
-			$entry['scan_permissions'] = $entry['permissions'];
+			$entry['scan_permissions'] ??= $entry['permissions'];
 			$entry['permissions'] &= $this->getACLPermissionsForPath($entry['path'], $rules);
 			if (!$entry['permissions']) {
 				return false;

--- a/lib/Mount/CacheRootPermissionsMask.php
+++ b/lib/Mount/CacheRootPermissionsMask.php
@@ -24,7 +24,7 @@ class CacheRootPermissionsMask extends CacheWrapper {
 	protected function formatCacheEntry($entry): ICacheEntry|false {
 		$isRoot = $entry->getId() === $this->rootId;
 		if (isset($entry['permissions']) && $isRoot) {
-			$entry['scan_permissions'] = $entry['permissions'];
+			$entry['scan_permissions'] ??= $entry['permissions'];
 			$entry['permissions'] &= $this->mask;
 		}
 


### PR DESCRIPTION
See https://github.com/nextcloud/server/pull/55374. The bug is not here, but for completeness and to avoid issues in the future it should be fixed here as well.