### PR TITLE
fix(quota): Convert custom quota value from base 1000 to base 1024

### DIFF
--- a/src/settings/QuotaSelect.tsx
+++ b/src/settings/QuotaSelect.tsx
@@ -47,7 +47,7 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 	}
 
 	onEditedValue = (value) => {
-		const size = parseFileSize(value)
+		const size = parseFileSize(value, true)
 		if (!size) {
 			this.setState({ isValidInput: false })
 		} else {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/4112

When entering a value like 200GB it needs to be converted to GiB, as that is the unit we use, even though we still display it as GB. Otherwise the value that is displayed afterwards is lower, due to 1GiB>1GB.