### PR TITLE
fix(command): Give formatted folders to writer

### DIFF
--- a/lib/Command/ListCommand.php
+++ b/lib/Command/ListCommand.php
@@ -84,11 +84,17 @@ class ListCommand extends Base {
 			foreach ($formatted as &$folder) {
 				$folder['size'] = $folder['root_cache_entry']->getSize();
 				unset($folder['root_cache_entry']);
-				$folder['group_details'] = $folder['groups'];
-				$folder['groups'] = array_map(fn (array $group): int => $group['permissions'], $folder['groups']);
+				$folder['groups_list'] = array_map(fn (array $group): int => $group['permissions'], $folder['groups']);
+				$folder['options'] = $folder['options'];
+				$folder['mountPoint'] = $folder['mount_point'];
+				unset($folder['mount_point']);
+				$folder['rootId'] = $folder['root_id'];
+				unset($folder['root_id']);
+				$folder['storageId'] = $folder['storage_id'];
+				unset($folder['storage_id']);
 			}
 
-			$this->writeArrayInOutputFormat($input, $output, $folders);
+			$this->writeArrayInOutputFormat($input, $output, $formatted);
 		} else {
 			$table = new Table($output);
 			$table->setHeaders(['Folder Id', 'Name', 'Groups', 'Quota', 'Size', 'Advanced Permissions', 'Manage advanced permissions']);

--- a/lib/Folder/FolderWithMappingsAndCache.php
+++ b/lib/Folder/FolderWithMappingsAndCache.php
@@ -65,6 +65,7 @@ class FolderWithMappingsAndCache extends FolderDefinitionWithMappings {
 			'root_cache_entry' => $this->rootCacheEntry,
 			'groups' => $this->groups,
 			'manage' => $this->manage,
+			'options' => $this->options,
 		];
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/4109

The output was missing the size, but now the properties have different names, so I also modified them to stick to the old output.

| Before | Without the renaming | After |
|--------|--------|--------|
| <img width="340" height="464" alt="Screenshot From 2025-11-07 15-26-58" src="https://github.com/user-attachments/assets/1865817b-a1b1-4c5f-893b-3ef5d5cd992d" /> | <img width="340" height="464" alt="Screenshot From 2025-11-07 15-26-34" src="https://github.com/user-attachments/assets/2baea5d1-52ea-41ef-9ba7-285f2b4441a7" /> | <img width="392" height="509" alt="image" src="https://github.com/user-attachments/assets/1aaa1c91-674e-4c18-8d17-aaf60f1c8325" />|






