### PR TITLE
fix(FolderManager): Use group display name instead of id for display name

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -258,7 +258,7 @@ class FolderManager {
 						'displayname' => $user->getDisplayName(),
 					];
 				case 'group':
-					$group = Server::get(IGroupManager::class)->get($entry['mapping_id']);
+					$group = $this->groupManager->get($entry['mapping_id']);
 					if ($group === null) {
 						return null;
 					}
@@ -364,7 +364,7 @@ class FolderManager {
 				$entityId = (string)$row['group_id'];
 
 				$entry = [
-					'displayName' => $row['group_id'],
+					'displayName' => $this->groupManager->get($row['group_id'])?->getDisplayName() ?? $row['group_id'],
 					'permissions' => (int)$row['permissions'],
 					'type' => 'group',
 				];


### PR DESCRIPTION
https://github.com/nextcloud/groupfolders/issues/3708