### PR TITLE
Show display name of user/group mapping in 'occ groupfolders:permissions'

### DIFF
--- a/lib/Command/ACL.php
+++ b/lib/Command/ACL.php
@@ -211,7 +211,12 @@ class ACL extends FolderCommand {
 			default:
 				$items = array_map(function (array $rulesForPath, string $path) use ($jailPathLength): array {
 					/** @var Rule[] $rulesForPath */
-					$mappings = array_map(fn (Rule $rule): string => $rule->getUserMapping()->getType() . ': ' . $rule->getUserMapping()->getId(), $rulesForPath);
+					$mappings = array_map(
+						fn (Rule $rule): string
+							=> $rule->getUserMapping()->getType()
+								. ': ' . $rule->getUserMapping()->getDisplayName() . ' (' . $rule->getUserMapping()->getId() . ')',
+						$rulesForPath,
+					);
 					$permissions = array_map(fn (Rule $rule): string => $rule->formatPermissions(), $rulesForPath);
 					$formattedPath = substr($path, $jailPathLength);
 


### PR DESCRIPTION
Group/user names can be informative there too.

```
+------+--------------------------+------------------+
| Path | User/Group               | Permissions      |
+------+--------------------------+------------------+
| /    | group: First group (gr1) | +read, +write    |
|      | user: Third user (user3) | +create, +delete |
+------+--------------------------+------------------+
```