### PR TITLE
fix: Downloading of trashbin files with specific filenames

### DIFF
--- a/lib/Trash/GroupTrashItem.php
+++ b/lib/Trash/GroupTrashItem.php
@@ -53,8 +53,13 @@ class GroupTrashItem extends TrashItem {
 	public function getInternalPath(): string {
 		// trashbin expects the path without the deletion timestamp
 		$path = parent::getInternalPath();
+		$deletionExtension = '.d' . $this->getDeletedTime();
 
-		return rtrim($path, '.d' . $this->getDeletedTime());
+		if (str_ends_with($path, $deletionExtension)) {
+			$path = substr($path, 0, -strlen($deletionExtension));
+		}
+
+		return $path;
 	}
 
 	public function getFullInternalPath(): string {


### PR DESCRIPTION
How to test:
* Create a new *.md file in a groupfolder
* Delete that file
* Go to trashbin and try to download that file

This will result in 

```
{
  "Exception": "TypeError",
  "Message": "fwrite(): Argument #2 ($data) must be of type string, bool given",
  "Code": 0,
  "Trace": [
    {
      "file": "/var/www/html/3rdparty/sabre/http/lib/Sapi.php",
      "line": 125,
      "function": "fwrite",
      "args": [
        null,
        false,
        4
      ]
    },
    {
      "file": "/var/www/html/3rdparty/sabre/dav/lib/DAV/Server.php",
      "line": 490,
      "function": "sendResponse",
      "class": "Sabre\\HTTP\\Sapi",
      "type": "::",
      "args": [
        {
          "__class__": "Sabre\\HTTP\\Response"
        }
      ]
    },
    {
      "file": "/var/www/html/apps/dav/lib/Connector/Sabre/Server.php",
      "line": 211,
      "function": "invokeMethod",
      "class": "Sabre\\DAV\\Server",
      "type": "->",
      "args": [
        {
          "__class__": "Sabre\\HTTP\\Request"
        },
        {
          "__class__": "Sabre\\HTTP\\Response"
        }
      ]
    },
    {
      "file": "/var/www/html/apps/dav/lib/Server.php",
      "line": 426,
      "function": "start",
      "class": "OCA\\DAV\\Connector\\Sabre\\Server",
      "type": "->",
      "args": []
    },
    {
      "file": "/var/www/html/apps/dav/appinfo/v2/remote.php",
      "line": 22,
      "function": "exec",
      "class": "OCA\\DAV\\Server",
      "type": "->",
      "args": []
    },
    {
      "file": "/var/www/html/remote.php",
      "line": 151,
      "args": [
        "/var/www/html/apps/dav/appinfo/v2/remote.php"
      ],
      "function": "require_once"
    }
  ],
  "File": "/var/www/html/3rdparty/sabre/http/lib/Sapi.php",
  "Line": 125,
  "message": "Uncaught exception",
  "exception": {},
  "CustomMessage": "Uncaught exception"
}
```

because we use `rtrim` to remove the deletion timestamp on the file, but this does remove all characters specified, not the whole string. In the *.md case we end up without the last "d", see:

<img width="755" height="458" alt="Bildschirmfoto 2025-12-14 um 14 47 30" src="https://github.com/user-attachments/assets/8c654811-cf5d-438e-ae21-8cda78aa9411" />

Example: https://3v4l.org/dfC0G