### PR TITLE
[stable31] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,10 +2222,11 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
-      "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
+      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -2233,14 +2234,14 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~4.0.0",
+        "form-data": "~4.0.4",
         "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.14.0",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
@@ -2248,6 +2249,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@cypress/request/node_modules/tough-cookie": {
@@ -4263,13 +4280,14 @@
       }
     },
     "node_modules/@nextcloud/cypress": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@nextcloud/cypress/-/cypress-1.0.0-beta.12.tgz",
-      "integrity": "sha512-/o+DiuX5LKeaIKpRvBiao8e4WXl0GJY+jn1NZpFg3jzYDQz4jDFx+wANvAzIlPpxoRqkKPPifZWwZc4IMYe0XQ==",
+      "version": "1.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cypress/-/cypress-1.0.0-beta.15.tgz",
+      "integrity": "sha512-0pTweoFmw9x0J2R1Ou+ycIw8aGuJGTrbudaorl4vFXUEDEIo4GAx136RzH1TzYkRn1zPxDloFi2qmHh54NMdng==",
       "dev": true,
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dockerode": "^4.0.2",
-        "fast-xml-parser": "^4.3.6",
+        "fast-xml-parser": "^5.2.2",
         "wait-on": "^8.0.0"
       },
       "engines": {
@@ -4280,34 +4298,65 @@
         "cypress": "^13.9.0"
       }
     },
+    "node_modules/@nextcloud/cypress/node_modules/fast-xml-parser": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.3.tgz",
+      "integrity": "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@nextcloud/cypress/node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nextcloud/dialogs": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.4.1.tgz",
-      "integrity": "sha512-Pr9pnZ21bwvvM43sc9tTLo3ETM6kIffmdILwvyfbTdCXkPcOsgggE2FI1c5iZUbtd8hrvAYMic4oZxhqA2izSA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.4.2.tgz",
+      "integrity": "sha512-xj6fyUdb56StWt1DWeDHYnqK0Ck7EWQLUEyWtXHnneknoOV3x/Y0HPRL5L2PTJaDuVQB8TcVW53JjR38JG9W6Q==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/browser-storage": "^0.5.0",
-        "@nextcloud/event-bus": "^3.3.2",
-        "@nextcloud/files": "^3.10.2",
+        "@nextcloud/event-bus": "^3.3.3",
+        "@nextcloud/files": "^3.12.2",
         "@nextcloud/initial-state": "^3.0.0",
-        "@nextcloud/l10n": "^3.4.0",
-        "@nextcloud/router": "^3.0.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
         "@nextcloud/sharing": "^0.3.0",
-        "@nextcloud/typings": "^1.9.1",
         "@types/toastify-js": "^1.12.4",
         "@vueuse/core": "^11.3.0",
         "cancelable-promise": "^4.3.1",
-        "p-queue": "^9.0.0",
+        "p-queue": "^9.0.1",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
         "webdav": "^5.8.0"
       },
       "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0",
-        "npm": "^10.5.1"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       },
       "peerDependencies": {
         "@nextcloud/vue": "^8.24.0",
@@ -4323,22 +4372,6 @@
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
-    "node_modules/@nextcloud/dialogs/node_modules/@nextcloud/sharing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/initial-state": "^3.0.0",
-        "is-svg": "^6.1.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      },
-      "optionalDependencies": {
-        "@nextcloud/files": "^3.12.0"
-      }
-    },
     "node_modules/@nextcloud/dialogs/node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -4346,9 +4379,9 @@
       "license": "MIT"
     },
     "node_modules/@nextcloud/dialogs/node_modules/p-queue": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.0.0.tgz",
-      "integrity": "sha512-KO1RyxstL9g1mK76530TExamZC/S2Glm080Nx8PE5sTd7nlduDQsAfEl4uXX+qZjLiwvDauvzXavufy3+rJ9zQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.0.1.tgz",
+      "integrity": "sha512-RhBdVhSwJb7Ocn3e8ULk4NMwBEuOxe+1zcgphUy9c2e5aR/xbEsdVXxHJ3lynw6Qiqu7OINEyHlZkiblEpaq7w==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -4460,20 +4493,20 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.0.tgz",
-      "integrity": "sha512-LVZklgooZzBj2jkbPRZO4jnnvW5+RvOn7wN5weyOZltF6i2wVMbg1Y/Czl2pi/UNMjUm5ENqc0j7FgxMBo8bwA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.12.2.tgz",
+      "integrity": "sha512-vBo8tf3Xh6efiF8CrEo3pKj9AtvAF6RdDGO1XKL65IxV8+UUd9Uxl2lUExHlzoDRRczCqfGfaWfRRaFhYqce5Q==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.5.1",
-        "@nextcloud/capabilities": "^1.2.0",
-        "@nextcloud/l10n": "^3.3.0",
-        "@nextcloud/logger": "^3.0.2",
-        "@nextcloud/paths": "^2.2.1",
-        "@nextcloud/router": "^3.0.1",
-        "@nextcloud/sharing": "^0.2.4",
+        "@nextcloud/auth": "^2.5.3",
+        "@nextcloud/capabilities": "^1.2.1",
+        "@nextcloud/l10n": "^3.4.1",
+        "@nextcloud/logger": "^3.0.3",
+        "@nextcloud/paths": "^3.0.0",
+        "@nextcloud/router": "^3.1.0",
+        "@nextcloud/sharing": "^0.3.0",
         "cancelable-promise": "^4.3.1",
-        "is-svg": "^6.0.0",
+        "is-svg": "^6.1.0",
         "typescript-event-target": "^1.1.1",
         "webdav": "^5.8.0"
       },
@@ -4507,15 +4540,15 @@
       }
     },
     "node_modules/@nextcloud/logger": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
-      "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.3.tgz",
+      "integrity": "sha512-TcbVRL4/O5ffI1RXFmQAFD3gwwT15AAdr1770x+RNqVvfBdoGVyhzOwCIyA5Vfc3fA1iJXFa+rE6buJZSoqlcw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0"
+        "@nextcloud/auth": "^2.5.3"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/password-confirmation": {
@@ -4540,13 +4573,12 @@
       }
     },
     "node_modules/@nextcloud/paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.2.1.tgz",
-      "integrity": "sha512-M3ShLjrxR7B48eKThLMoqbxTqTKyQXcwf9TgeXQGbCIhiHoXU6as5j8l5qNv/uZlANokVdowpuWHBi3b2+YNNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-3.0.0.tgz",
+      "integrity": "sha512-+sTfTkIbVUa2Ue3bkz3R7F1mhddvHPOWUxkSNg7Q5dAsimVFBaTRgiBAJmsAag3JPsxyuS8kUgeb0zdEssRdTA==",
       "license": "GPL-3.0-or-later",
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/router": {
@@ -4562,16 +4594,28 @@
       }
     },
     "node_modules/@nextcloud/sharing": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.4.tgz",
-      "integrity": "sha512-kOLAr0w4NDUGPF42L22i9iSs6Z3ylTsE0RudAGDBzw/pnxGY8PEwZI2j0IMAFRfQ7XFNcpV/EVHI5YCMxtxGMQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
+      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/initial-state": "^2.2.0"
+        "@nextcloud/initial-state": "^3.0.0",
+        "is-svg": "^6.1.0"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      },
+      "optionalDependencies": {
+        "@nextcloud/files": "^3.12.0"
+      }
+    },
+    "node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
+      "integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
+      "license": "GPL-3.0-or-later",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/stylelint-config": {
@@ -4690,31 +4734,6 @@
       },
       "peerDependencies": {
         "vue": "2.x"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.3.0.tgz",
-      "integrity": "sha512-kV7qeUZvd1fTKeFyH+W5Qq5rNOqG9rLATZM3U9MBxWXHJs3OxMqYQb8UQ3NYONzsX3zDGJmdQECIGHm1ei2sCA==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/initial-state": "^3.0.0",
-        "is-svg": "^6.1.0"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
-      },
-      "optionalDependencies": {
-        "@nextcloud/files": "^3.12.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/sharing/node_modules/@nextcloud/initial-state": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-3.0.0.tgz",
-      "integrity": "sha512-cV+HBdkQJGm8FxkBI5rFT/FbMNWNBvpbj6OPrg4Ae4YOOsQ15CL8InPOAw1t4XkOkQK2NEdUGQLVUz/19wXbdQ==",
-      "license": "GPL-3.0-or-later",
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@nextcloud/webpack-vue-config": {
@@ -5086,9 +5105,9 @@
       }
     },
     "node_modules/@testing-library/cypress": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-10.0.2.tgz",
-      "integrity": "sha512-dKv95Bre5fDmNb9tOIuWedhGUryxGu1GWYWtXDqUsDPcr9Ekld0fiTb+pcBvSsFpYXAZSpmyEjhoXzLbhh06yQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-tNkNtYRqPQh71xXKuMizr146zlellawUfDth7A/urYU4J66g0VGZ063YsS0gqS79Z58u1G/uo9UxN05qvKXMag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5100,7 +5119,7 @@
         "npm": ">=6"
       },
       "peerDependencies": {
-        "cypress": "^12.0.0 || ^13.0.0"
+        "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -7629,24 +7648,25 @@
       "peer": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -7663,12 +7683,45 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/bonjour-service": {
       "version": "1.2.1",
@@ -9262,15 +9315,16 @@
       "license": "MIT"
     },
     "node_modules/cypress-visual-regression": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/cypress-visual-regression/-/cypress-visual-regression-5.2.2.tgz",
-      "integrity": "sha512-QWCXlE7GCpNnwVLmkywiIJ8usrIgTdVdUE6j3LYhZPSB35jNR3GmwVihP6NzzAG4CpW4zm+MAEDrkuX1MQzPeA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/cypress-visual-regression/-/cypress-visual-regression-5.3.0.tgz",
+      "integrity": "sha512-vnGOcoty61JibQ6LMYmYXQ0MIdoiQzuRtLpL+iuGE3aalVaYecC9AUfQfrOJL1eRtC2hsvrmPRfgHBZ/MXe75A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.2",
-        "pixelmatch": "^5.2.1",
-        "pngjs": "^6.0.0",
-        "sanitize-filename": "^1.6.3"
+        "chalk": "4.1.2",
+        "pixelmatch": "5.3.0",
+        "pngjs": "7.0.0",
+        "sanitize-filename": "1.6.3"
       },
       "engines": {
         "node": ">=18"
@@ -9340,6 +9394,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cypress-visual-regression/node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/cypress-visual-regression/node_modules/supports-color": {
@@ -12154,41 +12218,41 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -13835,6 +13899,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -19822,12 +19887,14 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -19920,17 +19987,51 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 26 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/cypress](#user-content-\\@nextcloud\\/cypress)
## Fixed vulnerabilities

### `@nextcloud/cypress` <a href="#user-content-\@nextcloud\/cypress" id="\@nextcloud\/cypress">#</a>
* Caused by vulnerable dependency:
  * [cypress](#user-content-cypress)
* Affected versions: 
* Package usage:
  * `node_modules/@nextcloud/cypress`