### PR TITLE
fix: Ignore groupfolders which have a root_id pointing to nothing

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -128,7 +128,7 @@ class FolderManager {
 		)
 			->selectAlias('c.permissions', 'permissions')
 			->from('group_folders', 'f')
-			->leftJoin('f', 'filecache', 'c', $query->expr()->eq('c.fileid', 'f.root_id'));
+			->innerJoin('f', 'filecache', 'c', $query->expr()->eq('c.fileid', 'f.root_id'));
 		return $query;
 	}
 


### PR DESCRIPTION
In case the line in the filecache got lost for some reason (the
 directory was deleted and a scan ran, or a deletion crashed mid-way, or
 another bug), ignore the groupfolder instead of crashing. We cannot
 guess the info from filecache anyway.

- Fix #4018

We may want to provide repair steps or cli tools to clean DB in this case, but that’s another subject.