### PR TITLE
[stable31] fix: Ignore groupfolders which have a root_id pointing to nothing

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -135,7 +135,7 @@ class FolderManager {
 			$conditions[] = $query->expr()->eq('c.storage', $query->createNamedParameter($rootStorageId));
 		}
 
-		$query->leftJoin('f', 'filecache', 'c', $query->expr()->andX(...$conditions));
+		$query->innerJoin('f', 'filecache', 'c', $query->expr()->andX(...$conditions));
 	}
 
 	/**


### PR DESCRIPTION
Same as #4256 but adapted to stable31 code