### PR TITLE
fix: check for mountpoint conflict before rename in api

### DIFF
--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -294,10 +294,11 @@ class FolderController extends OCSController {
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'PUT', url: '/folders/{id}')]
 	public function setMountPoint(int $id, string $mountPoint): DataResponse {
+		$this->checkMountPointExists(trim($mountPoint));
+
 		$this->manager->renameFolder($id, trim($mountPoint));
 
 		$folder = $this->checkedGetFolder($id);
-		$this->checkMountPointExists(trim($mountPoint));
 
 		return new DataResponse(['success' => true, 'folder' => $this->formatFolder($folder)]);
 	}


### PR DESCRIPTION
Else it doesn't actually block a conflicting rename, and will always give an error.

Note that the webui uses a different endpoint, so the issue only happens for manual api usage.