### PR TITLE
fix(versions): Check the class of the file's storage instead of the mountpoint

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -148,7 +148,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 	private function getVersionsForFileFromDB(FileInfo $fileInfo, IUser $user): array {
 		$folder = $this->getFolderForFile($fileInfo);
 		$mountPoint = $fileInfo->getMountPoint();
-		if (!$mountPoint instanceof GroupMountPoint) {
+		if (!$fileInfo->getStorage()->instanceOfStorage(GroupFolderStorage::class)) {
 			return [];
 		}
 		$versionsFolder = $this->getVersionFolderForFile($fileInfo);
@@ -328,9 +328,8 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 		}
 
 		$sourceFile = $version->getSourceFile();
-		$mount = $sourceFile->getMountPoint();
 
-		if (!($mount instanceof GroupMountPoint)) {
+		if (!$sourceFile->getStorage()->instanceOfStorage(GroupFolderStorage::class)) {
 			return;
 		}
 
@@ -399,8 +398,7 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 	 * @psalm-suppress MethodSignatureMismatch - The signature of the method is correct, but psalm somehow can't understand it
 	 */
 	public function importVersionsForFile(IUser $user, Node $source, Node $target, array $versions): void {
-		$mount = $target->getMountPoint();
-		if (!($mount instanceof GroupMountPoint)) {
+		if (!$target->getStorage()->instanceOfStorage(GroupFolderStorage::class)) {
 			return;
 		}
 


### PR DESCRIPTION
1. Create a groupfolder
2. Create a file inside that groupfolder
3. Share the file to Alice
4. As Alice, list the file version --> fails

If we check the mount point, we are not really checking the actual storage of the file.

- Introduced by https://github.com/nextcloud/groupfolders/pull/3921