### PR TITLE
feat: validate mountpoint using FilenameValidator

### DIFF
--- a/lib/Command/Create.php
+++ b/lib/Command/Create.php
@@ -10,6 +10,7 @@ namespace OCA\GroupFolders\Command;
 
 use OC\Core\Command\Base;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCP\Files\InvalidPathException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -59,7 +60,13 @@ class Create extends Base {
 
 		$aclDefaultNoPermission = (bool)$input->getOption('acl-no-default-permission');
 
-		$id = $this->folderManager->createFolder($name, $options, $aclDefaultNoPermission);
+		try {
+			$id = $this->folderManager->createFolder($name, $options, $aclDefaultNoPermission);
+		} catch (InvalidPathException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return 1;
+		}
+
 		$output->writeln((string)$id);
 
 		return 0;

--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\GroupFolders\Command;
 
+use OCP\Files\InvalidPathException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -50,7 +51,12 @@ class Rename extends FolderCommand {
 			}
 		}
 
-		$this->folderManager->renameFolder($folder->id, $input->getArgument('name'));
+		try {
+			$this->folderManager->renameFolder($folder->id, $input->getArgument('name'));
+		} catch (InvalidPathException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return 1;
+		}
 
 		return 0;
 	}

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -26,6 +26,7 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\Files\Folder;
+use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -247,7 +248,12 @@ class FolderController extends OCSController {
 			$options['bucket'] = $bucket;
 		}
 
-		$id = $this->manager->createFolder(trim($mountpoint), $options, $acl_default_no_permission);
+		try {
+			$id = $this->manager->createFolder(trim($mountpoint), $options, $acl_default_no_permission);
+		} catch (InvalidPathException $e) {
+			throw new OCSBadRequestException($e->getMessage());
+		}
+
 		$folder = $this->checkedGetFolder($id);
 
 		return new DataResponse($this->formatFolder($folder));
@@ -293,7 +299,11 @@ class FolderController extends OCSController {
 	public function setMountPoint(int $id, string $mountPoint): DataResponse {
 		$this->checkMountPointExists(trim($mountPoint));
 
-		$this->manager->renameFolder($id, trim($mountPoint));
+		try {
+			$this->manager->renameFolder($id, trim($mountPoint));
+		} catch (InvalidPathException $e) {
+			throw new OCSBadRequestException($e->getMessage());
+		}
 
 		$folder = $this->checkedGetFolder($id);
 
@@ -477,7 +487,12 @@ class FolderController extends OCSController {
 		}
 
 		$this->checkMountPointExists(trim($mountpoint));
-		$this->manager->renameFolder($id, trim($mountpoint));
+
+		try {
+			$this->manager->renameFolder($id, trim($mountpoint));
+		} catch (InvalidPathException $e) {
+			throw new OCSBadRequestException($e->getMessage());
+		}
 
 		$folder = $this->checkedGetFolder($id);
 

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -18,6 +18,7 @@ import AdminGroupSelect from './AdminGroupSelect'
 import SubAdminGroupSelect from './SubAdminGroupSelect'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
+import { showError } from '@nextcloud/dialogs'
 
 const bytesInOneGibibyte = Math.pow(1024, 3)
 const defaultQuotaOptions = {
@@ -98,10 +99,17 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		if (!mountPoint) {
 			return
 		}
-		const folder = await this.api.createFolder(mountPoint, this.state.newACLDefaultNoPermission)
-		const folders = this.state.folders
-		folders.push(folder)
-		this.setState({ folders, newMountPoint: '' })
+
+		try {
+			const folder = await this.api.createFolder(mountPoint, this.state.newACLDefaultNoPermission)
+			const folders = this.state.folders
+			folders.push(folder)
+			this.setState({folders, newMountPoint: ''})
+		} catch (error) {
+			const message = error?.response?.data?.message || t('groupfolders', 'Failed to create team folder')
+			console.error('Error creating team folder:', message)
+			showError(message)
+		}
 	}
 
 	attach = (search: OC.Search.Core) => {
@@ -161,10 +169,16 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 	}
 
 	async renameFolder(folder: Folder, newName: string) {
-		await this.api.renameFolder(folder.id, newName)
-		const folders = this.state.folders
-		folder.mount_point = newName
-		this.setState({ folders, editingMountPoint: 0 })
+		try {
+			await this.api.renameFolder(folder.id, newName)
+			const folders = this.state.folders
+			folder.mount_point = newName
+			this.setState({ folders, editingMountPoint: 0 })
+		} catch (error) {
+			const message = error?.response?.data?.message || t('groupfolders', 'Failed to rename team folder')
+			console.error('Error renaming team folder:', message)
+			showError(message)
+		}
 	}
 
 	async setAcl(folder: Folder, acl: boolean) {


### PR DESCRIPTION
### Problem
Teamfolder with invalid characters (particularly `/` and `\`) in their mount point cause issues and errors.

### Solution
Implement validation using `IFilenameValidator` to reject invalid mount point names at creation and rename and display the error.