### PR TITLE
fix(trash): Hide trash from admins

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -469,9 +469,9 @@ class FolderManager {
 	 *
 	 * @throws Exception
 	 */
-	public function canManageACL(int $folderId, IUser $user): bool {
+	public function canManageACL(int $folderId, IUser $user, bool $excludeAdmins = false): bool {
 		$userId = $user->getUId();
-		if ($this->groupManager->isAdmin($userId)) {
+		if (!$excludeAdmins && $this->groupManager->isAdmin($userId)) {
 			return true;
 		}
 

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -426,7 +426,7 @@ class TrashBackend implements ITrashBackend {
 			// we apply acl filtering later to get the correct permissions again
 			$trashFolder = $this->setupTrashFolder($folder);
 			$content = $trashFolder->getDirectoryListing();
-			$userCanManageAcl = $this->folderManager->canManageACL($folder->id, $user);
+			$userCanManageAcl = $this->folderManager->canManageACL($folder->id, $user, true);
 			$this->aclManagerFactory->getACLManager($user)->preloadRulesForFolder($folder->storageId, $trashFolder->getId());
 
 			$itemsForFolder = array_map(function (Node $item) use ($user, $folder, $indexedRows): \OCA\GroupFolders\Trash\GroupTrashItem {


### PR DESCRIPTION
Instance admins can currently see the trash of all groupfolders, making their trashbin unusable. This is NOT a security issue because an admin could just add themselves to a groupfolder in order to see the trash.