### PR TITLE
fix getting groupfolder mount for users home directory

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -284,7 +284,11 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 				continue;
 			}
 
-			$userFolders[$user->getUID()] ??= $this->folderManager->getFoldersForUser($user, null, implode('/', array_splice($parts, 3, -1)));
+			$relativePath = implode('/', array_splice($parts, 3, -1));
+			if ($relativePath === '') {
+				$relativePath = '/';
+			}
+			$userFolders[$user->getUID()] ??= $this->folderManager->getFoldersForUser($user, null, $relativePath);
 			$folders = $userFolders[$user->getUID()];
 
 			foreach ($folders as $folder) {


### PR DESCRIPTION
We support overwriting the users home directory with a groupfolder by setting the mountpoint to `/`, but the current relative path logic doesn't handle that edge case.