### PR TITLE
fix(versions): Catch unique constraint violation inserting version entity

### DIFF
--- a/lib/Versions/VersionsBackend.php
+++ b/lib/Versions/VersionsBackend.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -431,7 +432,13 @@ class VersionsBackend implements IVersionBackend, IMetadataVersionBackend, IDele
 				$versionEntity->setDecodedMetadata($version->getMetadata());
 			}
 
-			$this->groupVersionsMapper->insert($versionEntity);
+			try {
+				$this->groupVersionsMapper->insert($versionEntity);
+			} catch (\OCP\DB\Exception $e) {
+				if ($e->getReason() !== \OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Preserve original logic, handle concurrency safely
Ignore `UniqueConstraintViolationException`

<details>
<summary>Stack trace</summary>

```
{
  "reqId": "9DlF0EbR4ujJLoVFmAsl",
  "level": 3,
  "time": "2026-02-10T16:22:14+01:00",
  "remoteAddr": "81.243.154.161",
  "user": "BE46",
  "app": "no app in context",
  "method": "MOVE",
  "url": "/remote.php/dav/files/BE46/Planning%20entretien%20CSApeda-RC-CTP.xlsx",
  "scriptName": "/remote.php",
  "message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36 Edg/144.0.0.0",
  "version": "31.0.13.1",
  "exception": {
    "Exception": "OC\\DB\\Exceptions\\DbalException",
    "Message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
    "Code": 1062,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
        "line": 69,
        "function": "wrap",
        "class": "OC\\DB\\Exceptions\\DbalException",
        "type": "::",
        "args": [
          {
            "__class__": "Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException"
          },
          "",
          "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
        "line": 306,
        "function": "executeStatement",
        "class": "OC\\DB\\ConnectionAdapter",
        "type": "->",
        "args": [
          "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
          {
            "dcValue1": 348584,
            "dcValue2": 1770710044,
            "dcValue3": 12256,
            "dcValue4": 26,
            "dcValue5": "[]"
          },
          {
            "dcValue1": 2,
            "dcValue2": 1,
            "dcValue3": 1,
            "dcValue4": 1,
            "dcValue5": 2
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
        "line": 116,
        "function": "executeStatement",
        "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/apps/groupfolders/lib/Versions/VersionsBackend.php",
        "line": 426,
        "function": "insert",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\GroupFolders\\Versions\\GroupVersionEntity",
            "id": null
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 141,
        "function": "importVersionsForFile",
        "class": "OCA\\GroupFolders\\Versions\\VersionsBackend",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          [
            {
              "__class__": "OCA\\Files_Versions\\Versions\\Version"
            }
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 118,
        "function": "handleMoveOrCopy",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
          },
          {
            "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 76,
        "function": "recursivelyHandleMoveOrCopy",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
          },
          {
            "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 68,
        "function": "handle",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 220,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 56,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            "And 2 more entries, set log level to debug to see all entries"
          ],
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 67,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 79,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
        "line": 169,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
        "line": 85,
        "function": "postRename",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          {
            "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
            "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/View.php",
        "line": 835,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "post_rename",
          {
            "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
            "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Directory.php",
        "line": 418,
        "function": "rename",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/Planning entretien CSApeda-RC-CTP.xlsx",
          "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Tree.php",
        "line": 178,
        "function": "moveInto",
        "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
        "type": "->",
        "args": [
          "Planning entretien CSApeda-RC-CTP.xlsx",
          "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
          {
            "__class__": "OCA\\DAV\\Connector\\Sabre\\File"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 612,
        "function": "move",
        "class": "Sabre\\DAV\\Tree",
        "type": "->",
        "args": [
          "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
          "files/BE46/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpMove",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "method:MOVE",
          [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
        "line": 49,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
        "line": 403,
        "function": "start",
        "class": "OCA\\DAV\\Connector\\Sabre\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
        "line": 21,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/remote.php",
        "line": 145,
        "args": [
          "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/nextcloud/lib/private/DB/Exceptions/DbalException.php",
    "Line": 56,
    "Previous": {
      "Exception": "Doctrine\\DBAL\\Exception\\UniqueConstraintViolationException",
      "Message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
      "Code": 1062,
      "Trace": [
        {
          "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1976,
          "function": "convert",
          "class": "Doctrine\\DBAL\\Driver\\API\\MySQL\\ExceptionConverter",
          "type": "->",
          "args": [
            {
              "__class__": "Doctrine\\DBAL\\Driver\\PDO\\Exception"
            },
            {
              "__class__": "Doctrine\\DBAL\\Query"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1918,
          "function": "handleDriverException",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->",
          "args": [
            {
              "__class__": "Doctrine\\DBAL\\Driver\\PDO\\Exception"
            },
            {
              "__class__": "Doctrine\\DBAL\\Query"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1218,
          "function": "convertExceptionDuringQuery",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->",
          "args": [
            {
              "__class__": "Doctrine\\DBAL\\Driver\\PDO\\Exception"
            },
            "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(?, ?, ?, ?, ?)",
            [
              348584,
              1770710044,
              12256,
              26,
              "[]"
            ],
            [
              2,
              1,
              1,
              1,
              2
            ]
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php",
          "line": 292,
          "function": "executeStatement",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->",
          "args": [
            "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(?, ?, ?, ?, ?)",
            [
              348584,
              1770710044,
              12256,
              26,
              "[]"
            ],
            [
              2,
              1,
              1,
              1,
              2
            ]
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/DB/Connection.php",
          "line": 466,
          "function": "executeStatement",
          "class": "Doctrine\\DBAL\\Connections\\PrimaryReadReplicaConnection",
          "type": "->",
          "args": [
            "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
            {
              "dcValue1": 348584,
              "dcValue2": 1770710044,
              "dcValue3": 12256,
              "dcValue4": 26,
              "dcValue5": "[]"
            },
            {
              "dcValue1": 2,
              "dcValue2": 1,
              "dcValue3": 1,
              "dcValue4": 1,
              "dcValue5": 2
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
          "line": 67,
          "function": "executeStatement",
          "class": "OC\\DB\\Connection",
          "type": "->",
          "args": [
            "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
            {
              "dcValue1": 348584,
              "dcValue2": 1770710044,
              "dcValue3": 12256,
              "dcValue4": 26,
              "dcValue5": "[]"
            },
            {
              "dcValue1": 2,
              "dcValue2": 1,
              "dcValue3": 1,
              "dcValue4": 1,
              "dcValue5": 2
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
          "line": 306,
          "function": "executeStatement",
          "class": "OC\\DB\\ConnectionAdapter",
          "type": "->",
          "args": [
            "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
            {
              "dcValue1": 348584,
              "dcValue2": 1770710044,
              "dcValue3": 12256,
              "dcValue4": 26,
              "dcValue5": "[]"
            },
            {
              "dcValue1": 2,
              "dcValue2": 1,
              "dcValue3": 1,
              "dcValue4": 1,
              "dcValue5": 2
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
          "line": 116,
          "function": "executeStatement",
          "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
          "type": "->",
          "args": []
        },
        {
          "file": "/var/www/nextcloud/apps/groupfolders/lib/Versions/VersionsBackend.php",
          "line": 426,
          "function": "insert",
          "class": "OCP\\AppFramework\\Db\\QBMapper",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\GroupFolders\\Versions\\GroupVersionEntity",
              "id": null
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
          "line": 141,
          "function": "importVersionsForFile",
          "class": "OCA\\GroupFolders\\Versions\\VersionsBackend",
          "type": "->",
          "args": [
            {
              "__class__": "OC\\User\\User"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            [
              {
                "__class__": "OCA\\Files_Versions\\Versions\\Version"
              }
            ]
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
          "line": 118,
          "function": "handleMoveOrCopy",
          "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            },
            {
              "__class__": "OC\\User\\User"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            {
              "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
            },
            {
              "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
          "line": 76,
          "function": "recursivelyHandleMoveOrCopy",
          "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            },
            {
              "__class__": "OC\\User\\User"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            {
              "__class__": "OC\\Files\\Node\\File"
            },
            {
              "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
            },
            {
              "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
          "line": 68,
          "function": "handle",
          "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
          "line": 220,
          "function": "__invoke",
          "class": "OC\\EventDispatcher\\ServiceEventListener",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            },
            "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
            {
              "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
          "line": 56,
          "function": "callListeners",
          "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
          "type": "->",
          "args": [
            [
              {
                "__class__": "Closure"
              },
              {
                "__class__": "Closure"
              },
              {
                "__class__": "Closure"
              },
              {
                "__class__": "Closure"
              },
              {
                "__class__": "Closure"
              },
              "And 2 more entries, set log level to debug to see all entries"
            ],
            "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
          "line": 67,
          "function": "dispatch",
          "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            },
            "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
          "line": 79,
          "function": "dispatch",
          "class": "OC\\EventDispatcher\\EventDispatcher",
          "type": "->",
          "args": [
            "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
          "line": 169,
          "function": "dispatchTyped",
          "class": "OC\\EventDispatcher\\EventDispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
          "line": 85,
          "function": "postRename",
          "class": "OC\\Files\\Node\\HookConnector",
          "type": "->",
          "args": [
            {
              "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
              "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/lib/private/Files/View.php",
          "line": 835,
          "function": "emit",
          "class": "OC_Hook",
          "type": "::",
          "args": [
            "OC_Filesystem",
            "post_rename",
            {
              "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
              "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Directory.php",
          "line": 418,
          "function": "rename",
          "class": "OC\\Files\\View",
          "type": "->",
          "args": [
            "/Planning entretien CSApeda-RC-CTP.xlsx",
            "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Tree.php",
          "line": 178,
          "function": "moveInto",
          "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
          "type": "->",
          "args": [
            "Planning entretien CSApeda-RC-CTP.xlsx",
            "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
            {
              "__class__": "OCA\\DAV\\Connector\\Sabre\\File"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
          "line": 612,
          "function": "move",
          "class": "Sabre\\DAV\\Tree",
          "type": "->",
          "args": [
            "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
            "files/BE46/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
          "line": 89,
          "function": "httpMove",
          "class": "Sabre\\DAV\\CorePlugin",
          "type": "->",
          "args": [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
          "line": 472,
          "function": "emit",
          "class": "Sabre\\DAV\\Server",
          "type": "->",
          "args": [
            "method:MOVE",
            [
              {
                "__class__": "Sabre\\HTTP\\Request"
              },
              {
                "__class__": "Sabre\\HTTP\\Response"
              }
            ]
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
          "line": 49,
          "function": "invokeMethod",
          "class": "Sabre\\DAV\\Server",
          "type": "->",
          "args": [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        },
        {
          "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
          "line": 403,
          "function": "start",
          "class": "OCA\\DAV\\Connector\\Sabre\\Server",
          "type": "->",
          "args": []
        },
        {
          "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
          "line": 21,
          "function": "exec",
          "class": "OCA\\DAV\\Server",
          "type": "->",
          "args": []
        },
        {
          "file": "/var/www/nextcloud/remote.php",
          "line": 145,
          "args": [
            "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
          ],
          "function": "require_once"
        }
      ],
      "File": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php",
      "Line": 64,
      "Previous": {
        "Exception": "Doctrine\\DBAL\\Driver\\PDO\\Exception",
        "Message": "SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
        "Code": 1062,
        "Trace": [
          {
            "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
            "line": 132,
            "function": "new",
            "class": "Doctrine\\DBAL\\Driver\\PDO\\Exception",
            "type": "::",
            "args": [
              {
                "__class__": "PDOException",
                "errorInfo": [
                  "23000",
                  1062,
                  "Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'"
                ]
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
            "line": 1212,
            "function": "execute",
            "class": "Doctrine\\DBAL\\Driver\\PDO\\Statement",
            "type": "->",
            "args": []
          },
          {
            "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php",
            "line": 292,
            "function": "executeStatement",
            "class": "Doctrine\\DBAL\\Connection",
            "type": "->",
            "args": [
              "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(?, ?, ?, ?, ?)",
              [
                348584,
                1770710044,
                12256,
                26,
                "[]"
              ],
              [
                2,
                1,
                1,
                1,
                2
              ]
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/DB/Connection.php",
            "line": 466,
            "function": "executeStatement",
            "class": "Doctrine\\DBAL\\Connections\\PrimaryReadReplicaConnection",
            "type": "->",
            "args": [
              "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
              {
                "dcValue1": 348584,
                "dcValue2": 1770710044,
                "dcValue3": 12256,
                "dcValue4": 26,
                "dcValue5": "[]"
              },
              {
                "dcValue1": 2,
                "dcValue2": 1,
                "dcValue3": 1,
                "dcValue4": 1,
                "dcValue5": 2
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
            "line": 67,
            "function": "executeStatement",
            "class": "OC\\DB\\Connection",
            "type": "->",
            "args": [
              "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
              {
                "dcValue1": 348584,
                "dcValue2": 1770710044,
                "dcValue3": 12256,
                "dcValue4": 26,
                "dcValue5": "[]"
              },
              {
                "dcValue1": 2,
                "dcValue2": 1,
                "dcValue3": 1,
                "dcValue4": 1,
                "dcValue5": 2
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
            "line": 306,
            "function": "executeStatement",
            "class": "OC\\DB\\ConnectionAdapter",
            "type": "->",
            "args": [
              "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
              {
                "dcValue1": 348584,
                "dcValue2": 1770710044,
                "dcValue3": 12256,
                "dcValue4": 26,
                "dcValue5": "[]"
              },
              {
                "dcValue1": 2,
                "dcValue2": 1,
                "dcValue3": 1,
                "dcValue4": 1,
                "dcValue5": 2
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
            "line": 116,
            "function": "executeStatement",
            "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
            "type": "->",
            "args": []
          },
          {
            "file": "/var/www/nextcloud/apps/groupfolders/lib/Versions/VersionsBackend.php",
            "line": 426,
            "function": "insert",
            "class": "OCP\\AppFramework\\Db\\QBMapper",
            "type": "->",
            "args": [
              {
                "__class__": "OCA\\GroupFolders\\Versions\\GroupVersionEntity",
                "id": null
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
            "line": 141,
            "function": "importVersionsForFile",
            "class": "OCA\\GroupFolders\\Versions\\VersionsBackend",
            "type": "->",
            "args": [
              {
                "__class__": "OC\\User\\User"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              [
                {
                  "__class__": "OCA\\Files_Versions\\Versions\\Version"
                }
              ]
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
            "line": 118,
            "function": "handleMoveOrCopy",
            "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              },
              {
                "__class__": "OC\\User\\User"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              {
                "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
              },
              {
                "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
            "line": 76,
            "function": "recursivelyHandleMoveOrCopy",
            "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              },
              {
                "__class__": "OC\\User\\User"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              {
                "__class__": "OC\\Files\\Node\\File"
              },
              {
                "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
              },
              {
                "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
            "line": 68,
            "function": "handle",
            "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
            "line": 220,
            "function": "__invoke",
            "class": "OC\\EventDispatcher\\ServiceEventListener",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              },
              "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
              {
                "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
            "line": 56,
            "function": "callListeners",
            "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
            "type": "->",
            "args": [
              [
                {
                  "__class__": "Closure"
                },
                {
                  "__class__": "Closure"
                },
                {
                  "__class__": "Closure"
                },
                {
                  "__class__": "Closure"
                },
                {
                  "__class__": "Closure"
                },
                "And 2 more entries, set log level to debug to see all entries"
              ],
              "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
            "line": 67,
            "function": "dispatch",
            "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              },
              "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
            "line": 79,
            "function": "dispatch",
            "class": "OC\\EventDispatcher\\EventDispatcher",
            "type": "->",
            "args": [
              "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
            "line": 169,
            "function": "dispatchTyped",
            "class": "OC\\EventDispatcher\\EventDispatcher",
            "type": "->",
            "args": [
              {
                "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
            "line": 85,
            "function": "postRename",
            "class": "OC\\Files\\Node\\HookConnector",
            "type": "->",
            "args": [
              {
                "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
                "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/lib/private/Files/View.php",
            "line": 835,
            "function": "emit",
            "class": "OC_Hook",
            "type": "::",
            "args": [
              "OC_Filesystem",
              "post_rename",
              {
                "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
                "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Directory.php",
            "line": 418,
            "function": "rename",
            "class": "OC\\Files\\View",
            "type": "->",
            "args": [
              "/Planning entretien CSApeda-RC-CTP.xlsx",
              "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Tree.php",
            "line": 178,
            "function": "moveInto",
            "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
            "type": "->",
            "args": [
              "Planning entretien CSApeda-RC-CTP.xlsx",
              "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
              {
                "__class__": "OCA\\DAV\\Connector\\Sabre\\File"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
            "line": 612,
            "function": "move",
            "class": "Sabre\\DAV\\Tree",
            "type": "->",
            "args": [
              "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
              "files/BE46/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
            "line": 89,
            "function": "httpMove",
            "class": "Sabre\\DAV\\CorePlugin",
            "type": "->",
            "args": [
              {
                "__class__": "Sabre\\HTTP\\Request"
              },
              {
                "__class__": "Sabre\\HTTP\\Response"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
            "line": 472,
            "function": "emit",
            "class": "Sabre\\DAV\\Server",
            "type": "->",
            "args": [
              "method:MOVE",
              [
                {
                  "__class__": "Sabre\\HTTP\\Request"
                },
                {
                  "__class__": "Sabre\\HTTP\\Response"
                }
              ]
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
            "line": 49,
            "function": "invokeMethod",
            "class": "Sabre\\DAV\\Server",
            "type": "->",
            "args": [
              {
                "__class__": "Sabre\\HTTP\\Request"
              },
              {
                "__class__": "Sabre\\HTTP\\Response"
              }
            ]
          },
          {
            "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
            "line": 403,
            "function": "start",
            "class": "OCA\\DAV\\Connector\\Sabre\\Server",
            "type": "->",
            "args": []
          },
          {
            "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
            "line": 21,
            "function": "exec",
            "class": "OCA\\DAV\\Server",
            "type": "->",
            "args": []
          },
          {
            "file": "/var/www/nextcloud/remote.php",
            "line": 145,
            "args": [
              "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
            ],
            "function": "require_once"
          }
        ],
        "File": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Exception.php",
        "Line": 24,
        "Previous": {
          "Exception": "PDOException",
          "Message": "SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
          "Code": "23000",
          "Trace": [
            {
              "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
              "line": 130,
              "function": "execute",
              "class": "PDOStatement",
              "type": "->",
              "args": [
                null
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
              "line": 1212,
              "function": "execute",
              "class": "Doctrine\\DBAL\\Driver\\PDO\\Statement",
              "type": "->",
              "args": []
            },
            {
              "file": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php",
              "line": 292,
              "function": "executeStatement",
              "class": "Doctrine\\DBAL\\Connection",
              "type": "->",
              "args": [
                "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(?, ?, ?, ?, ?)",
                [
                  348584,
                  1770710044,
                  12256,
                  26,
                  "[]"
                ],
                [
                  2,
                  1,
                  1,
                  1,
                  2
                ]
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/DB/Connection.php",
              "line": 466,
              "function": "executeStatement",
              "class": "Doctrine\\DBAL\\Connections\\PrimaryReadReplicaConnection",
              "type": "->",
              "args": [
                "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
                {
                  "dcValue1": 348584,
                  "dcValue2": 1770710044,
                  "dcValue3": 12256,
                  "dcValue4": 26,
                  "dcValue5": "[]"
                },
                {
                  "dcValue1": 2,
                  "dcValue2": 1,
                  "dcValue3": 1,
                  "dcValue4": 1,
                  "dcValue5": 2
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
              "line": 67,
              "function": "executeStatement",
              "class": "OC\\DB\\Connection",
              "type": "->",
              "args": [
                "INSERT INTO `oc_group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
                {
                  "dcValue1": 348584,
                  "dcValue2": 1770710044,
                  "dcValue3": 12256,
                  "dcValue4": 26,
                  "dcValue5": "[]"
                },
                {
                  "dcValue1": 2,
                  "dcValue2": 1,
                  "dcValue3": 1,
                  "dcValue4": 1,
                  "dcValue5": 2
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
              "line": 306,
              "function": "executeStatement",
              "class": "OC\\DB\\ConnectionAdapter",
              "type": "->",
              "args": [
                "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)",
                {
                  "dcValue1": 348584,
                  "dcValue2": 1770710044,
                  "dcValue3": 12256,
                  "dcValue4": 26,
                  "dcValue5": "[]"
                },
                {
                  "dcValue1": 2,
                  "dcValue2": 1,
                  "dcValue3": 1,
                  "dcValue4": 1,
                  "dcValue5": 2
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
              "line": 116,
              "function": "executeStatement",
              "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
              "type": "->",
              "args": []
            },
            {
              "file": "/var/www/nextcloud/apps/groupfolders/lib/Versions/VersionsBackend.php",
              "line": 426,
              "function": "insert",
              "class": "OCP\\AppFramework\\Db\\QBMapper",
              "type": "->",
              "args": [
                {
                  "__class__": "OCA\\GroupFolders\\Versions\\GroupVersionEntity",
                  "id": null
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
              "line": 141,
              "function": "importVersionsForFile",
              "class": "OCA\\GroupFolders\\Versions\\VersionsBackend",
              "type": "->",
              "args": [
                {
                  "__class__": "OC\\User\\User"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                [
                  {
                    "__class__": "OCA\\Files_Versions\\Versions\\Version"
                  }
                ]
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
              "line": 118,
              "function": "handleMoveOrCopy",
              "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                },
                {
                  "__class__": "OC\\User\\User"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                {
                  "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
                },
                {
                  "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
              "line": 76,
              "function": "recursivelyHandleMoveOrCopy",
              "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                },
                {
                  "__class__": "OC\\User\\User"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                {
                  "__class__": "OC\\Files\\Node\\File"
                },
                {
                  "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
                },
                {
                  "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
              "line": 68,
              "function": "handle",
              "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
              "line": 220,
              "function": "__invoke",
              "class": "OC\\EventDispatcher\\ServiceEventListener",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                },
                "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
                {
                  "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
              "line": 56,
              "function": "callListeners",
              "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
              "type": "->",
              "args": [
                [
                  {
                    "__class__": "Closure"
                  },
                  {
                    "__class__": "Closure"
                  },
                  {
                    "__class__": "Closure"
                  },
                  {
                    "__class__": "Closure"
                  },
                  {
                    "__class__": "Closure"
                  },
                  "And 2 more entries, set log level to debug to see all entries"
                ],
                "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
              "line": 67,
              "function": "dispatch",
              "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                },
                "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
              "line": 79,
              "function": "dispatch",
              "class": "OC\\EventDispatcher\\EventDispatcher",
              "type": "->",
              "args": [
                "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
              "line": 169,
              "function": "dispatchTyped",
              "class": "OC\\EventDispatcher\\EventDispatcher",
              "type": "->",
              "args": [
                {
                  "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
              "line": 85,
              "function": "postRename",
              "class": "OC\\Files\\Node\\HookConnector",
              "type": "->",
              "args": [
                {
                  "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
                  "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/lib/private/Files/View.php",
              "line": 835,
              "function": "emit",
              "class": "OC_Hook",
              "type": "::",
              "args": [
                "OC_Filesystem",
                "post_rename",
                {
                  "oldpath": "/Planning entretien CSApeda-RC-CTP.xlsx",
                  "newpath": "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Directory.php",
              "line": 418,
              "function": "rename",
              "class": "OC\\Files\\View",
              "type": "->",
              "args": [
                "/Planning entretien CSApeda-RC-CTP.xlsx",
                "/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Tree.php",
              "line": 178,
              "function": "moveInto",
              "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
              "type": "->",
              "args": [
                "Planning entretien CSApeda-RC-CTP.xlsx",
                "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
                {
                  "__class__": "OCA\\DAV\\Connector\\Sabre\\File"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
              "line": 612,
              "function": "move",
              "class": "Sabre\\DAV\\Tree",
              "type": "->",
              "args": [
                "files/BE46/Planning entretien CSApeda-RC-CTP.xlsx",
                "files/BE46/X - Partagés avec moi/CSA - Reconductions 2026/Planning entretien CSApeda-RC-CTP.xlsx"
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
              "line": 89,
              "function": "httpMove",
              "class": "Sabre\\DAV\\CorePlugin",
              "type": "->",
              "args": [
                {
                  "__class__": "Sabre\\HTTP\\Request"
                },
                {
                  "__class__": "Sabre\\HTTP\\Response"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
              "line": 472,
              "function": "emit",
              "class": "Sabre\\DAV\\Server",
              "type": "->",
              "args": [
                "method:MOVE",
                [
                  {
                    "__class__": "Sabre\\HTTP\\Request"
                  },
                  {
                    "__class__": "Sabre\\HTTP\\Response"
                  }
                ]
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
              "line": 49,
              "function": "invokeMethod",
              "class": "Sabre\\DAV\\Server",
              "type": "->",
              "args": [
                {
                  "__class__": "Sabre\\HTTP\\Request"
                },
                {
                  "__class__": "Sabre\\HTTP\\Response"
                }
              ]
            },
            {
              "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
              "line": 403,
              "function": "start",
              "class": "OCA\\DAV\\Connector\\Sabre\\Server",
              "type": "->",
              "args": []
            },
            {
              "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
              "line": 21,
              "function": "exec",
              "class": "OCA\\DAV\\Server",
              "type": "->",
              "args": []
            },
            {
              "file": "/var/www/nextcloud/remote.php",
              "line": 145,
              "args": [
                "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
              ],
              "function": "require_once"
            }
          ],
          "File": "/var/www/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
          "Line": 130
        }
      }
    },
    "message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'",
    "exception": {
      "query": "INSERT INTO `*PREFIX*group_folders_versions` (`file_id`, `timestamp`, `size`, `mimetype`, `metadata`) VALUES(:dcValue1, :dcValue2, :dcValue3, :dcValue4, :dcValue5)"
    },
    "CustomMessage": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '348584-1770710044' for key 'gf_versions_uniq_index'"
  },
  "id": "698b50ae97013"
}
```

</details>