### PR TITLE
feat: performance tuning for ACL rule derivation

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -164,7 +164,7 @@ class ACLManager {
 			}
 		}
 
-		return $this->calculatePermissionsForPath($filteredRules);
+		return $this->calculatePermissionsForPath($folderId, $filteredRules);
 	}
 
 	/**


### PR DESCRIPTION
Optimized ACLManager::getRelevantRulesForPath() by replacing repeated array_merge() + array_unique() calls with map-style deduplication ($allPaths[$path] = true) and passing array_keys() to getRules(). This avoids repeated large-array rebuilds

_Blackfire Profiling on NC31 with 30k Team Folders + 30k ACLs_

Before: 
<img width="1202" height="313" alt="Bildschirmfoto 2026-02-11 um 15 06 19" src="https://github.com/user-attachments/assets/1a87d81c-1728-4f86-9a55-38ab9ea7d19e" />

After:
<img width="1065" height="311" alt="Bildschirmfoto 2026-02-11 um 15 05 49" src="https://github.com/user-attachments/assets/d7a00126-af64-4c77-a352-ad762bd8d1aa" />
