### PR TITLE
fix(ACL): apply ACL rules in the correct order

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -165,6 +165,8 @@ class ACLManager {
 			}
 		}
 
+		uksort($filteredRules, static fn (string $a, string $b) => strlen($a) <=> strlen($b));
+
 		return $this->calculatePermissionsForPath($filteredRules);
 	}
 


### PR DESCRIPTION
Before this change the filteredRules array would be flipped in comparison to the $rules. So rules for the parents would be applied before rules for the children.