### PR TITLE
fix(MountProvider): Remove wrong cache in getMountsForPath

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -270,8 +270,6 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 		/** @var array<string, IMountPoint> $mounts */
 		$mounts = [];
 
-		/** @var array<string, list<FolderDefinitionWithPermissions>> $userFolders */
-		$userFolders = [];
 		/** @var array<string, ACLManager> $userAclManagers */
 		$userAclManagers = [];
 
@@ -288,10 +286,8 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 			if ($relativePath === '') {
 				$relativePath = '/';
 			}
-			$userFolders[$user->getUID()] ??= $this->folderManager->getFoldersForUser($user, null, $relativePath);
-			$folders = $userFolders[$user->getUID()];
 
-			foreach ($folders as $folder) {
+			foreach ($this->folderManager->getFoldersForUser($user, null, $relativePath) as $folder) {
 				$mountPoint = '/' . $user->getUID() . '/files/' . $folder->mountPoint;
 				if (isset($mounts[$mountPoint])) {
 					continue;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/4442

The variable was only set once and on subsequent runs the folders for the other paths weren't queried anymore.
I first did it as a two step to keep the cache, but then opted to remove it as the cache will not really do much anyway, as the same set of queries are still executed.