### PR TITLE
enh(pagination): add loading guard, total count, jump to page

### DIFF
--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -25,13 +25,13 @@ jobs:
       server-max: ${{ steps.versions.outputs.branches-max-list }}
     steps:
       - name: Checkout app
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Get version matrix
         id: versions
-        uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2
 
   changes:
     runs-on: ubuntu-latest-low
@@ -43,7 +43,7 @@ jobs:
       src: ${{ steps.changes.outputs.src }}
 
     steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         continue-on-error: true
         with:
@@ -70,28 +70,21 @@ jobs:
       matrix:
         php-versions: ${{ fromJson(needs.matrix.outputs.php-version) }}
         server-versions: ${{ fromJson(needs.matrix.outputs.server-max) }}
+        oci-versions: ['18', '21', '23']
 
-    name: OCI PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
+    name: OCI ${{ matrix.oci-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}
 
     services:
       oracle:
-        image: ghcr.io/gvenzl/oracle-xe:11
-
-        # Provide passwords and other environment variables to container
+        image: ghcr.io/gvenzl/oracle-${{ matrix.oci-versions < 23 && 'xe' || 'free' }}:${{ matrix.oci-versions }}
         env:
-          ORACLE_RANDOM_PASSWORD: true
-          APP_USER: autotest
-          APP_USER_PASSWORD: owncloud
-
-        # Forward Oracle port
+          ORACLE_PASSWORD: oracle
         ports:
-          - 1521:1521/tcp
-
-        # Provide healthcheck script options for startup
+          - 1521:1521
         options: >-
           --health-cmd healthcheck.sh
-          --health-interval 10s
-          --health-timeout 5s
+          --health-interval 20s
+          --health-timeout 10s
           --health-retries 10
 
     steps:
@@ -102,7 +95,7 @@ jobs:
           echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
 
       - name: Checkout server
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           submodules: true
@@ -110,34 +103,32 @@ jobs:
           ref: ${{ matrix.server-versions }}
 
       - name: Checkout Circles
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: nextcloud/circles
           ref: master
           path: apps/circles
 
       - name: Checkout app
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: ${{ matrix.php-versions }}
-          # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, oci8
           coverage: none
           ini-file: development
-          # Temporary workaround for missing pcntl_* in PHP 8.3
           ini-values: disable_functions=
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check composer file existence
         id: check_composer
-        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        uses: andstor/file-existence-action@558493d6c74bf472d87c84eab196434afc2fa029 # v3.1.0
         with:
           files: apps/${{ env.APP_NAME }}/composer.json
 
@@ -146,7 +137,6 @@ jobs:
         run: composer i
 
       - name: Set up dependencies
-        # Only run if phpunit config file exists
         if: steps.check_composer.outputs.files_exists == 'true'
         working-directory: apps/${{ env.APP_NAME }}
         run: |
@@ -158,7 +148,7 @@ jobs:
           DB_PORT: 1521
         run: |
           mkdir data
-          ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass admin
+          ./occ maintenance:install --verbose --database=oci --database-name=${{ matrix.oci-versions < 23 && 'XE' || 'FREE' }} --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=system --database-pass=oracle --admin-user admin --admin-pass admin
           ./occ app:enable --force circles
           ./occ app:enable --force ${{ env.APP_NAME }}
 

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -187,7 +187,7 @@ class FolderController extends OCSController {
 	 * 200: Groupfolder returned
 	 */
 	#[NoAdminRequired]
-	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}')]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}', requirements: ['id' => '\d+'])]
 	public function getFolder(int $id): DataResponse {
 		$storageId = $this->getRootFolderStorageId();
 		if ($storageId === null) {
@@ -583,5 +583,19 @@ class FolderController extends OCSController {
 			'groups' => $groups,
 			'circles' => $circles
 		]);
+	}
+
+	/**
+	 * Gets the total number of Groupfolders
+	 *
+	 * @return DataResponse<Http::STATUS_OK, array{count: int}, array{}>
+	 *
+	 * 200: Groupfolder count returned
+	 */
+	#[RequireGroupFolderAdmin]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/count')]
+	public function getFoldersCount(): DataResponse {
+		return new DataResponse(['count' => $this->manager->countAllFolders()]);
 	}
 }

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -1205,4 +1205,12 @@ class FolderManager {
 
 		return $hasDefaultNoPermission;
 	}
+
+	public function countAllFolders(): int {
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->func()->count('folder_id'))
+			->from('group_folders');
+		$result = $query->executeQuery()->fetchOne();
+		return is_numeric($result) ? (int)$result : 0;
+	}
 }

--- a/openapi.json
+++ b/openapi.json
@@ -2703,6 +2703,104 @@
                     }
                 }
             }
+        },
+        "/index.php/apps/groupfolders/folders/count": {
+            "get": {
+                "operationId": "folder-get-folders-count",
+                "summary": "Gets the total number of Groupfolders",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Groupfolder count returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "count"
+                                                    ],
+                                                    "properties": {
+                                                        "count": {
+                                                            "type": "integer",
+                                                            "format": "int64"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "tags": []

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -148,4 +148,9 @@ export class Api {
 		}
 	}
 
+	async countFolders(): Promise<number> {
+		const response = await axios.get<OCSResponse<{ count: number }>>(this.getUrl('folders/count'))
+		return response.data.ocs.data.count
+	}
+
 }

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -178,15 +178,30 @@
 		}
 	}
 
-	.groupfolders-pagination__list {
-		display: flex;
-		gap: var(--default-grid-baseline);
-		justify-content: center;
-	}
+    .groupfolders-pagination {
+      display: flex;
+      align-items: center;
 
-	.groupfolders-pagination__button {
-		height: var(--default-clickable-area);
-	}
+      .groupfolders-pagination__list {
+        display: flex;
+        gap: var(--default-grid-baseline);
+        justify-content: center;
+      }
+
+      .groupfolders-pagination__button {
+        height: var(--default-clickable-area);
+        line-height: var(--default-clickable-area);
+      }
+
+      .groupfolders-pagination__goto-page {
+        flex: 1;
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        gap: 6px;
+      }
+
+    }
 
 }
 

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -57,6 +57,8 @@ export interface AppState {
 	isAdminNextcloud: boolean;
 	checkAppsInstalled: boolean;
 	currentPage: number;
+	loading: boolean;
+	totalFolders: number;
 }
 
 export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Search.Core> {
@@ -80,6 +82,8 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		isAdminNextcloud: false,
 		checkAppsInstalled: false,
 		currentPage: 0,
+		loading: false,
+		totalFolders: 0,
 	}
 
 	componentDidMount() {
@@ -92,6 +96,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		})
 		this.api.listCircles().then((circles) => {
 			this.setState({ circles })
+		})
+		this.api.countFolders().then((totalFolders) => {
+			this.setState({ totalFolders })
 		})
 
 		this.setState({ isAdminNextcloud: loadState('groupfolders', 'isAdminNextcloud') })
@@ -203,13 +210,25 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 	}
 
 	async goToPage(page: number) {
+		if (this.state.loading) return
+
 		const loadedPage = Math.floor(this.state.folders.length / pageSize)
 		if (loadedPage <= page) {
-			const folders = await this.api.listFolders(this.state.folders.length, (page + 1) * pageSize - this.state.folders.length + 1, this.state.sort)
-			this.setState({
-				folders: [...this.state.folders, ...folders],
-				currentPage: page,
-			})
+			this.setState({ loading: true })
+			try {
+				const folders = await this.api.listFolders(
+					this.state.folders.length, (page + 1) * pageSize - this.state.folders.length + 1,
+					this.state.sort,
+					this.state.sortOrder === 1 ? 'asc' : 'desc',
+				)
+				this.setState({
+					folders: [...this.state.folders, ...folders],
+					currentPage: page,
+				})
+			} finally {
+				this.setState({ loading: false })
+			}
+
 		} else {
 			this.setState({
 				currentPage: page,
@@ -266,6 +285,7 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 
 	render() {
 		const isCirclesEnabled = loadState('groupfolders', 'isCirclesEnabled', false)
+		const lastPage = Math.max(0, Math.ceil(this.state.totalFolders / pageSize) - 1)
 		const groupHeader = isCirclesEnabled
 			? t('groupfolders', 'Group or team')
 			: t('groupfolders', 'Group')
@@ -273,6 +293,8 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		const groupHeaderSort = isCirclesEnabled
 			? t('groupfolders', 'Sort by number of groups or teams that have access to this folder')
 			: t('groupfolders', 'Sort by number of groups that have access to this folder')
+
+		console.log('totalFolders:', this.state.totalFolders, 'lastPage:', lastPage, 'currentPage:', this.state.currentPage)
 
 		const rows
 			= this.state.folders
@@ -416,13 +438,14 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 					</tr>
 				</FlipMove>
 			</table>
-			<nav className="groupfolders-pagination" aria-label={t('groupfolders', 'Pagination of team folders')}>
+			<nav className="groupfolders-pagination" style={{ display: 'flex', alignItems: 'center' }} aria-label={t('groupfolders', 'Pagination of team folders')}>
+				<div style={{ flex: 1 }} />
 				<ul className="groupfolders-pagination__list">
 					<li>
 						<button
 							aria-label={t('groupfolders', 'Previous')}
 							className="groupfolders-pagination__button"
-							disabled={this.state.currentPage === 0}
+							disabled={this.state.currentPage === 0 || this.state.loading}
 							title={t('groupfolders', 'Previous')}
 							onClick={() => this.goToPage(this.state.currentPage - 1)}>⮜</button>
 					</li>
@@ -441,34 +464,53 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 					<li><button aria-current="page" aria-disabled className="primary">{this.state.currentPage + 1}</button></li>
 					{
 						// show the next page if it exists (we know at least that the next exists or not)
-						(this.state.currentPage + 1) < (this.state.folders.length / pageSize)
+						(this.state.currentPage + 1) <= lastPage
 							&& <li>
 								<button onClick={() => this.goToPage(this.state.currentPage + 1)}>{this.state.currentPage + 2}</button>
 							</li>
 					}
 					{
 						// If we know more than two next pages exist we show the ellipsis for the intermediate pages
-						(this.state.currentPage + 3) < (this.state.folders.length / pageSize)
+						(this.state.currentPage + 3) <= lastPage
 							&& <li>
 								<button disabled>&#8230;</button>
 							</li>
 					}
 					{
 						// If more than one next page exist we show the last page as a button
-						(this.state.currentPage + 2) < (this.state.folders.length / pageSize)
+						(this.state.currentPage + 2) <= lastPage
 							&& <li>
-								<button onClick={() => this.goToPage(Math.floor(this.state.folders.length / pageSize))}>{Math.floor(this.state.folders.length / pageSize) + 1}</button>
+								<button onClick={() => this.goToPage(lastPage)}>{lastPage + 1}</button>
 							</li>
 					}
 					<li>
 						<button
 							aria-label={t('groupfolders', 'Next')}
 							className="groupfolders-pagination__button"
-							disabled={this.state.currentPage >= Math.floor(this.state.folders.length / pageSize)}
+							disabled={this.state.currentPage >= lastPage || this.state.loading}
 							title={t('groupfolders', 'Next')}
 							onClick={() => this.goToPage(this.state.currentPage + 1)}>⮞</button>
 					</li>
 				</ul>
+				{lastPage > 4 && (
+					<div className="groupfolders-pagination__goto-page">
+						<label style={{ whiteSpace: 'nowrap' }}>
+							{t('groupfolders', 'Page:')}
+						</label>
+						<input
+							type="number"
+							min={1}
+							max={lastPage + 1}
+							style={{ width: 70, textAlign: 'center' }}
+							value={this.state.currentPage + 1}
+							onChange={(e) => {
+								const page = Math.min(parseInt(e.target.value) - 1, lastPage)
+								if (page >= 0) this.goToPage(page)
+							}}
+						/>
+						<span style={{ whiteSpace: 'nowrap' }}>/ {lastPage + 1}</span>
+					</div>
+				)}
 			</nav>
 		</div>
 	}

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -242,6 +242,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/index.php/apps/groupfolders/folders/count": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Gets the total number of Groupfolders */
+        get: operations["folder-get-folders-count"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 };
 export type webhooks = Record<string, never>;
 export type components = {
@@ -1388,6 +1405,51 @@ export interface operations {
             };
             /** @description Not allowed to search */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-get-folders-count": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Groupfolder count returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** Format: int64 */
+                                count: number;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
### Summary

Improves the pagination in the admin settings UI, making it usable for instances with a large number of team folders.

### Changes

**Backend**
- Add `countAllFolders()` to `FolderManager` to get the total folder count
- Add `GET /folders/count` endpoint in `FolderController`
- Add `\d+` requirement to `GET /folders/{id}` to prevent route conflict with `/folders/count`

**Frontend**
- Add loading guard to `goToPage` to prevent duplicate entries on clicks before loading finishes
- Fetch total folder count to enable proper last-page calculation
- Fix pagination buttons to use total count instead of loaded folders length
- Add input to switch to a page (shown only when there are more than 5 pages)
<details>
<summary>Screenshot</summary>
<img width="1434" height="922" alt="Screenshot from 2026-03-04 20-00-11" src="https://github.com/user-attachments/assets/6e588618-24d6-4183-9983-b5f2c9c24412" />
</details>