### PR TITLE
fix(acls): allow uploading files with read+create+delete permissions

### DIFF
--- a/lib/ACL/ACLStorageWrapper.php
+++ b/lib/ACL/ACLStorageWrapper.php
@@ -85,12 +85,9 @@ class ACLStorageWrapper extends Wrapper implements IConstructableStorage {
 
 	#[\Override]
 	public function rename(string $source, string $target): bool {
-		if (str_starts_with($source, $target)) {
-			$part = substr($source, strlen($target));
-			//This is a rename of the transfer file to the original file
-			if (str_starts_with($part, '.ocTransferId')) {
-				return $this->checkPermissions($target, Constants::PERMISSION_CREATE) && parent::rename($source, $target);
-			}
+		// This is a rename of the transfer file to the original file
+		if (dirname($source) === dirname($target) && strpos($source, '.ocTransferId') > 0) {
+			return $this->checkPermissions($target, Constants::PERMISSION_CREATE) && parent::rename($source, $target);
 		}
 
 		$permissions = $this->file_exists($target) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;


### PR DESCRIPTION
This fixes an issue with accounts unable to upload files or folders without the edit permission. The logic was essentially copied from server's [permission mask wrapper](https://github.com/nextcloud/server/blob/1a70d192f3d328cd0e9ad74d5b1a0b45b5ab61e0/lib/private/Files/Storage/Wrapper/PermissionsMask.php#L65).