### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,12 +71,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a643b20f9ff1849a297d69ef250414ef16c48f6a"
+                "reference": "81260a8a5000a33ef0d1c99f6950e711bcef1fd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a643b20f9ff1849a297d69ef250414ef16c48f6a",
-                "reference": "a643b20f9ff1849a297d69ef250414ef16c48f6a",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/81260a8a5000a33ef0d1c99f6950e711bcef1fd5",
+                "reference": "81260a8a5000a33ef0d1c99f6950e711bcef1fd5",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-02-12T01:11:10+00:00"
+            "time": "2026-03-21T01:05:02+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency