### PR TITLE
fix: Include fileid in route params

### DIFF
--- a/src/actions/openGroupfolderAction.ts
+++ b/src/actions/openGroupfolderAction.ts
@@ -19,7 +19,7 @@ export const action: IFileAction = {
 		const dir = nodes[0].attributes.mountPoint
 		window.OCP.Files.Router.goToRoute(
 			null, // use default route
-			{ view: 'files' },
+			{ view: 'files', fileid: nodes[0].id },
 			{ dir },
 		)
 		return null


### PR DESCRIPTION
When clicking a folder in the Team Folders view, the `goToRoute` call omitted the `fileid` route param. Without it, the resolved route `/files?dir=/X` can collide with stale router state from a previous navigation, causing Vue Router to silently drop it as a `NavigationDuplicated`.

Adding `fileid` makes the target route `/files/123?dir=/X`, which is structurally distinct and navigates correctly.

On `stable32`:

https://github.com/nextcloud/groupfolders/blob/1ef5993faf35bb39869caa7844d8162f8e758783/src/actions/openGroupfolderAction.ts#L24

Returning `null cast to boolean` evaluates as falsy at runtime. The v3.x `FileAction` executor treated a falsy result as "action failed" and did not record this navigation as the successful result of a default action. This meant the router's state wasn't tied to this specific action's outcome, so the stale-route issue didn't surface before.

Fix https://github.com/nextcloud/groupfolders/issues/4499