### PR TITLE
[stable33] fix: Use trimmed name in groupfolders:rename command

### DIFF
--- a/lib/Command/Rename.php
+++ b/lib/Command/Rename.php
@@ -46,7 +46,7 @@ class Rename extends FolderCommand {
 			return 1;
 		}
 
-		$this->folderManager->renameFolder($folder->id, $input->getArgument('name'));
+		$this->folderManager->renameFolder($folder->id, $name);
 
 		return 0;
 	}


### PR DESCRIPTION
Already fixed on master by https://github.com/nextcloud/groupfolders/pull/4344