### PR TITLE
fix(quota): Invalidate root ETag on quota change

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -1057,6 +1057,20 @@ class FolderManager {
 		$query->executeStatement();
 
 		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The quota for groupfolder with id %d was set to %d bytes', [$folderId, $quota]));
+
+		// Bump the root etag so desktop clients re-fetch quota-available-bytes on
+		// their next PROPFIND. Going through Cache::update() also emits the cache
+		// events notify_push relies on; no user session or mounted storage is needed.
+		try {
+			$folder = $this->getFolder($folderId);
+			if ($folder !== null) {
+				$storage = $this->folderStorageManager->getBaseStorageForFolder($folder->id, $folder->useSeparateStorage(), $folder);
+				$storage->getCache()->update($folder->rootId, ['etag' => uniqid()]);
+			}
+		} catch (\Exception $e) {
+			// Best effort: a failed invalidation must not fail the quota update
+			$this->logger->warning('Failed to invalidate group folder root etag after quota change', ['folderId' => $folderId, 'exception' => $e]);
+		}
 	}
 
 	/**

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -493,6 +493,37 @@ class FolderManagerTest extends TestCase {
 		$this->assertEquals(0, $permissions);
 	}
 
+	public function testSetFolderQuotaInvalidatesEtag(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+
+		$folderId = $this->manager->createFolder('quota-etag-test');
+
+		$folderBefore = $this->manager->getFolder($folderId);
+		$this->assertNotNull($folderBefore);
+		$etagBefore = $folderBefore->rootCacheEntry->getEtag();
+
+		$this->manager->setFolderQuota($folderId, 1024 * 1024 * 1024);
+
+		$folderAfter = $this->manager->getFolder($folderId);
+		$this->assertNotNull($folderAfter);
+		$etagAfter = $folderAfter->rootCacheEntry->getEtag();
+
+		$this->assertNotEquals(
+			$etagBefore,
+			$etagAfter,
+			'Etag must change after quota update so desktop clients re-fetch quota-available-bytes via PROPFIND',
+		);
+
+		$this->assertSame(
+			1024 * 1024 * 1024,
+			$folderAfter->quota,
+			'Quota value must be persisted correctly',
+		);
+	}
+
 	public function testQuotaDefaultValue(): void {
 		$folderId1 = $this->manager->createFolder('foo');
 


### PR DESCRIPTION
When  the quota of a team folder changes, desktop clients continued to receive the stale `quota-available-bytes` value on subsequent PROPFINDs until the `etag` of the folder root changed. This fix invalidates the root etag immediately after the quota is updated, without requiring a mounted storage or an active user session.

This forces every desktop client to issue a fresh PROPFIND on the next sync cycle, at which point the DAV layer computes and returns the updated `quota-available-bytes` value.

Server side: https://github.com/nextcloud/server/pull/59398
Needed for https://github.com/nextcloud/desktop/issues/4580