### PR TITLE
fix: Add `datadirectory` fallback if not defined

### DIFF
--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -137,7 +137,7 @@ class FolderStorageManager {
 		int $folderId,
 		bool $init = false,
 	): IStorage {
-		$dataDirectory = $this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data')
+		$dataDirectory = $this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
 		$rootPath = $dataDirectory . '/__groupfolders/' . $folderId;
 		if ($init) {
 			$result = mkdir($rootPath . '/files', recursive:  true);

--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -137,7 +137,7 @@ class FolderStorageManager {
 		int $folderId,
 		bool $init = false,
 	): IStorage {
-		$dataDirectory = $this->config->getSystemValueString('datadirectory');
+		$dataDirectory = $this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data')
 		$rootPath = $dataDirectory . '/__groupfolders/' . $folderId;
 		if ($init) {
 			$result = mkdir($rootPath . '/files', recursive:  true);


### PR DESCRIPTION
Prevent things like https://github.com/nextcloud/groupfolders/issues/4264