### PR TITLE
[stable33] fix: Add `datadirectory` fallback if not defined

### DIFF
--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -125,7 +125,7 @@ class FolderStorageManager {
 		int $folderId,
 		bool $init = false,
 	): IStorage {
-		$dataDirectory = $this->config->getSystemValue('datadirectory');
+		$dataDirectory = $this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
 		$rootPath = $dataDirectory . '/__groupfolders/' . $folderId;
 		if ($init) {
 			$result = mkdir($rootPath . '/files', recursive:  true);


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/groupfolders/pull/4552