### PR TITLE
[stable33] fix(MountProvider): Fix ACL no permissions by default

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -307,7 +307,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 				$loader,
 				$user,
 				$aclManager,
-				$folder->acl ? $aclManager->getRulesByFileIds([$folder->rootId]) : [],
+				$folder->acl ? $aclManager->getRulesByFileIds([$folder->rootId])[$folder->storageId] ?? [] : [],
 			);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/groupfolders/issues/4495

Was already fixed on master in https://github.com/nextcloud/groupfolders/pull/4344.