### PR TITLE
fix(info.xml): app store entry formatting + update description

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,18 +8,18 @@
 	<name>Team Folders</name>
 	<summary>Shared folders managed by admins, accessible to designated teams with configurable permissions and quotas</summary>
 	<description>
-		<![CDATA[
-			Team Folders (formerly "Group Folders") allows administrators to create and manage shared folders that are accessible
-			to selected teams within Nextcloud.
+<![CDATA[
+Team Folders (formerly "Group Folders") allows administrators to create and manage shared
+folders for selected teams within Nextcloud.
 
-			Admins can configure folders from the Team Folders section in the admin settings, where they can grant access to one
-			or more teams, set custom permissions (such as read, write, and sharing rights), and assign storage quotas to each
-			folder.
+Admins can grant one or more teams access to a folder, configure permissions (such as read,
+write, and sharing rights), and assign storage quotas from the Team Folders section (under
+admin settings). The app also supports advanced permissions and integration with Nextcloud’s
+trash and versioning systems.
 
-			As of Hub 10/Nextcloud 31, admins must be members of a team to assign it a Team Folder. The app supports advanced
-			features such as quota management, granular access control, and integration with Nextcloud’s trash and versioning
-			systems.
-		]]>
+As of Hub 10 / Nextcloud 31, admins must be members of a team to assign that team to a Team
+Folder.
+]]>
 	</description>
 	<version>22.0.0-dev.0</version>
 	<licence>agpl</licence>


### PR DESCRIPTION
App store entry formatting got messed up at some point:

<img width="718" height="639" alt="image" src="https://github.com/user-attachments/assets/a60b210c-901c-44f7-954b-785fed7e622b" />

This fixes the formatting and also updates the language slightly for clarity/etc.
