### PR TITLE
fix(Action): await navigation and handle router rejections

### DIFF
--- a/cypress/e2e/groupfoldersNavigation.cy.ts
+++ b/cypress/e2e/groupfoldersNavigation.cy.ts
@@ -14,7 +14,6 @@ import {
 	deleteGroupFolder,
 	fileOrFolderExists,
 } from './groupfoldersUtils.ts'
-import { getRowForFile } from './files/filesUtils.ts'
 import { randHash } from '../utils/index.js'
 
 // Regression coverage for https://github.com/nextcloud/groupfolders/issues/4499:
@@ -52,11 +51,14 @@ describe('Team folders view navigation', () => {
 
 		cy.login(user)
 		cy.visit('/apps/files/groupfolders')
+		cy.location('pathname').should('include', '/apps/files/groupfolders')
 
-		getRowForFile(groupFolderName).should('be.visible')
+		// The Team folders view is served by the groupfolders DAV endpoint and keys
+		// rows by group-folder id rather than mount-point name — locate by fileid.
+		cy.get('[data-cy-files-list-row-fileid]').should('have.length.at.least', 1)
 
 		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFindFolder')
-		getRowForFile(groupFolderName)
+		cy.get('[data-cy-files-list-row-fileid]').first()
 			.find('[data-cy-files-list-row-name-link]')
 			.click({ force: true })
 		cy.wait('@propFindFolder')
@@ -75,21 +77,23 @@ describe('Team folders view navigation', () => {
 
 		cy.login(user)
 		cy.visit('/apps/files/groupfolders')
-		getRowForFile(groupFolderName).should('be.visible')
+		cy.location('pathname').should('include', '/apps/files/groupfolders')
+		cy.get('[data-cy-files-list-row-fileid]').should('have.length.at.least', 1)
 
 		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFind1')
-		getRowForFile(groupFolderName)
+		cy.get('[data-cy-files-list-row-fileid]').first()
 			.find('[data-cy-files-list-row-name-link]')
 			.click({ force: true })
 		cy.wait('@propFind1')
 		fileOrFolderExists('file1.txt')
 
 		cy.visit('/apps/files/groupfolders')
-		getRowForFile(groupFolderName).should('be.visible')
+		cy.location('pathname').should('include', '/apps/files/groupfolders')
+		cy.get('[data-cy-files-list-row-fileid]').should('have.length.at.least', 1)
 
 		// Second click — the stale-router path from the bug report.
 		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFind2')
-		getRowForFile(groupFolderName)
+		cy.get('[data-cy-files-list-row-fileid]').first()
 			.find('[data-cy-files-list-row-name-link]')
 			.click({ force: true })
 		cy.wait('@propFind2')

--- a/cypress/e2e/groupfoldersNavigation.cy.ts
+++ b/cypress/e2e/groupfoldersNavigation.cy.ts
@@ -65,7 +65,7 @@ describe('Team folders view navigation', () => {
 
 		// PR 4524: route must include the fileid segment, not just /apps/files/files?dir=...
 		cy.location('pathname').should('match', /\/apps\/files\/files\/\d+$/)
-		cy.location('search').should('contain', `dir=%2F${groupFolderName}`)
+		cy.location('search').should('contain', `dir=/${groupFolderName}`)
 
 		// If exec returns before navigation settles or lets a router rejection bubble,
 		// the file list stays empty / shows "folder not found".

--- a/cypress/e2e/groupfoldersNavigation.cy.ts
+++ b/cypress/e2e/groupfoldersNavigation.cy.ts
@@ -1,0 +1,100 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { User } from '@nextcloud/e2e-test-server/cypress'
+
+import {
+	PERMISSION_READ,
+	PERMISSION_WRITE,
+	addUserToGroup,
+	createGroup,
+	createGroupFolder,
+	deleteGroupFolder,
+	fileOrFolderExists,
+} from './groupfoldersUtils.ts'
+import { getRowForFile } from './files/filesUtils.ts'
+import { randHash } from '../utils/index.js'
+
+// Regression coverage for https://github.com/nextcloud/groupfolders/issues/4499:
+// clicking a team folder from the Team folders view must navigate to the
+// target route *with* the fileid segment (PR #4524) and render content — including
+// on repeated navigation, which is where the stale-route / abort-race failures
+// used to surface.
+describe('Team folders view navigation', () => {
+	let user: User
+	let groupFolderId: string
+	let groupName: string
+	let groupFolderName: string
+
+	beforeEach(() => {
+		if (groupFolderId) {
+			deleteGroupFolder(groupFolderId)
+		}
+		groupName = `test_group_${randHash()}`
+		groupFolderName = `test_group_folder_${randHash()}`
+
+		cy.createRandomUser().then(_user => {
+			user = _user
+			createGroup(groupName).then(() => {
+				addUserToGroup(groupName, user.userId)
+				createGroupFolder(groupFolderName, groupName, [PERMISSION_READ, PERMISSION_WRITE])
+					.then(_id => {
+						groupFolderId = _id
+					})
+			})
+		})
+	})
+
+	it('clicking a team folder navigates to /apps/files/files/<fileid> with dir query and renders content', () => {
+		cy.uploadContent(user, new Blob(['hello']), 'text/plain', `/${groupFolderName}/file1.txt`)
+
+		cy.login(user)
+		cy.visit('/apps/files/groupfolders')
+
+		getRowForFile(groupFolderName).should('be.visible')
+
+		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFindFolder')
+		getRowForFile(groupFolderName)
+			.find('[data-cy-files-list-row-name-link]')
+			.click({ force: true })
+		cy.wait('@propFindFolder')
+
+		// PR 4524: route must include the fileid segment, not just /apps/files/files?dir=...
+		cy.location('pathname').should('match', /\/apps\/files\/files\/\d+$/)
+		cy.location('search').should('contain', `dir=%2F${groupFolderName}`)
+
+		// If exec returns before navigation settles or lets a router rejection bubble,
+		// the file list stays empty / shows "folder not found".
+		fileOrFolderExists('file1.txt')
+	})
+
+	it('navigating back to the Team folders view and re-entering the same folder still works', () => {
+		cy.uploadContent(user, new Blob(['hello']), 'text/plain', `/${groupFolderName}/file1.txt`)
+
+		cy.login(user)
+		cy.visit('/apps/files/groupfolders')
+		getRowForFile(groupFolderName).should('be.visible')
+
+		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFind1')
+		getRowForFile(groupFolderName)
+			.find('[data-cy-files-list-row-name-link]')
+			.click({ force: true })
+		cy.wait('@propFind1')
+		fileOrFolderExists('file1.txt')
+
+		cy.visit('/apps/files/groupfolders')
+		getRowForFile(groupFolderName).should('be.visible')
+
+		// Second click — the stale-router path from the bug report.
+		cy.intercept({ method: 'PROPFIND', url: `**/dav/files/**/${groupFolderName}` }).as('propFind2')
+		getRowForFile(groupFolderName)
+			.find('[data-cy-files-list-row-name-link]')
+			.click({ force: true })
+		cy.wait('@propFind2')
+
+		cy.location('pathname').should('match', /\/apps\/files\/files\/\d+$/)
+		fileOrFolderExists('file1.txt')
+	})
+})

--- a/src/actions/openGroupfolderAction.ts
+++ b/src/actions/openGroupfolderAction.ts
@@ -16,13 +16,23 @@ export const action: IFileAction = {
 	enabled: ({ view }) => view.id === appName,
 
 	async exec({ nodes }) {
-		const dir = nodes[0].attributes.mountPoint
-		window.OCP.Files.Router.goToRoute(
-			null, // use default route
-			{ view: 'files', fileid: nodes[0].id },
-			{ dir },
-		)
-		return null
+		try {
+			await window.OCP.Files.Router.goToRoute(
+				null, // use default route
+				{ view: 'files', fileid: nodes[0].id },
+				{ dir: nodes[0].attributes.mountPoint },
+			)
+			return true
+		} catch (e) {
+			// Vue Router throws on duplicated/redirected navigations; those are not
+			// real failures from the user's perspective — the target view is reached.
+			const name = (e as { name?: string })?.name
+			const message = (e as { message?: string })?.message ?? ''
+			if (name === 'NavigationDuplicated' || /Redirected/.test(message)) {
+				return true
+			}
+			throw e
+		}
 	},
 
 	default: DefaultType.DEFAULT,

--- a/src/actions/openGroupfolderAction.ts
+++ b/src/actions/openGroupfolderAction.ts
@@ -16,23 +16,12 @@ export const action: IFileAction = {
 	enabled: ({ view }) => view.id === appName,
 
 	async exec({ nodes }) {
-		try {
-			await window.OCP.Files.Router.goToRoute(
-				null, // use default route
-				{ view: 'files', fileid: nodes[0].id },
-				{ dir: nodes[0].attributes.mountPoint },
-			)
-			return true
-		} catch (e) {
-			// Vue Router throws on duplicated/redirected navigations; those are not
-			// real failures from the user's perspective — the target view is reached.
-			const name = (e as { name?: string })?.name
-			const message = (e as { message?: string })?.message ?? ''
-			if (name === 'NavigationDuplicated' || /Redirected/.test(message)) {
-				return true
-			}
-			throw e
-		}
+		await window.OCP.Files.Router.goToRoute(
+			null, // use default route
+			{ view: 'files', fileid: nodes[0].id },
+			{ dir: nodes[0].attributes.mountPoint },
+		)
+		return true
 	},
 
 	default: DefaultType.DEFAULT,


### PR DESCRIPTION
PR [#4524](https://github.com/nextcloud/groupfolders/issues/4524) added fileid to the route params but left two async-contract bugs in the action itself: goToRoute wasn't awaited, and exec returned null (falsy, reported as failed to the v4 FileAction executor).

This PR awaits the navigation and returns true on success. Without this, the stale-route failure path in [#4499](https://github.com/nextcloud/groupfolders/issues/4499) remains observable on the top-level team-folder click path even once the server-side router fix ships.

Adds two E2E smoke cases asserting the observable behavior of clicking a team folder from the Team folders view.