### PR TITLE
Bring back used quota bar

### DIFF
--- a/src/settings/EditSelect.scss
+++ b/src/settings/EditSelect.scss
@@ -26,7 +26,7 @@
 		top: 0;
 		left: 0;
 		margin: 0;
-		background-color: var(--color-main-background);
+		background-color: transparent;
 	}
 
 	.quotabar-holder {


### PR DESCRIPTION
🔥 If I remember correctly, this is the second time this regression has occurred (although the reason may be different)
⚠️ The “After” screenshots are simulations created using my browser's CSS inspector; no actual testing has been performed (no test environment). **Reviewers must test the changes before merging.**

## Light theme
| Before | After | 
| --- | --- |
| <img width="196" height="655" alt="2026-04-30_10-20" src="https://github.com/user-attachments/assets/b99a49ea-6478-4b97-97b2-5eddf58d48e5" /> | <img width="196" height="655" alt="2026-04-30_10-20_1" src="https://github.com/user-attachments/assets/06b53a73-ff73-4479-aa17-96add0c87a16" /> | 

## Dark theme
| Before | After | 
| --- | --- |
| <img width="196" height="655" alt="2026-04-30_10-19_1" src="https://github.com/user-attachments/assets/c41dbc7a-4e99-4122-8a53-ff20aa8e0757" /> | <img width="196" height="655" alt="2026-04-30_10-19" src="https://github.com/user-attachments/assets/610ff845-0822-484c-a6d5-126943889c16" /> |