### PR TITLE
fall back to filename for restore if original location can't be determined

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -436,8 +436,8 @@ class TrashBackend implements ITrashBackend {
 				$name = $pathParts['filename'];
 				$key = $folder->id . '/' . $name . '/' . $timestamp;
 
-				$originalLocation = $indexedRows[$key]['original_location'] ?: '';
-				$deletedBy = $indexedRows[$key]['deleted_by'] ?: '';
+				$originalLocation = $indexedRows[$key]['original_location'] ?? '';
+				$deletedBy = $indexedRows[$key]['deleted_by'] ?? '';
 
 				return new GroupTrashItem(
 					$this,

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -140,6 +140,11 @@ class TrashBackend implements ITrashBackend {
 		/** @var Folder $targetFolder */
 		$targetFolder = $userFolder->get($item->getGroupFolderMountPoint());
 		$originalLocation = $item->getInternalOriginalLocation();
+
+		if ($originalLocation === '') {
+			$originalLocation = $item->getInternalPath();
+		}
+
 		$parent = dirname($originalLocation);
 		if ($parent === '.') {
 			$parent = '';

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -17,11 +17,14 @@ use OCA\GroupFolders\ACL\UserMapping\UserMapping;
 use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
+use OCA\GroupFolders\Trash\GroupTrashItem;
 use OCA\GroupFolders\Trash\TrashBackend;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
 use OCP\Share;
@@ -286,6 +289,9 @@ class TrashBackendTest extends TestCase {
 		// Restoring to original location works
 		$this->trashBackend->restoreItem($trashedOfUserA[0]);
 		$this->assertTrue($userAFolder->nodeExists('D/E/F/G'));
+
+		$this->folderManager->removeFolder($groupFolderId);
+		$groupBackend->deleteGroup('C');
 	}
 
 	public function testMoveToTrashSameNameDifferentSubfolders(): void {
@@ -330,5 +336,34 @@ class TrashBackendTest extends TestCase {
 		$this->assertCount(2, $dbReadmeRows, 'Both Readme.md entries should exist in oc_group_folders_trash');
 
 		$this->logout();
+	}
+
+	public function testRestoreNoOriginalLocation(): void {
+		$folder = $this->managerUserFolder->get($this->folderName);
+		$this->assertInstanceOf(Folder::class, $folder);
+		$folder->newFolder('folder');
+		$folder->newFile('folder/sub', 'foo');
+
+		$node = $folder->get('folder/sub');
+		$nodeId = $node->getId();
+		$node->delete();
+
+		$this->assertFalse($folder->nodeExists('folder/sub'));
+
+		// Simulate a broken origin location
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->delete('group_folders_trash')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($nodeId, IQueryBuilder::PARAM_INT)))
+			->executeStatement();
+
+		$trashedOfUserA = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $trashedOfUserA);
+		$trashItem = $trashedOfUserA[0];
+		$this->assertInstanceOf(GroupTrashItem::class, $trashItem);
+		$this->assertSame('', $trashItem->getInternalOriginalLocation());
+
+		// Restoring can't put it in the original location, but it still has a sensible name
+		$this->trashBackend->restoreItem($trashItem);
+		$this->assertTrue($folder->nodeExists('sub'));
 	}
 }

--- a/tests/stubs/oc_app.php
+++ b/tests/stubs/oc_app.php
@@ -57,8 +57,8 @@ class OC_App {
 	 * @deprecated 31.0.0 use IAppManager::cleanAppId
 	 */
 	public static function cleanAppId(string $app): string
- {
- }
+    {
+    }
 
 	/**
 	 * Check if an app is loaded
@@ -66,8 +66,8 @@ class OC_App {
 	 * @deprecated 27.0.0 use IAppManager::isAppLoaded
 	 */
 	public static function isAppLoaded(string $app): bool
- {
- }
+    {
+    }
 
 	/**
 	 * loads all apps
@@ -83,8 +83,8 @@ class OC_App {
 	 * @deprecated 29.0.0 use IAppManager::loadApps instead
 	 */
 	public static function loadApps(array $types = []): bool
- {
- }
+    {
+    }
 
 	/**
 	 * load a single app
@@ -93,15 +93,15 @@ class OC_App {
 	 * @deprecated 27.0.0 use IAppManager::loadApp
 	 */
 	public static function loadApp(string $app): void
- {
- }
+    {
+    }
 
 	/**
 	 * @internal
 	 */
 	public static function registerAutoloading(string $app, string $path, bool $force = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * Check if an app is of a specific type
@@ -109,8 +109,8 @@ class OC_App {
 	 * @deprecated 27.0.0 use IAppManager::isType
 	 */
 	public static function isType(string $app, array $types): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Returns apps enabled for the current user.
@@ -121,8 +121,8 @@ class OC_App {
 	 * @return list<string>
 	 */
 	public static function getEnabledApps(bool $forceRefresh = false, bool $all = false): array
- {
- }
+    {
+    }
 
 	/**
 	 * enables an app
@@ -134,8 +134,8 @@ class OC_App {
 	 * This function set an app as enabled in appconfig.
 	 */
 	public function enable(string $appId, array $groups = []): void
- {
- }
+    {
+    }
 
 	/**
 	 * Find the apps root for an app id.
@@ -147,8 +147,8 @@ class OC_App {
 	 * @deprecated 32.0.0 internal, use getAppPath or getAppWebPath
 	 */
 	public static function findAppInDirectories(string $appId, bool $ignoreCache = false)
- {
- }
+    {
+    }
 
 	/**
 	 * get app's version based on it's path
@@ -156,30 +156,30 @@ class OC_App {
 	 * @deprecated 32.0.0 use Server::get(IAppManager)->getAppInfoByPath() with the path to info.xml directly
 	 */
 	public static function getAppVersionByPath(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * get the id of loaded app
 	 * @deprecated 34.0.0 Don’t do that
 	 */
 	public static function getCurrentApp(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 Please register your alternative login option using the registerAlternativeLogin() on the RegistrationContext in your Application class implementing the OCP\Authentication\IAlternativeLogin interface
 	 */
 	public static function registerLogIn(array $entry): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return list<array{name: string, href: string, class: string}>
 	 */
 	public static function getAlternativeLogIns(): array
- {
- }
+    {
+    }
 
 	/**
 	 * get a list of all apps in the apps folder
@@ -188,8 +188,8 @@ class OC_App {
 	 * @deprecated 31.0.0 Use IAppManager::getAllAppsInAppsFolders instead
 	 */
 	public static function getAllApps(): array
- {
- }
+    {
+    }
 
 	/**
 	 * List all supported apps
@@ -197,22 +197,22 @@ class OC_App {
 	 * @deprecated 32.0.0 Use \OCP\Support\Subscription\IRegistry::delegateGetSupportedApps instead
 	 */
 	public function getSupportedApps(): array
- {
- }
+    {
+    }
 
 	/**
 	 * List all apps, this is used in apps.php
 	 */
 	public function listAllApps(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 32.0.0 Use IAppManager::isUpgradeRequired instead
 	 */
 	public static function shouldUpgrade(string $app): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Check whether the current Nextcloud version matches the given
@@ -232,16 +232,16 @@ class OC_App {
 	 * @deprecated 32.0.0 Use IAppManager::isAppCompatible instead
 	 */
 	public static function isAppCompatible(string $ocVersion, array $appInfo, bool $ignoreMax = false): bool
- {
- }
+    {
+    }
 
 	/**
 	 * get the installed version of all apps
 	 * @deprecated 32.0.0 Use IAppManager::getAppInstalledVersions or IAppConfig::getAppInstalledVersions instead
 	 */
 	public static function getAppVersions(): array
- {
- }
+    {
+    }
 
 	/**
 	 * update the database for the app and call the update script
@@ -249,8 +249,8 @@ class OC_App {
 	 * @deprecated 32.0.0 Use IAppManager::upgradeApp instead
 	 */
 	public static function updateApp(string $appId): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appId
@@ -258,20 +258,20 @@ class OC_App {
 	 * @throws NeedsUpdateException
 	 */
 	public static function executeRepairSteps(string $appId, array $steps)
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 32.0.0 Use the IJobList directly instead
 	 */
 	public static function setupBackgroundJobs(array $jobs): void
- {
- }
+    {
+    }
 
 	/**
 	 * @throws \Exception
 	 */
 	public static function checkAppDependencies(IConfig $config, IL10N $l, array $info, bool $ignoreMax): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_ocs_baseresponse.php
+++ b/tests/stubs/oc_appframework_ocs_baseresponse.php
@@ -26,30 +26,30 @@ abstract class BaseResponse extends Response {
 	 * @param DataResponse<S, T, H> $dataResponse
 	 */
 	public function __construct(DataResponse $dataResponse, protected string $format = 'xml', protected ?string $statusMessage = null, protected ?int $itemsCount = null, protected ?int $itemsPerPage = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @param array<string,string|int> $meta
 	 * @return string
 	 */
 	protected function renderResult(array $meta): string
- {
- }
+    {
+    }
 
 	/**
 	 * @psalm-taint-escape has_quotes
 	 * @psalm-taint-escape html
 	 */
 	protected function toJson(array $array): string
- {
- }
+    {
+    }
 
 	protected function toXML(array $array, \XMLWriter $writer): void
- {
- }
+    {
+    }
 
 	public function getOCSStatus()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_ocs_v1response.php
+++ b/tests/stubs/oc_appframework_ocs_v1response.php
@@ -23,18 +23,20 @@ class V1Response extends BaseResponse {
 	 *
 	 * @return Http::STATUS_*
 	 */
-	public function getStatus()
- {
- }
+	#[\Override]
+    public function getStatus()
+    {
+    }
 
 	/**
 	 * In v1 all OK is 100
 	 *
 	 * @return int
 	 */
-	public function getOCSStatus()
- {
- }
+	#[\Override]
+    public function getOCSStatus()
+    {
+    }
 
 	/**
 	 * Construct the meta part of the response
@@ -42,7 +44,8 @@ class V1Response extends BaseResponse {
 	 *
 	 * @return string
 	 */
-	public function render()
- {
- }
+	#[\Override]
+    public function render()
+    {
+    }
 }

--- a/tests/stubs/oc_appframework_utility_simplecontainer.php
+++ b/tests/stubs/oc_appframework_utility_simplecontainer.php
@@ -29,45 +29,51 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	public static bool $useLazyObjects = false;
 
 	public function __construct()
- {
- }
+    {
+    }
 
 	/**
 	 * @template T
 	 * @param class-string<T>|string $id
 	 * @return ($id is class-string<T> ? T : mixed)
 	 */
-	public function get(string $id): mixed
- {
- }
+	#[\Override]
+    public function get(string $id): mixed
+    {
+    }
 
-	public function has(string $id): bool
- {
- }
-
-	/**
-	 * @inheritDoc
-	 * @param list<class-string> $chain
-	 */
-	public function resolve(string $name, array $chain = []): mixed
- {
- }
+	#[\Override]
+    public function has(string $id): bool
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @param list<class-string> $chain
 	 */
-	public function query(string $name, bool $autoload = true, array $chain = []): mixed
- {
- }
+	#[\Override]
+    public function resolve(string $name, array $chain = []): mixed
+    {
+    }
 
-	public function registerParameter(string $name, mixed $value): void
- {
- }
+	/**
+	 * @inheritDoc
+	 * @param list<class-string> $chain
+	 */
+	#[\Override]
+    public function query(string $name, bool $autoload = true, array $chain = []): mixed
+    {
+    }
 
-	public function registerService(string $name, Closure $closure, bool $shared = true): void
- {
- }
+	#[\Override]
+    public function registerParameter(string $name, mixed $value): void
+    {
+    }
+
+	#[\Override]
+    public function registerService(string $name, Closure $closure, bool $shared = true): void
+    {
+    }
 
 	/**
 	 * Shortcut for returning a service from a service under a different key,
@@ -76,49 +82,54 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	 * @param string $alias the alias that should be registered
 	 * @param string $target the target that should be resolved instead
 	 */
-	public function registerAlias(string $alias, string $target): void
- {
- }
+	#[\Override]
+    public function registerAlias(string $alias, string $target): void
+    {
+    }
 
 	protected function registerDeprecatedAlias(string $alias, string $target): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 * @return string
 	 */
 	protected function sanitizeName($name)
- {
- }
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::has
 	 */
-	public function offsetExists($id): bool
- {
- }
+	#[\Override]
+    public function offsetExists($id): bool
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 * @return mixed
 	 */
-	#[\ReturnTypeWillChange]
- public function offsetGet($id)
- {
- }
+	#[\Override]
+    #[\ReturnTypeWillChange]
+    public function offsetGet($id)
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0 use \OCP\IContainer::registerService
 	 */
-	public function offsetSet($offset, $value): void
- {
- }
+	#[\Override]
+    public function offsetSet($offset, $value): void
+    {
+    }
 
 	/**
 	 * @deprecated 20.0.0
 	 */
-	public function offsetUnset($offset): void
- {
- }
+	#[\Override]
+    public function offsetUnset($offset): void
+    {
+    }
 }

--- a/tests/stubs/oc_db_querybuilder_querybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_querybuilder.php
@@ -39,8 +39,8 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * Initializes a new QueryBuilder.
 	 */
 	public function __construct(private ConnectionAdapter $connection, private SystemConfig $systemConfig, private LoggerInterface $logger)
- {
- }
+    {
+    }
 
 	/**
 	 * Enable/disable automatic prefixing of table names with the oc_ prefix
@@ -49,9 +49,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *                      owncloud database prefix automatically.
 	 * @since 8.2.0
 	 */
-	public function automaticTablePrefix($enabled)
- {
- }
+	#[\Override]
+    public function automaticTablePrefix($enabled)
+    {
+    }
 
 	/**
 	 * Gets an ExpressionBuilder used for object-oriented construction of query expressions.
@@ -69,9 +70,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IExpressionBuilder
 	 */
-	public function expr()
- {
- }
+	#[\Override]
+    public function expr()
+    {
+    }
 
 	/**
 	 * Gets an FunctionBuilder used for object-oriented construction of query functions.
@@ -89,27 +91,30 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IFunctionBuilder
 	 */
-	public function func()
- {
- }
+	#[\Override]
+    public function func()
+    {
+    }
 
 	/**
 	 * Gets the type of the currently built query.
 	 *
 	 * @return integer
 	 */
-	public function getType()
- {
- }
+	#[\Override]
+    public function getType()
+    {
+    }
 
 	/**
 	 * Gets the associated DBAL Connection for this query builder.
 	 *
 	 * @return IDBConnection
 	 */
-	public function getConnection()
- {
- }
+	#[\Override]
+    public function getConnection()
+    {
+    }
 
 	/**
 	 * Gets the state of this query builder instance.
@@ -118,17 +123,20 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @deprecated 30.0.0 This function is going to be removed with the next Doctrine/DBAL update
 	 *    and we can not fix this in our wrapper.
 	 */
-	public function getState()
- {
- }
+	#[\Override]
+    public function getState()
+    {
+    }
 
-	public function executeQuery(?IDBConnection $connection = null): IResult
- {
- }
+	#[\Override]
+    public function executeQuery(?IDBConnection $connection = null): IResult
+    {
+    }
 
-	public function executeStatement(?IDBConnection $connection = null): int
- {
- }
+	#[\Override]
+    public function executeStatement(?IDBConnection $connection = null): int
+    {
+    }
 
 
 	/**
@@ -143,9 +151,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return string The SQL query string.
 	 */
-	public function getSQL()
- {
- }
+	#[\Override]
+    public function getSQL()
+    {
+    }
 
 	/**
 	 * Sets a query parameter for the query being constructed.
@@ -164,9 +173,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function setParameter($key, $value, $type = null)
- {
- }
+	#[\Override]
+    public function setParameter($key, $value, $type = null)
+    {
+    }
 
 	/**
 	 * Sets a collection of query parameters for the query being constructed.
@@ -187,18 +197,20 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function setParameters(array $params, array $types = [])
- {
- }
+	#[\Override]
+    public function setParameters(array $params, array $types = [])
+    {
+    }
 
 	/**
 	 * Gets all defined query parameters for the query being constructed indexed by parameter index or name.
 	 *
 	 * @return array The currently defined query parameters indexed by parameter index or name.
 	 */
-	public function getParameters()
- {
- }
+	#[\Override]
+    public function getParameters()
+    {
+    }
 
 	/**
 	 * Gets a (previously set) query parameter of the query being constructed.
@@ -207,18 +219,20 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return mixed The value of the bound parameter.
 	 */
-	public function getParameter($key)
- {
- }
+	#[\Override]
+    public function getParameter($key)
+    {
+    }
 
 	/**
 	 * Gets all defined query parameter types for the query being constructed indexed by parameter index or name.
 	 *
 	 * @return array The currently defined query parameter types indexed by parameter index or name.
 	 */
-	public function getParameterTypes()
- {
- }
+	#[\Override]
+    public function getParameterTypes()
+    {
+    }
 
 	/**
 	 * Gets a (previously set) query parameter type of the query being constructed.
@@ -227,9 +241,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return mixed The value of the bound parameter type.
 	 */
-	public function getParameterType($key)
- {
- }
+	#[\Override]
+    public function getParameterType($key)
+    {
+    }
 
 	/**
 	 * Sets the position of the first result to retrieve (the "offset").
@@ -238,9 +253,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function setFirstResult($firstResult)
- {
- }
+	#[\Override]
+    public function setFirstResult($firstResult)
+    {
+    }
 
 	/**
 	 * Gets the position of the first result the query object was set to retrieve (the "offset").
@@ -248,9 +264,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return int The position of the first result.
 	 */
-	public function getFirstResult()
- {
- }
+	#[\Override]
+    public function getFirstResult()
+    {
+    }
 
 	/**
 	 * Sets the maximum number of results to retrieve (the "limit").
@@ -263,9 +280,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function setMaxResults($maxResults)
- {
- }
+	#[\Override]
+    public function setMaxResults($maxResults)
+    {
+    }
 
 	/**
 	 * Gets the maximum number of results the query object was set to retrieve (the "limit").
@@ -273,9 +291,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return int|null The maximum number of results.
 	 */
-	public function getMaxResults()
- {
- }
+	#[\Override]
+    public function getMaxResults()
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned in the query result.
@@ -292,9 +311,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * '@return $this This QueryBuilder instance.
 	 */
-	public function select(...$selects)
- {
- }
+	#[\Override]
+    public function select(...$selects)
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned with a different name in the query result.
@@ -311,9 +331,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function selectAlias($select, $alias): self
- {
- }
+	#[\Override]
+    public function selectAlias($select, $alias): self
+    {
+    }
 
 	/**
 	 * Specifies an item that is to be returned uniquely in the query result.
@@ -328,9 +349,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function selectDistinct($select)
- {
- }
+	#[\Override]
+    public function selectDistinct($select)
+    {
+    }
 
 	/**
 	 * Adds an item that is to be returned in the query result.
@@ -347,13 +369,15 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function addSelect(...$select)
- {
- }
+	#[\Override]
+    public function addSelect(...$select)
+    {
+    }
 
-	public function getOutputColumns(): array
- {
- }
+	#[\Override]
+    public function getOutputColumns(): array
+    {
+    }
 
 	/**
 	 * Turns the query being built into a bulk delete query that ranges over
@@ -372,9 +396,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 * @since 30.0.0 Alias is deprecated and will no longer be used with the next Doctrine/DBAL update
 	 */
-	public function delete($delete = null, $alias = null)
- {
- }
+	#[\Override]
+    public function delete($delete = null, $alias = null)
+    {
+    }
 
 	/**
 	 * Turns the query being built into a bulk update query that ranges over
@@ -393,9 +418,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @return $this This QueryBuilder instance.
 	 * @since 30.0.0 Alias is deprecated and will no longer be used with the next Doctrine/DBAL update
 	 */
-	public function update($update = null, $alias = null)
- {
- }
+	#[\Override]
+    public function update($update = null, $alias = null)
+    {
+    }
 
 	/**
 	 * Turns the query being built into an insert query that inserts into
@@ -416,9 +442,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function insert($insert = null)
- {
- }
+	#[\Override]
+    public function insert($insert = null)
+    {
+    }
 
 	/**
 	 * Creates and adds a query root corresponding to the table identified by the
@@ -435,9 +462,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function from($from, $alias = null)
- {
- }
+	#[\Override]
+    public function from($from, $alias = null)
+    {
+    }
 
 	/**
 	 * Creates and adds a join to the query.
@@ -456,9 +484,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function join($fromAlias, $join, $alias, $condition = null)
- {
- }
+	#[\Override]
+    public function join($fromAlias, $join, $alias, $condition = null)
+    {
+    }
 
 	/**
 	 * Creates and adds a join to the query.
@@ -477,9 +506,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function innerJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+	#[\Override]
+    public function innerJoin($fromAlias, $join, $alias, $condition = null)
+    {
+    }
 
 	/**
 	 * Creates and adds a left join to the query.
@@ -498,9 +528,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function leftJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+	#[\Override]
+    public function leftJoin($fromAlias, $join, $alias, $condition = null)
+    {
+    }
 
 	/**
 	 * Creates and adds a right join to the query.
@@ -519,9 +550,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function rightJoin($fromAlias, $join, $alias, $condition = null)
- {
- }
+	#[\Override]
+    public function rightJoin($fromAlias, $join, $alias, $condition = null)
+    {
+    }
 
 	/**
 	 * Sets a new value for a column in a bulk update query.
@@ -538,9 +570,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function set($key, $value)
- {
- }
+	#[\Override]
+    public function set($key, $value)
+    {
+    }
 
 	/**
 	 * Specifies one or more restrictions to the query result.
@@ -569,9 +602,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function where(...$predicates)
- {
- }
+	#[\Override]
+    public function where(...$predicates)
+    {
+    }
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical
@@ -591,9 +625,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @see where()
 	 */
-	public function andWhere(...$where)
- {
- }
+	#[\Override]
+    public function andWhere(...$where)
+    {
+    }
 
 	/**
 	 * Adds one or more restrictions to the query results, forming a logical
@@ -613,9 +648,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @see where()
 	 */
-	public function orWhere(...$where)
- {
- }
+	#[\Override]
+    public function orWhere(...$where)
+    {
+    }
 
 	/**
 	 * Specifies a grouping over the results of the query.
@@ -632,9 +668,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function groupBy(...$groupBys)
- {
- }
+	#[\Override]
+    public function groupBy(...$groupBys)
+    {
+    }
 
 	/**
 	 * Adds a grouping expression to the query.
@@ -651,9 +688,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function addGroupBy(...$groupBy)
- {
- }
+	#[\Override]
+    public function addGroupBy(...$groupBy)
+    {
+    }
 
 	/**
 	 * Sets a value for a column in an insert query.
@@ -674,9 +712,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function setValue($column, $value)
- {
- }
+	#[\Override]
+    public function setValue($column, $value)
+    {
+    }
 
 	/**
 	 * Specifies values for an insert query indexed by column names.
@@ -697,9 +736,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function values(array $values)
- {
- }
+	#[\Override]
+    public function values(array $values)
+    {
+    }
 
 	/**
 	 * Specifies a restriction over the groups of the query.
@@ -709,9 +749,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function having(...$having)
- {
- }
+	#[\Override]
+    public function having(...$having)
+    {
+    }
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical
@@ -721,9 +762,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function andHaving(...$having)
- {
- }
+	#[\Override]
+    public function andHaving(...$having)
+    {
+    }
 
 	/**
 	 * Adds a restriction over the groups of the query, forming a logical
@@ -733,9 +775,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function orHaving(...$having)
- {
- }
+	#[\Override]
+    public function orHaving(...$having)
+    {
+    }
 
 	/**
 	 * Specifies an ordering for the query results.
@@ -746,9 +789,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function orderBy($sort, $order = null)
- {
- }
+	#[\Override]
+    public function orderBy($sort, $order = null)
+    {
+    }
 
 	/**
 	 * Adds an ordering to the query results.
@@ -758,9 +802,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return $this This QueryBuilder instance.
 	 */
-	public function addOrderBy($sort, $order = null)
- {
- }
+	#[\Override]
+    public function addOrderBy($sort, $order = null)
+    {
+    }
 
 	/**
 	 * Gets a query part by its name.
@@ -771,9 +816,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @deprecated 30.0.0 This function is going to be removed with the next Doctrine/DBAL update
 	 *   and we can not fix this in our wrapper. Please track the details you need, outside the object.
 	 */
-	public function getQueryPart($queryPartName)
- {
- }
+	#[\Override]
+    public function getQueryPart($queryPartName)
+    {
+    }
 
 	/**
 	 * Gets all query parts.
@@ -782,9 +828,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @deprecated 30.0.0 This function is going to be removed with the next Doctrine/DBAL update
 	 *   and we can not fix this in our wrapper. Please track the details you need, outside the object.
 	 */
-	public function getQueryParts()
- {
- }
+	#[\Override]
+    public function getQueryParts()
+    {
+    }
 
 	/**
 	 * Resets SQL parts.
@@ -795,9 +842,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @deprecated 30.0.0 This function is going to be removed with the next Doctrine/DBAL update
 	 *  and we can not fix this in our wrapper. Please create a new IQueryBuilder instead.
 	 */
-	public function resetQueryParts($queryPartNames = null)
- {
- }
+	#[\Override]
+    public function resetQueryParts($queryPartNames = null)
+    {
+    }
 
 	/**
 	 * Resets a single SQL part.
@@ -808,9 +856,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @deprecated 30.0.0 This function is going to be removed with the next Doctrine/DBAL update
 	 *  and we can not fix this in our wrapper. Please create a new IQueryBuilder instead.
 	 */
-	public function resetQueryPart($queryPartName)
- {
- }
+	#[\Override]
+    public function resetQueryPart($queryPartName)
+    {
+    }
 
 	/**
 	 * Creates a new named parameter and bind the value $value to it.
@@ -841,9 +890,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IParameter the placeholder name used.
 	 */
-	public function createNamedParameter($value, $type = IQueryBuilder::PARAM_STR, $placeHolder = null)
- {
- }
+	#[\Override]
+    public function createNamedParameter($value, $type = IQueryBuilder::PARAM_STR, $placeHolder = null)
+    {
+    }
 
 	/**
 	 * Creates a new positional parameter and bind the given value to it.
@@ -867,9 +917,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IParameter
 	 */
-	public function createPositionalParameter($value, $type = IQueryBuilder::PARAM_STR)
- {
- }
+	#[\Override]
+    public function createPositionalParameter($value, $type = IQueryBuilder::PARAM_STR)
+    {
+    }
 
 	/**
 	 * Creates a new parameter
@@ -887,9 +938,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IParameter
 	 */
-	public function createParameter($name)
- {
- }
+	#[\Override]
+    public function createParameter($name)
+    {
+    }
 
 	/**
 	 * Creates a new function
@@ -914,18 +966,20 @@ class QueryBuilder extends TypedQueryBuilder {
 	 *
 	 * @return IQueryFunction
 	 */
-	public function createFunction($call)
- {
- }
+	#[\Override]
+    public function createFunction($call)
+    {
+    }
 
 	/**
 	 * Used to get the id of the last inserted element
 	 * @return int
 	 * @throws \BadMethodCallException When being called before an insert query has been run.
 	 */
-	public function getLastInsertId(): int
- {
- }
+	#[\Override]
+    public function getLastInsertId(): int
+    {
+    }
 
 	/**
 	 * Returns the table name quoted and with database prefix as needed by the implementation
@@ -933,9 +987,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @param string|IQueryFunction $table
 	 * @return string
 	 */
-	public function getTableName($table)
- {
- }
+	#[\Override]
+    public function getTableName($table)
+    {
+    }
 
 	/**
 	 * Returns the table name with database prefix as needed by the implementation
@@ -945,9 +1000,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @param string $table
 	 * @return string
 	 */
-	public function prefixTableName(string $table): string
- {
- }
+	#[\Override]
+    public function prefixTableName(string $table): string
+    {
+    }
 
 	/**
 	 * Returns the column name quoted and with table alias prefix as needed by the implementation
@@ -956,9 +1012,10 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @param string $tableAlias
 	 * @return string
 	 */
-	public function getColumnName($column, $tableAlias = '')
- {
- }
+	#[\Override]
+    public function getColumnName($column, $tableAlias = '')
+    {
+    }
 
 	/**
 	 * Returns the column name quoted and with table alias prefix as needed by the implementation
@@ -967,23 +1024,25 @@ class QueryBuilder extends TypedQueryBuilder {
 	 * @return string
 	 */
 	public function quoteAlias($alias)
- {
- }
+    {
+    }
 
 	public function escapeLikeParameter(string $parameter): string
- {
- }
+    {
+    }
 
-	public function hintShardKey(string $column, mixed $value, bool $overwrite = false): self
- {
- }
+	#[\Override]
+    public function hintShardKey(string $column, mixed $value, bool $overwrite = false): self
+    {
+    }
 
-	public function runAcrossAllShards(): self
- {
- }
+	#[\Override]
+    public function runAcrossAllShards(): self
+    {
+    }
 
 	#[Override]
- public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::Ordinary): self
- {
- }
+    public function forUpdate(ConflictResolutionMode $conflictResolutionMode = ConflictResolutionMode::Ordinary): self
+    {
+    }
 }

--- a/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
@@ -16,11 +16,13 @@ use RuntimeException;
  * @template-implements ITypedQueryBuilder<string>
  */
 abstract class TypedQueryBuilder implements ITypedQueryBuilder {
-	public function selectColumns(string ...$columns): static
- {
- }
+	#[\Override]
+    public function selectColumns(string ...$columns): static
+    {
+    }
 
-	public function selectColumnsDistinct(string ...$columns): static
- {
- }
+	#[\Override]
+    public function selectColumnsDistinct(string ...$columns): static
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_cache.php
+++ b/tests/stubs/oc_files_cache_cache.php
@@ -72,30 +72,31 @@ class Cache implements ICache {
 	protected IFilesMetadataManager $metadataManager;
 
 	public function __construct(
-     private IStorage $storage,
-     // this constructor is used in to many pleases to easily do proper di
-     // so instead we group it all together
-     ?CacheDependencies $dependencies = null
- )
- {
- }
+        private IStorage $storage,
+        // this constructor is used in to many pleases to easily do proper di
+        // so instead we group it all together
+        ?CacheDependencies $dependencies = null
+    )
+    {
+    }
 
 	protected function getQueryBuilder()
- {
- }
+    {
+    }
 
 	public function getStorageCache(): Storage
- {
- }
+    {
+    }
 
 	/**
 	 * Get the numeric storage id for this cache's storage
 	 *
 	 * @return int
 	 */
-	public function getNumericStorageId()
- {
- }
+	#[\Override]
+    public function getNumericStorageId()
+    {
+    }
 
 	/**
 	 * get the stored metadata of a file or folder
@@ -103,26 +104,27 @@ class Cache implements ICache {
 	 * @param string|int $file either the path of a file or folder or the file id for a file or folder
 	 * @return ICacheEntry|false the cache entry as array or false if the file is not found in the cache
 	 */
-	public function get($file)
- {
- }
+	#[\Override]
+    public function get($file)
+    {
+    }
 
 	/**
 	 * Create a CacheEntry from database row
 	 */
 	public static function cacheEntryFromData(array $data, IMimeTypeLoader $mimetypeLoader): CacheEntry
- {
- }
+    {
+    }
 
 	#[Override]
- public function getFolderContents(string $folder, ?string $mimeTypeFilter = null)
- {
- }
+    public function getFolderContents(string $folder, ?string $mimeTypeFilter = null)
+    {
+    }
 
 	#[Override]
- public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null)
- {
- }
+    public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null)
+    {
+    }
 
 	/**
 	 * insert or update meta data for a file or folder
@@ -133,9 +135,10 @@ class Cache implements ICache {
 	 * @return int file id
 	 * @throws \RuntimeException
 	 */
-	public function put($file, array $data)
- {
- }
+	#[\Override]
+    public function put($file, array $data)
+    {
+    }
 
 	/**
 	 * insert meta data for a new file or folder
@@ -146,9 +149,10 @@ class Cache implements ICache {
 	 * @return int file id
 	 * @throws \RuntimeException|Exception
 	 */
-	public function insert($file, array $data)
- {
- }
+	#[\Override]
+    public function insert($file, array $data)
+    {
+    }
 
 	/**
 	 * update the metadata of an existing file or folder in the cache
@@ -156,9 +160,10 @@ class Cache implements ICache {
 	 * @param int $id the fileid of the existing file or folder
 	 * @param array $data [$key => $value] the metadata to update, only the fields provided in the array will be updated, non-provided values will remain unchanged
 	 */
-	public function update($id, array $data)
- {
- }
+	#[\Override]
+    public function update($id, array $data)
+    {
+    }
 
 	/**
 	 * extract query parts and params array from data array
@@ -167,8 +172,8 @@ class Cache implements ICache {
 	 * @return array
 	 */
 	protected function normalizeData(array $data): array
- {
- }
+    {
+    }
 
 	/**
 	 * get the file id for a file
@@ -180,9 +185,10 @@ class Cache implements ICache {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getId($file)
- {
- }
+	#[\Override]
+    public function getId($file)
+    {
+    }
 
 	/**
 	 * get the id of the parent folder of a file
@@ -190,9 +196,10 @@ class Cache implements ICache {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getParentId($file)
- {
- }
+	#[\Override]
+    public function getParentId($file)
+    {
+    }
 
 	/**
 	 * check if a file is available in the cache
@@ -200,9 +207,10 @@ class Cache implements ICache {
 	 * @param string $file
 	 * @return bool
 	 */
-	public function inCache($file)
- {
- }
+	#[\Override]
+    public function inCache($file)
+    {
+    }
 
 	/**
 	 * remove a file or folder from the cache
@@ -211,9 +219,10 @@ class Cache implements ICache {
 	 *
 	 * @param string $file
 	 */
-	public function remove($file)
- {
- }
+	#[\Override]
+    public function remove($file)
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -221,9 +230,10 @@ class Cache implements ICache {
 	 * @param string $source
 	 * @param string $target
 	 */
-	public function move($source, $target)
- {
- }
+	#[\Override]
+    public function move($source, $target)
+    {
+    }
 
 	/**
 	 * Get the storage id and path needed for a move
@@ -232,16 +242,16 @@ class Cache implements ICache {
 	 * @return array [$storageId, $internalPath]
 	 */
 	protected function getMoveInfo($path)
- {
- }
+    {
+    }
 
 	protected function hasEncryptionWrapper(): bool
- {
- }
+    {
+    }
 
 	protected function shouldEncrypt(string $targetPath): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -252,16 +262,17 @@ class Cache implements ICache {
 	 * @throws DatabaseException
 	 * @throws \Exception if the given storages have an invalid id
 	 */
-	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
- {
- }
+	#[\Override]
+    public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
+    {
+    }
 
 	/**
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the scan status of a file
@@ -275,9 +286,10 @@ class Cache implements ICache {
 	 *
 	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
-	public function getStatus($file)
- {
- }
+	#[\Override]
+    public function getStatus($file)
+    {
+    }
 
 	/**
 	 * search for files matching $pattern
@@ -285,9 +297,10 @@ class Cache implements ICache {
 	 * @param string $pattern the search pattern using SQL search syntax (e.g. '%searchstring%')
 	 * @return ICacheEntry[] an array of cache entries where the name matches the search pattern
 	 */
-	public function search($pattern)
- {
- }
+	#[\Override]
+    public function search($pattern)
+    {
+    }
 
 	/**
 	 * search for files by mimetype
@@ -296,13 +309,15 @@ class Cache implements ICache {
 	 *                         where it will search for all mimetypes in the group ('image/*')
 	 * @return ICacheEntry[] an array of cache entries where the mimetype matches the search
 	 */
-	public function searchByMime($mimetype)
- {
- }
+	#[\Override]
+    public function searchByMime($mimetype)
+    {
+    }
 
-	public function searchQuery(ISearchQuery $query)
- {
- }
+	#[\Override]
+    public function searchQuery(ISearchQuery $query)
+    {
+    }
 
 	/**
 	 * Re-calculate the folder size and the size of all parent folders
@@ -310,8 +325,8 @@ class Cache implements ICache {
 	 * @param array|ICacheEntry|null $data (optional) meta data of the folder
 	 */
 	public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * get the incomplete count that shares parent $folder
@@ -320,8 +335,8 @@ class Cache implements ICache {
 	 * @return int
 	 */
 	public function getIncompleteChildrenCount($fileId)
- {
- }
+    {
+    }
 
 	/**
 	 * calculate the size of a folder and set it in the cache
@@ -331,8 +346,8 @@ class Cache implements ICache {
 	 * @return int|float
 	 */
 	public function calculateFolderSize($path, $entry = null)
- {
- }
+    {
+    }
 
 
 	/**
@@ -344,8 +359,8 @@ class Cache implements ICache {
 	 * @return int|float
 	 */
 	protected function calculateFolderSizeInner(string $path, $entry = null, bool $ignoreUnknown = false)
- {
- }
+    {
+    }
 
 	/**
 	 * get all file ids on the files on the storage
@@ -353,8 +368,8 @@ class Cache implements ICache {
 	 * @return int[]
 	 */
 	public function getAll()
- {
- }
+    {
+    }
 
 	/**
 	 * find a folder in the cache which has not been fully scanned
@@ -365,9 +380,10 @@ class Cache implements ICache {
 	 *
 	 * @return string|false the path of the folder or false when no folder matched
 	 */
-	public function getIncomplete()
- {
- }
+	#[\Override]
+    public function getIncomplete()
+    {
+    }
 
 	/**
 	 * get the path of a file on this storage by it's file id
@@ -375,9 +391,10 @@ class Cache implements ICache {
 	 * @param int $id the file id of the file or folder to search
 	 * @return string|null the path of the file (relative to the storage) or null if a file with the given id does not exists within this cache
 	 */
-	public function getPathById($id)
- {
- }
+	#[\Override]
+    public function getPathById($id)
+    {
+    }
 
 	/**
 	 * get the storage id of the storage for a file and the internal path of the file
@@ -389,8 +406,8 @@ class Cache implements ICache {
 	 * @deprecated 17.0.0 use getPathById() instead
 	 */
 	public static function getById($id)
- {
- }
+    {
+    }
 
 	/**
 	 * normalize the given path
@@ -398,9 +415,10 @@ class Cache implements ICache {
 	 * @param string $path
 	 * @return string
 	 */
-	public function normalize($path)
- {
- }
+	#[\Override]
+    public function normalize($path)
+    {
+    }
 
 	/**
 	 * Copy a file or folder in the cache
@@ -410,15 +428,18 @@ class Cache implements ICache {
 	 * @param string $targetPath
 	 * @return int fileId of copied entry
 	 */
-	public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int
- {
- }
+	#[\Override]
+    public function copyFromCache(ICache $sourceCache, ICacheEntry $sourceEntry, string $targetPath): int
+    {
+    }
 
-	public function getQueryFilterForStorage(): ISearchOperator
- {
- }
+	#[\Override]
+    public function getQueryFilterForStorage(): ISearchOperator
+    {
+    }
 
-	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
- {
- }
+	#[\Override]
+    public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_cacheentry.php
+++ b/tests/stubs/oc_files_cache_cacheentry.php
@@ -18,103 +18,124 @@ class CacheEntry implements ICacheEntry {
 	) {
 	}
 
-	public function offsetSet($offset, $value): void
- {
- }
+	#[\Override]
+    public function offsetSet($offset, $value): void
+    {
+    }
 
-	public function offsetExists($offset): bool
- {
- }
+	#[\Override]
+    public function offsetExists($offset): bool
+    {
+    }
 
-	public function offsetUnset($offset): void
- {
- }
+	#[\Override]
+    public function offsetUnset($offset): void
+    {
+    }
 
 	/**
 	 * @return mixed
 	 */
-	#[\ReturnTypeWillChange]
- public function offsetGet($offset)
- {
- }
+	#[\Override]
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+    }
 
-	public function getId()
- {
- }
+	#[\Override]
+    public function getId()
+    {
+    }
 
-	public function getStorageId()
- {
- }
-
-
-	public function getPath()
- {
- }
+	#[\Override]
+    public function getStorageId()
+    {
+    }
 
 
-	public function getName()
- {
- }
+	#[\Override]
+    public function getPath()
+    {
+    }
 
 
-	public function getMimeType(): string
- {
- }
+	#[\Override]
+    public function getName()
+    {
+    }
 
 
-	public function getMimePart()
- {
- }
+	#[\Override]
+    public function getMimeType(): string
+    {
+    }
 
-	public function getSize()
- {
- }
 
-	public function getMTime()
- {
- }
+	#[\Override]
+    public function getMimePart()
+    {
+    }
 
-	public function getStorageMTime()
- {
- }
+	#[\Override]
+    public function getSize()
+    {
+    }
 
-	public function getEtag()
- {
- }
+	#[\Override]
+    public function getMTime()
+    {
+    }
 
-	public function getPermissions(): int
- {
- }
+	#[\Override]
+    public function getStorageMTime()
+    {
+    }
 
-	public function isEncrypted()
- {
- }
+	#[\Override]
+    public function getEtag()
+    {
+    }
 
-	public function getMetadataEtag(): ?string
- {
- }
+	#[\Override]
+    public function getPermissions(): int
+    {
+    }
 
-	public function getCreationTime(): ?int
- {
- }
+	#[\Override]
+    public function isEncrypted()
+    {
+    }
 
-	public function getUploadTime(): ?int
- {
- }
+	#[\Override]
+    public function getMetadataEtag(): ?string
+    {
+    }
 
-	public function getParentId(): int
- {
- }
+	#[\Override]
+    public function getCreationTime(): ?int
+    {
+    }
+
+	#[\Override]
+    public function getUploadTime(): ?int
+    {
+    }
+
+	#[\Override]
+    public function getParentId(): int
+    {
+    }
 
 	public function getData()
- {
- }
+    {
+    }
 
 	public function __clone()
- {
- }
+    {
+    }
 
-	public function getUnencryptedSize(): int
- {
- }
+	#[\Override]
+    public function getUnencryptedSize(): int
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_scanner.php
+++ b/tests/stubs/oc_files_cache_scanner.php
@@ -51,8 +51,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	protected IDBConnection $connection;
 
 	public function __construct(protected Storage $storage)
- {
- }
+    {
+    }
 
 	/**
 	 * Whether to wrap the scanning of a folder in a database transaction
@@ -61,8 +61,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param bool $useTransactions
 	 */
 	public function setUseTransactions($useTransactions): void
- {
- }
+    {
+    }
 
 	/**
 	 * get all the metadata of a file or folder
@@ -72,8 +72,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return array|null an array of metadata of the file
 	 */
 	protected function getData($path)
- {
- }
+    {
+    }
 
 	/**
 	 * scan a single file and store it in the cache
@@ -87,13 +87,14 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return array|null an array of metadata of the scanned file
 	 * @throws LockedException
 	 */
-	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null)
- {
- }
+	#[\Override]
+    public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null)
+    {
+    }
 
 	protected function removeFromCache($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -102,8 +103,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return int the id of the added file
 	 */
 	protected function addToCache($path, $data, $fileId = -1)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -111,8 +112,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param int $fileId
 	 */
 	protected function updateCache($path, $data, $fileId = -1)
- {
- }
+    {
+    }
 
 	/**
 	 * scan a folder and all it's children
@@ -123,9 +124,10 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param bool $lock set to false to disable getting an additional read lock during scanning
 	 * @return array|null an array of the meta data of the scanned file or folder
 	 */
-	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true)
- {
- }
+	#[\Override]
+    public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true)
+    {
+    }
 
 	/**
 	 * Compares $array1 against $array2 and returns all the values in $array1 that are not in $array2
@@ -143,8 +145,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 *
 	 */
 	protected function array_diff_assoc_multi(array $array1, array $array2)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the children currently in the cache
@@ -153,8 +155,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return array<string, ICacheEntry>
 	 */
 	protected function getExistingChildren($folderId): array
- {
- }
+    {
+    }
 
 	/**
 	 * scan all the files and folders in a folder
@@ -168,8 +170,8 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @return int|float the size of the scanned folder or -1 if the size is unknown at this stage
 	 */
 	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize, &$etagChanged = false)
- {
- }
+    {
+    }
 
 	/**
 	 * check if the file should be ignored when scanning
@@ -179,20 +181,22 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param string $file
 	 * @return boolean
 	 */
-	public static function isPartialFile($file)
- {
- }
+	#[\Override]
+    public static function isPartialFile($file)
+    {
+    }
 
 	/**
 	 * walk over any folders that are not fully scanned yet and scan them
 	 */
-	public function backgroundScan()
- {
- }
+	#[\Override]
+    public function backgroundScan()
+    {
+    }
 
 	protected function runBackgroundScanJob(callable $callback, $path)
- {
- }
+    {
+    }
 
 	/**
 	 * Set whether the cache is affected by scan operations
@@ -200,6 +204,6 @@ class Scanner extends BasicEmitter implements IScanner {
 	 * @param boolean $active The active state of the cache
 	 */
 	public function setCacheActive($active)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_wrapper_cachejail.php
+++ b/tests/stubs/oc_files_cache_wrapper_cachejail.php
@@ -25,15 +25,15 @@ class CacheJail extends CacheWrapper {
 	protected string $unjailedRoot;
 
 	public function __construct(?ICache $cache, protected string $root, ?CacheDependencies $dependencies = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	protected function getRoot()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the root path with any nested jails resolved
@@ -41,19 +41,19 @@ class CacheJail extends CacheWrapper {
 	 * @return string
 	 */
 	public function getGetUnjailedRoot()
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	protected function getSourcePath(string $path)
- {
- }
+    {
+    }
 
 	protected function getUnjailedSourcePath(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -61,12 +61,13 @@ class CacheJail extends CacheWrapper {
 	 * @return null|string the jailed path or null if the path is outside the jail
 	 */
 	protected function getJailedPath(string $path, ?string $root = null)
- {
- }
+    {
+    }
 
-	protected function formatCacheEntry($entry)
- {
- }
+	#[\Override]
+    protected function formatCacheEntry($entry)
+    {
+    }
 
 	/**
 	 * get the stored metadata of a file or folder
@@ -74,9 +75,10 @@ class CacheJail extends CacheWrapper {
 	 * @param string|int $file
 	 * @return ICacheEntry|false
 	 */
-	public function get($file)
- {
- }
+	#[\Override]
+    public function get($file)
+    {
+    }
 
 	/**
 	 * insert meta data for a new file or folder
@@ -87,9 +89,10 @@ class CacheJail extends CacheWrapper {
 	 * @return int file id
 	 * @throws \RuntimeException
 	 */
-	public function insert($file, array $data)
- {
- }
+	#[\Override]
+    public function insert($file, array $data)
+    {
+    }
 
 	/**
 	 * update the metadata in the cache
@@ -97,9 +100,10 @@ class CacheJail extends CacheWrapper {
 	 * @param int $id
 	 * @param array $data
 	 */
-	public function update($id, array $data)
- {
- }
+	#[\Override]
+    public function update($id, array $data)
+    {
+    }
 
 	/**
 	 * get the file id for a file
@@ -107,9 +111,10 @@ class CacheJail extends CacheWrapper {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getId($file)
- {
- }
+	#[\Override]
+    public function getId($file)
+    {
+    }
 
 	/**
 	 * get the id of the parent folder of a file
@@ -117,9 +122,10 @@ class CacheJail extends CacheWrapper {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getParentId($file)
- {
- }
+	#[\Override]
+    public function getParentId($file)
+    {
+    }
 
 	/**
 	 * check if a file is available in the cache
@@ -127,18 +133,20 @@ class CacheJail extends CacheWrapper {
 	 * @param string $file
 	 * @return bool
 	 */
-	public function inCache($file)
- {
- }
+	#[\Override]
+    public function inCache($file)
+    {
+    }
 
 	/**
 	 * remove a file or folder from the cache
 	 *
 	 * @param string $file
 	 */
-	public function remove($file)
- {
- }
+	#[\Override]
+    public function remove($file)
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -146,9 +154,10 @@ class CacheJail extends CacheWrapper {
 	 * @param string $source
 	 * @param string $target
 	 */
-	public function move($source, $target)
- {
- }
+	#[\Override]
+    public function move($source, $target)
+    {
+    }
 
 	/**
 	 * Get the storage id and path needed for a move
@@ -156,34 +165,38 @@ class CacheJail extends CacheWrapper {
 	 * @param string $path
 	 * @return array [$storageId, $internalPath]
 	 */
-	protected function getMoveInfo($path)
- {
- }
+	#[\Override]
+    protected function getMoveInfo($path)
+    {
+    }
 
 	/**
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
-	public function clear()
- {
- }
+	#[\Override]
+    public function clear()
+    {
+    }
 
 	/**
 	 * @param string $file
 	 *
 	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
-	public function getStatus($file)
- {
- }
+	#[\Override]
+    public function getStatus($file)
+    {
+    }
 
 	/**
 	 * update the folder size and the size of all parent folders
 	 *
 	 * @param array|ICacheEntry|null $data (optional) meta data of the folder
 	 */
-	public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
- {
- }
+	#[\Override]
+    public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
+    {
+    }
 
 	/**
 	 * get the size of a folder and set it in the cache
@@ -192,18 +205,20 @@ class CacheJail extends CacheWrapper {
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int|float
 	 */
-	public function calculateFolderSize($path, $entry = null)
- {
- }
+	#[\Override]
+    public function calculateFolderSize($path, $entry = null)
+    {
+    }
 
 	/**
 	 * get all file ids on the files on the storage
 	 *
 	 * @return int[]
 	 */
-	public function getAll()
- {
- }
+	#[\Override]
+    public function getAll()
+    {
+    }
 
 	/**
 	 * find a folder in the cache which has not been fully scanned
@@ -214,9 +229,10 @@ class CacheJail extends CacheWrapper {
 	 *
 	 * @return string|false the path of the folder or false when no folder matched
 	 */
-	public function getIncomplete()
- {
- }
+	#[\Override]
+    public function getIncomplete()
+    {
+    }
 
 	/**
 	 * get the path of a file on this storage by it's id
@@ -224,9 +240,10 @@ class CacheJail extends CacheWrapper {
 	 * @param int $id
 	 * @return string|null
 	 */
-	public function getPathById($id)
- {
- }
+	#[\Override]
+    public function getPathById($id)
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -236,19 +253,22 @@ class CacheJail extends CacheWrapper {
 	 * @param string $sourcePath
 	 * @param string $targetPath
 	 */
-	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
- {
- }
+	#[\Override]
+    public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
+    {
+    }
 
-	public function getQueryFilterForStorage(): ISearchOperator
- {
- }
+	#[\Override]
+    public function getQueryFilterForStorage(): ISearchOperator
+    {
+    }
 
 	protected function addJailFilterQuery(ISearchOperator $filter): ISearchOperator
- {
- }
+    {
+    }
 
-	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
- {
- }
+	#[\Override]
+    public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
+    {
+    }
 }

--- a/tests/stubs/oc_files_cache_wrapper_cachewrapper.php
+++ b/tests/stubs/oc_files_cache_wrapper_cachewrapper.php
@@ -17,20 +17,22 @@ use OCP\Server;
 
 class CacheWrapper extends Cache {
 	public function __construct(protected ?ICache $cache, ?CacheDependencies $dependencies = null)
- {
- }
+    {
+    }
 
 	public function getCache(): ICache
- {
- }
+    {
+    }
 
-	protected function hasEncryptionWrapper(): bool
- {
- }
+	#[\Override]
+    protected function hasEncryptionWrapper(): bool
+    {
+    }
 
-	protected function shouldEncrypt(string $targetPath): bool
- {
- }
+	#[\Override]
+    protected function shouldEncrypt(string $targetPath): bool
+    {
+    }
 
 	/**
 	 * Make it easy for wrappers to modify every returned cache entry
@@ -39,8 +41,8 @@ class CacheWrapper extends Cache {
 	 * @return ICacheEntry|false
 	 */
 	protected function formatCacheEntry($entry)
- {
- }
+    {
+    }
 
 	/**
 	 * get the stored metadata of a file or folder
@@ -48,9 +50,10 @@ class CacheWrapper extends Cache {
 	 * @param string|int $file
 	 * @return ICacheEntry|false
 	 */
-	public function get($file)
- {
- }
+	#[\Override]
+    public function get($file)
+    {
+    }
 
 	/**
 	 * get the metadata of all files stored in $folder
@@ -58,9 +61,10 @@ class CacheWrapper extends Cache {
 	 * @param string $folder
 	 * @return ICacheEntry[]
 	 */
-	public function getFolderContents(string $folder, ?string $mimeTypeFilter = null): array
- {
- }
+	#[\Override]
+    public function getFolderContents(string $folder, ?string $mimeTypeFilter = null): array
+    {
+    }
 
 	/**
 	 * Get the metadata of all files stored in given folder
@@ -68,9 +72,10 @@ class CacheWrapper extends Cache {
 	 * @param int $fileId the file id of the folder
 	 * @return ICacheEntry[]
 	 */
-	public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null)
- {
- }
+	#[\Override]
+    public function getFolderContentsById(int $fileId, ?string $mimeTypeFilter = null)
+    {
+    }
 
 	/**
 	 * insert or update meta data for a file or folder
@@ -81,9 +86,10 @@ class CacheWrapper extends Cache {
 	 * @return int file id
 	 * @throws \RuntimeException
 	 */
-	public function put($file, array $data)
- {
- }
+	#[\Override]
+    public function put($file, array $data)
+    {
+    }
 
 	/**
 	 * insert meta data for a new file or folder
@@ -94,9 +100,10 @@ class CacheWrapper extends Cache {
 	 * @return int file id
 	 * @throws \RuntimeException
 	 */
-	public function insert($file, array $data)
- {
- }
+	#[\Override]
+    public function insert($file, array $data)
+    {
+    }
 
 	/**
 	 * update the metadata in the cache
@@ -104,9 +111,10 @@ class CacheWrapper extends Cache {
 	 * @param int $id
 	 * @param array $data
 	 */
-	public function update($id, array $data)
- {
- }
+	#[\Override]
+    public function update($id, array $data)
+    {
+    }
 
 	/**
 	 * get the file id for a file
@@ -114,9 +122,10 @@ class CacheWrapper extends Cache {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getId($file)
- {
- }
+	#[\Override]
+    public function getId($file)
+    {
+    }
 
 	/**
 	 * get the id of the parent folder of a file
@@ -124,9 +133,10 @@ class CacheWrapper extends Cache {
 	 * @param string $file
 	 * @return int
 	 */
-	public function getParentId($file)
- {
- }
+	#[\Override]
+    public function getParentId($file)
+    {
+    }
 
 	/**
 	 * check if a file is available in the cache
@@ -134,18 +144,20 @@ class CacheWrapper extends Cache {
 	 * @param string $file
 	 * @return bool
 	 */
-	public function inCache($file)
- {
- }
+	#[\Override]
+    public function inCache($file)
+    {
+    }
 
 	/**
 	 * remove a file or folder from the cache
 	 *
 	 * @param string $file
 	 */
-	public function remove($file)
- {
- }
+	#[\Override]
+    public function remove($file)
+    {
+    }
 
 	/**
 	 * Move a file or folder in the cache
@@ -153,46 +165,53 @@ class CacheWrapper extends Cache {
 	 * @param string $source
 	 * @param string $target
 	 */
-	public function move($source, $target)
- {
- }
+	#[\Override]
+    public function move($source, $target)
+    {
+    }
 
-	protected function getMoveInfo($path)
- {
- }
+	#[\Override]
+    protected function getMoveInfo($path)
+    {
+    }
 
-	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
- {
- }
+	#[\Override]
+    public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath)
+    {
+    }
 
 	/**
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
-	public function clear()
- {
- }
+	#[\Override]
+    public function clear()
+    {
+    }
 
 	/**
 	 * @param string $file
 	 *
 	 * @return int Cache::NOT_FOUND, Cache::PARTIAL, Cache::SHALLOW or Cache::COMPLETE
 	 */
-	public function getStatus($file)
- {
- }
+	#[\Override]
+    public function getStatus($file)
+    {
+    }
 
-	public function searchQuery(ISearchQuery $query)
- {
- }
+	#[\Override]
+    public function searchQuery(ISearchQuery $query)
+    {
+    }
 
 	/**
 	 * update the folder size and the size of all parent folders
 	 *
 	 * @param array|ICacheEntry|null $data (optional) meta data of the folder
 	 */
-	public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
- {
- }
+	#[\Override]
+    public function correctFolderSize(string $path, $data = null, bool $isBackgroundScan = false): void
+    {
+    }
 
 	/**
 	 * get the size of a folder and set it in the cache
@@ -201,18 +220,20 @@ class CacheWrapper extends Cache {
 	 * @param array|null|ICacheEntry $entry (optional) meta data of the folder
 	 * @return int|float
 	 */
-	public function calculateFolderSize($path, $entry = null)
- {
- }
+	#[\Override]
+    public function calculateFolderSize($path, $entry = null)
+    {
+    }
 
 	/**
 	 * get all file ids on the files on the storage
 	 *
 	 * @return int[]
 	 */
-	public function getAll()
- {
- }
+	#[\Override]
+    public function getAll()
+    {
+    }
 
 	/**
 	 * find a folder in the cache which has not been fully scanned
@@ -223,9 +244,10 @@ class CacheWrapper extends Cache {
 	 *
 	 * @return string|false the path of the folder or false when no folder matched
 	 */
-	public function getIncomplete()
- {
- }
+	#[\Override]
+    public function getIncomplete()
+    {
+    }
 
 	/**
 	 * get the path of a file on this storage by it's id
@@ -233,18 +255,20 @@ class CacheWrapper extends Cache {
 	 * @param int $id
 	 * @return string|null
 	 */
-	public function getPathById($id)
- {
- }
+	#[\Override]
+    public function getPathById($id)
+    {
+    }
 
 	/**
 	 * Returns the numeric storage id
 	 *
 	 * @return int
 	 */
-	public function getNumericStorageId()
- {
- }
+	#[\Override]
+    public function getNumericStorageId()
+    {
+    }
 
 	/**
 	 * get the storage id of the storage for a file and the internal path of the file
@@ -254,15 +278,18 @@ class CacheWrapper extends Cache {
 	 * @param int $id
 	 * @return array first element holding the storage id, second the path
 	 */
-	public static function getById($id)
- {
- }
+	#[\Override]
+    public static function getById($id)
+    {
+    }
 
-	public function getQueryFilterForStorage(): ISearchOperator
- {
- }
+	#[\Override]
+    public function getQueryFilterForStorage(): ISearchOperator
+    {
+    }
 
-	public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
- {
- }
+	#[\Override]
+    public function getCacheEntryFromSearchResult(ICacheEntry $rawEntry): ?ICacheEntry
+    {
+    }
 }

--- a/tests/stubs/oc_files_fileinfo.php
+++ b/tests/stubs/oc_files_fileinfo.php
@@ -7,8 +7,8 @@
  */
 namespace OC\Files;
 
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Mount\HomeMountPoint;
-use OCA\Files_Sharing\External\Mount;
 use OCA\Files_Sharing\ISharedMountPoint;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
@@ -28,206 +28,233 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @param ?IUser $owner
 	 */
 	public function __construct(private $path, private $storage, private $internalPath, private array|ICacheEntry $data, $mount, private ?IUser $owner = null)
- {
- }
+    {
+    }
 
-	public function offsetSet($offset, $value): void
- {
- }
+	#[\Override]
+    public function offsetSet($offset, $value): void
+    {
+    }
 
-	public function offsetExists($offset): bool
- {
- }
+	#[\Override]
+    public function offsetExists($offset): bool
+    {
+    }
 
-	public function offsetUnset($offset): void
- {
- }
+	#[\Override]
+    public function offsetUnset($offset): void
+    {
+    }
 
-	public function offsetGet(mixed $offset): mixed
- {
- }
-
-	/**
-	 * @return string
-	 */
-	public function getPath()
- {
- }
-
-	public function getStorage()
- {
- }
+	#[\Override]
+    public function offsetGet(mixed $offset): mixed
+    {
+    }
 
 	/**
 	 * @return string
 	 */
-	public function getInternalPath()
- {
- }
+	#[\Override]
+    public function getPath()
+    {
+    }
+
+	#[\Override]
+    public function getStorage()
+    {
+    }
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getInternalPath()
+    {
+    }
 
 	/**
 	 * Get FileInfo ID or null in case of part file
 	 *
 	 * @return int|null
 	 */
-	public function getId()
- {
- }
+	#[\Override]
+    public function getId()
+    {
+    }
 
-	public function getMimetype(): string
- {
- }
-
-	/**
-	 * @return string
-	 */
-	public function getMimePart()
- {
- }
+	#[\Override]
+    public function getMimetype(): string
+    {
+    }
 
 	/**
 	 * @return string
 	 */
-	public function getName()
- {
- }
+	#[\Override]
+    public function getMimePart()
+    {
+    }
 
 	/**
 	 * @return string
 	 */
-	public function getEtag()
- {
- }
+	#[\Override]
+    public function getName()
+    {
+    }
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getEtag()
+    {
+    }
 
 	/**
 	 * @param bool $includeMounts
 	 * @return int|float
 	 */
-	public function getSize($includeMounts = true)
- {
- }
+	#[\Override]
+    public function getSize($includeMounts = true)
+    {
+    }
 
 	/**
 	 * @return int
 	 */
-	public function getMTime()
- {
- }
+	#[\Override]
+    public function getMTime()
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
-	public function isEncrypted()
- {
- }
+	#[\Override]
+    public function isEncrypted()
+    {
+    }
 
 	/**
 	 * Return the current version used for the HMAC in the encryption app
 	 */
 	public function getEncryptedVersion(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
-	public function getPermissions()
- {
- }
+	#[\Override]
+    public function getPermissions()
+    {
+    }
 
 	/**
 	 * @return string \OCP\Files\FileInfo::TYPE_FILE|\OCP\Files\FileInfo::TYPE_FOLDER
 	 */
-	public function getType()
- {
- }
+	#[\Override]
+    public function getType()
+    {
+    }
 
-	public function getData()
- {
- }
+	#[\Override]
+    public function getData(): ICacheEntry
+    {
+    }
 
 	/**
 	 * @param int $permissions
 	 * @return bool
 	 */
 	protected function checkPermissions($permissions)
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
-	public function isReadable()
- {
- }
+	#[\Override]
+    public function isReadable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
-	public function isUpdateable()
- {
- }
+	#[\Override]
+    public function isUpdateable()
+    {
+    }
 
 	/**
 	 * Check whether new files or folders can be created inside this folder
 	 *
 	 * @return bool
 	 */
-	public function isCreatable()
- {
- }
+	#[\Override]
+    public function isCreatable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
-	public function isDeletable()
- {
- }
+	#[\Override]
+    public function isDeletable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
-	public function isShareable()
- {
- }
+	#[\Override]
+    public function isShareable()
+    {
+    }
 
 	/**
 	 * Check if a file or folder is shared
 	 *
 	 * @return bool
 	 */
-	public function isShared()
- {
- }
+	#[\Override]
+    public function isShared()
+    {
+    }
 
-	public function isMounted()
- {
- }
+	#[\Override]
+    public function isMounted()
+    {
+    }
 
 	/**
 	 * Get the mountpoint the file belongs to
 	 *
 	 * @return \OCP\Files\Mount\IMountPoint
 	 */
-	public function getMountPoint()
- {
- }
+	#[\Override]
+    public function getMountPoint()
+    {
+    }
 
 	/**
 	 * Get the owner of the file
 	 *
 	 * @return ?IUser
 	 */
-	public function getOwner()
- {
- }
+	#[\Override]
+    public function getOwner()
+    {
+    }
 
 	/**
 	 * @param IMountPoint[] $mounts
 	 */
 	public function setSubMounts(array $mounts)
- {
- }
+    {
+    }
 
 	/**
 	 * Add a cache entry which is the child of this folder
@@ -238,41 +265,48 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @param string $entryPath full path of the child entry
 	 */
 	public function addSubEntry($data, $entryPath)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritdoc
 	 */
-	public function getChecksum()
- {
- }
+	#[\Override]
+    public function getChecksum()
+    {
+    }
 
-	public function getExtension(): string
- {
- }
+	#[\Override]
+    public function getExtension(): string
+    {
+    }
 
-	public function getCreationTime(): int
- {
- }
+	#[\Override]
+    public function getCreationTime(): int
+    {
+    }
 
-	public function getUploadTime(): int
- {
- }
+	#[\Override]
+    public function getUploadTime(): int
+    {
+    }
 
-	public function getLastActivity(): int
- {
- }
+	#[\Override]
+    public function getLastActivity(): int
+    {
+    }
 
-	public function getParentId(): int
- {
- }
+	#[\Override]
+    public function getParentId(): int
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @return array<string, int|string|bool|float|string[]|int[]>
 	 */
-	public function getMetadata(): array
- {
- }
+	#[\Override]
+    public function getMetadata(): array
+    {
+    }
 }

--- a/tests/stubs/oc_files_filesystem.php
+++ b/tests/stubs/oc_files_filesystem.php
@@ -151,8 +151,8 @@ class Filesystem {
 	 * @internal
 	 */
 	public static function logWarningWhenAddingStorageWrapper(bool $shouldLog): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $wrapperName
@@ -160,8 +160,8 @@ class Filesystem {
 	 * @param int $priority
 	 */
 	public static function addStorageWrapper($wrapperName, $wrapper, $priority = 50)
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the storage factory
@@ -169,15 +169,15 @@ class Filesystem {
 	 * @return IStorageFactory
 	 */
 	public static function getLoader()
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the mount manager
 	 */
 	public static function getMountManager(): Mount\Manager
- {
- }
+    {
+    }
 
 	/**
 	 * get the mountpoint of the storage object for a path
@@ -189,8 +189,8 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function getMountPoint($path)
- {
- }
+    {
+    }
 
 	/**
 	 * get a list of all mount points in a directory
@@ -199,8 +199,8 @@ class Filesystem {
 	 * @return string[]
 	 */
 	public static function getMountPoints($path)
- {
- }
+    {
+    }
 
 	/**
 	 * get the storage mounted at $mountPoint
@@ -209,24 +209,24 @@ class Filesystem {
 	 * @return IStorage|null
 	 */
 	public static function getStorage($mountPoint)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $id
 	 * @return IMountPoint[]
 	 */
 	public static function getMountByStorageId($id)
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $id
 	 * @return IMountPoint[]
 	 */
 	public static function getMountByNumericId($id)
- {
- }
+    {
+    }
 
 	/**
 	 * resolve a path to a storage and internal path
@@ -235,20 +235,20 @@ class Filesystem {
 	 * @return array{?IStorage, string} an array consisting of the storage and the internal path
 	 */
 	public static function resolvePath($path): array
- {
- }
+    {
+    }
 
 	public static function init(string|IUser|null $user, string $root): bool
- {
- }
+    {
+    }
 
 	public static function initInternal(string $root): bool
- {
- }
+    {
+    }
 
 	public static function initMountManager(): void
- {
- }
+    {
+    }
 
 	/**
 	 * Initialize system and personal mount points for a user
@@ -256,22 +256,22 @@ class Filesystem {
 	 * @throws NoUserException if the user is not available
 	 */
 	public static function initMountPoints(string|IUser|null $user = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * Get the default filesystem view
 	 */
 	public static function getView(): ?View
- {
- }
+    {
+    }
 
 	/**
 	 * tear down the filesystem, removing all storage providers
 	 */
 	public static function tearDown()
- {
- }
+    {
+    }
 
 	/**
 	 * get the relative path of the root data directory for the current user
@@ -281,8 +281,8 @@ class Filesystem {
 	 * Returns path like /admin/files
 	 */
 	public static function getRoot()
- {
- }
+    {
+    }
 
 	/**
 	 * mount an \OC\Files\Storage\Storage in our virtual filesystem
@@ -292,8 +292,8 @@ class Filesystem {
 	 * @param string $mountpoint
 	 */
 	public static function mount($class, $arguments, $mountpoint)
- {
- }
+    {
+    }
 
 	/**
 	 * check if the requested path is valid
@@ -302,8 +302,8 @@ class Filesystem {
 	 * @return bool
 	 */
 	public static function isValidPath($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $filename
@@ -312,8 +312,8 @@ class Filesystem {
 	 * @deprecated 30.0.0 - use \OC\Files\FilenameValidator::isForbidden
 	 */
 	public static function isFileBlacklisted($filename)
- {
- }
+    {
+    }
 
 	/**
 	 * check if the directory should be ignored when scanning
@@ -323,137 +323,137 @@ class Filesystem {
 	 * @return boolean
 	 */
 	public static function isIgnoredDir($dir)
- {
- }
+    {
+    }
 
 	/**
 	 * following functions are equivalent to their php builtin equivalents for arguments/return values.
 	 */
 	public static function mkdir($path)
- {
- }
+    {
+    }
 
 	public static function rmdir($path)
- {
- }
+    {
+    }
 
 	public static function is_dir($path)
- {
- }
+    {
+    }
 
 	public static function is_file($path)
- {
- }
+    {
+    }
 
 	public static function stat($path)
- {
- }
+    {
+    }
 
 	public static function filetype($path)
- {
- }
+    {
+    }
 
 	public static function filesize($path)
- {
- }
+    {
+    }
 
 	public static function readfile($path)
- {
- }
+    {
+    }
 
 	public static function isCreatable($path)
- {
- }
+    {
+    }
 
 	public static function isReadable($path)
- {
- }
+    {
+    }
 
 	public static function isUpdatable($path)
- {
- }
+    {
+    }
 
 	public static function isDeletable($path)
- {
- }
+    {
+    }
 
 	public static function isSharable($path)
- {
- }
+    {
+    }
 
 	public static function file_exists($path)
- {
- }
+    {
+    }
 
 	public static function filemtime($path)
- {
- }
+    {
+    }
 
 	public static function touch($path, $mtime = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @return string|false
 	 */
 	public static function file_get_contents($path)
- {
- }
+    {
+    }
 
 	public static function file_put_contents($path, $data)
- {
- }
+    {
+    }
 
 	public static function unlink($path)
- {
- }
+    {
+    }
 
 	public static function rename($source, $target)
- {
- }
+    {
+    }
 
 	public static function copy($source, $target)
- {
- }
+    {
+    }
 
 	public static function fopen($path, $mode)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @throws InvalidPathException
 	 */
 	public static function toTmpFile($path): string|false
- {
- }
+    {
+    }
 
 	public static function fromTmpFile($tmpFile, $path)
- {
- }
+    {
+    }
 
 	public static function getMimeType($path)
- {
- }
+    {
+    }
 
 	public static function hash($type, $path, $raw = false)
- {
- }
+    {
+    }
 
 	public static function free_space($path = '/')
- {
- }
+    {
+    }
 
 	public static function search($query)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $query
 	 */
 	public static function searchByMime($query)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string|int $tag name or tag id
@@ -461,8 +461,8 @@ class Filesystem {
 	 * @return FileInfo[] array or file info
 	 */
 	public static function searchByTag($tag, $userId)
- {
- }
+    {
+    }
 
 	/**
 	 * check if a file or folder has been updated since $time
@@ -472,8 +472,8 @@ class Filesystem {
 	 * @return bool
 	 */
 	public static function hasUpdated($path, $time)
- {
- }
+    {
+    }
 
 	/**
 	 * Fix common problems with a file path
@@ -486,8 +486,8 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function normalizePath($path, $stripTrailingSlash = true, $isAbsolutePath = false, $keepUnicode = false)
- {
- }
+    {
+    }
 
 	/**
 	 * get the filesystem info
@@ -498,8 +498,8 @@ class Filesystem {
 	 * @return FileInfo|false False if file does not exist
 	 */
 	public static function getFileInfo($path, $includeMountPoints = true)
- {
- }
+    {
+    }
 
 	/**
 	 * change file metadata
@@ -511,8 +511,8 @@ class Filesystem {
 	 * returns the fileid of the updated file
 	 */
 	public static function putFileInfo($path, $data)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the content of a directory.
@@ -522,8 +522,8 @@ class Filesystem {
 	 * @return FileInfo[]
 	 */
 	public static function getDirectoryContent($directory, ?string $mimeTypeFilter = null): array
- {
- }
+    {
+    }
 
 	/**
 	 * Get the path of a file by id
@@ -535,8 +535,8 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function getPath($id)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the owner for a file or folder
@@ -545,13 +545,13 @@ class Filesystem {
 	 * @return string
 	 */
 	public static function getOwner($path)
- {
- }
+    {
+    }
 
 	/**
 	 * get the ETag for a file or folder
 	 */
 	public static function getETag(string $path): string|false
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_mount_mountpoint.php
+++ b/tests/stubs/oc_files_mount_mountpoint.php
@@ -46,62 +46,69 @@ class MountPoint implements IMountPoint {
 	 * @throws \Exception
 	 */
 	public function __construct(string|IStorage $storage, string $mountpoint, ?array $arguments = null, ?IStorageFactory $loader = null, ?array $mountOptions = null, protected ?int $mountId = null, ?string $mountProvider = null)
- {
- }
+    {
+    }
 
 	/**
 	 * get complete path to the mount point, relative to data/
 	 *
 	 * @return string
 	 */
-	public function getMountPoint()
- {
- }
+	#[\Override]
+    public function getMountPoint()
+    {
+    }
 
 	/**
 	 * Sets the mount point path, relative to data/
 	 *
 	 * @param string $mountPoint new mount point
 	 */
-	public function setMountPoint($mountPoint)
- {
- }
+	#[\Override]
+    public function setMountPoint($mountPoint)
+    {
+    }
 
 	/**
 	 * @return IStorage|null
 	 */
-	public function getStorage()
- {
- }
+	#[\Override]
+    public function getStorage()
+    {
+    }
 
 	/**
 	 * @return string|null
 	 */
-	public function getStorageId()
- {
- }
+	#[\Override]
+    public function getStorageId()
+    {
+    }
 
 	/**
 	 * @return int
 	 */
-	public function getNumericStorageId()
- {
- }
+	#[\Override]
+    public function getNumericStorageId()
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return string
 	 */
-	public function getInternalPath($path)
- {
- }
+	#[\Override]
+    public function getInternalPath($path)
+    {
+    }
 
 	/**
 	 * @param callable $wrapper
 	 */
-	public function wrapStorage($wrapper)
- {
- }
+	#[\Override]
+    public function wrapStorage($wrapper)
+    {
+    }
 
 	/**
 	 * Get a mount option
@@ -110,37 +117,43 @@ class MountPoint implements IMountPoint {
 	 * @param mixed $default Default value for the mount option
 	 * @return mixed
 	 */
-	public function getOption($name, $default)
- {
- }
+	#[\Override]
+    public function getOption($name, $default)
+    {
+    }
 
 	/**
 	 * Get all options for the mount
 	 *
 	 * @return array
 	 */
-	public function getOptions()
- {
- }
+	#[\Override]
+    public function getOptions()
+    {
+    }
 
 	/**
 	 * Get the file id of the root of the storage
 	 *
 	 * @return int
 	 */
-	public function getStorageRootId()
- {
- }
+	#[\Override]
+    public function getStorageRootId()
+    {
+    }
 
-	public function getMountId()
- {
- }
+	#[\Override]
+    public function getMountId()
+    {
+    }
 
-	public function getMountType()
- {
- }
+	#[\Override]
+    public function getMountType()
+    {
+    }
 
-	public function getMountProvider(): string
- {
- }
+	#[\Override]
+    public function getMountProvider(): string
+    {
+    }
 }

--- a/tests/stubs/oc_files_node_lazyfolder.php
+++ b/tests/stubs/oc_files_node_lazyfolder.php
@@ -10,6 +10,7 @@ namespace OC\Files\Node;
 use OC\Files\Filesystem;
 use OC\Files\Utils\PathHelper;
 use OCP\Constants;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -35,16 +36,16 @@ class LazyFolder implements Folder {
 	 * @param array $data
 	 */
 	public function __construct(IRootFolder $rootFolder, private \Closure $folderClosure, protected array $data = [])
- {
- }
+    {
+    }
 
 	protected function getRootFolder(): IRootFolder
- {
- }
+    {
+    }
 
 	protected function getRealFolder(): Folder
- {
- }
+    {
+    }
 
 	/**
 	 * Magic method to first get the real rootFolder and then
@@ -55,459 +56,519 @@ class LazyFolder implements Folder {
 	 * @return mixed
 	 */
 	public function __call($method, $args)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getUser()
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function listen($scope, $method, callable $callback)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function removeListener($scope = null, $method = null, ?callable $callback = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function emit($scope, $method, $arguments = [])
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function mount($storage, $mountPoint, $arguments = [])
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getMount(string $mountPoint): IMountPoint
- {
- }
+    {
+    }
 
 	/**
 	 * @return IMountPoint[]
 	 */
 	public function getMountsIn(string $mountPoint): array
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getMountByStorageId($storageId)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getMountByNumericStorageId($numericId)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function unMount($mount)
- {
- }
+    {
+    }
 
-	public function get($path)
- {
- }
+	#[\Override]
+    public function get($path)
+    {
+    }
 
 	#[Override]
- public function getOrCreateFolder(string $path, int $maxRetries = 5): Folder
- {
- }
+    public function getOrCreateFolder(string $path, int $maxRetries = 5): Folder
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function rename($targetPath)
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function delete()
- {
- }
+	#[\Override]
+    public function delete()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function copy($targetPath)
- {
- }
+	#[\Override]
+    public function copy($targetPath)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function touch($mtime = null)
- {
- }
+	#[\Override]
+    public function touch($mtime = null)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getStorage()
- {
- }
+	#[\Override]
+    public function getStorage()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getPath()
- {
- }
+	#[\Override]
+    public function getPath()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getInternalPath()
- {
- }
+	#[\Override]
+    public function getInternalPath()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getId()
- {
- }
+	#[\Override]
+    public function getId()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function stat()
- {
- }
+	#[\Override]
+    public function stat()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getMTime()
- {
- }
+	#[\Override]
+    public function getMTime()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getSize($includeMounts = true): int|float
- {
- }
+	#[\Override]
+    public function getSize($includeMounts = true): int|float
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getEtag()
- {
- }
+	#[\Override]
+    public function getEtag()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getPermissions()
- {
- }
+	#[\Override]
+    public function getPermissions()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isReadable()
- {
- }
+	#[\Override]
+    public function isReadable()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isUpdateable()
- {
- }
+	#[\Override]
+    public function isUpdateable()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isDeletable()
- {
- }
+	#[\Override]
+    public function isDeletable()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isShareable()
- {
- }
+	#[\Override]
+    public function isShareable()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getParent()
- {
- }
+	#[\Override]
+    public function getParent()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getName()
- {
- }
+	#[\Override]
+    public function getName()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getUserFolder($userId)
- {
- }
+    {
+    }
 
-	public function getMimetype(): string
- {
- }
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getMimePart()
- {
- }
+	#[\Override]
+    public function getMimetype(): string
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isEncrypted()
- {
- }
+	#[\Override]
+    public function getMimePart()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getType()
- {
- }
+	#[\Override]
+    public function isEncrypted()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isShared()
- {
- }
+	#[\Override]
+    public function getType()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isMounted()
- {
- }
+	#[\Override]
+    public function isShared()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getMountPoint()
- {
- }
+	#[\Override]
+    public function isMounted()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getOwner()
- {
- }
+	#[\Override]
+    public function getMountPoint()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getChecksum()
- {
- }
-
-	public function getExtension(): string
- {
- }
+	#[\Override]
+    public function getOwner()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getFullPath($path)
- {
- }
+	#[\Override]
+    public function getChecksum()
+    {
+    }
+
+	#[\Override]
+    public function getExtension(): string
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isSubNode($node)
- {
- }
+	#[\Override]
+    public function getFullPath($path)
+    {
+    }
+
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+    public function isSubNode($node)
+    {
+    }
 
 	#[Override]
- public function getDirectoryListing(?string $mimetypeFilter = null): array
- {
- }
+    public function getDirectoryListing(?string $mimetypeFilter = null): array
+    {
+    }
 
-	public function nodeExists($path)
- {
- }
-
-	/**
-	 * @inheritDoc
-	 */
-	public function newFolder($path)
- {
- }
+	#[\Override]
+    public function nodeExists($path)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function newFile($path, $content = null)
- {
- }
+	#[\Override]
+    public function newFolder($path)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function search($query)
- {
- }
+	#[\Override]
+    public function newFile($path, $content = null)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function searchByMime($mimetype)
- {
- }
+	#[\Override]
+    public function search($query)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function searchByTag($tag, $userId)
- {
- }
-
-	public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0)
- {
- }
+	#[\Override]
+    public function searchByMime($mimetype)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getById($id)
- {
- }
+	#[\Override]
+    public function searchByTag($tag, $userId)
+    {
+    }
 
-	public function getFirstNodeById(int $id): ?Node
- {
- }
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getFreeSpace()
- {
- }
+	#[\Override]
+    public function searchBySystemTag(string $tagName, string $userId, int $limit = 0, int $offset = 0)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function isCreatable()
- {
- }
+	#[\Override]
+    public function getById($id)
+    {
+    }
+
+	#[\Override]
+    public function getFirstNodeById(int $id): ?Node
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getNonExistingName($filename)
- {
- }
+	#[\Override]
+    public function getFreeSpace()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function move($targetPath)
- {
- }
+	#[\Override]
+    public function isCreatable()
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function lock($type)
- {
- }
+	#[\Override]
+    public function getNonExistingName($filename)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function changeLock($targetType)
- {
- }
+	#[\Override]
+    public function move($targetPath)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function unlock($type)
- {
- }
+	#[\Override]
+    public function lock($type)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getRecent($limit, $offset = 0)
- {
- }
+	#[\Override]
+    public function changeLock($targetType)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getCreationTime(): int
- {
- }
+	#[\Override]
+    public function unlock($type)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getUploadTime(): int
- {
- }
+	#[\Override]
+    public function getRecent($limit, $offset = 0)
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getLastActivity(): int
- {
- }
+	#[\Override]
+    public function getCreationTime(): int
+    {
+    }
 
-	public function getRelativePath($path)
- {
- }
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+    public function getUploadTime(): int
+    {
+    }
 
-	public function getParentId(): int
- {
- }
+	/**
+	 * @inheritDoc
+	 */
+	#[\Override]
+    public function getLastActivity(): int
+    {
+    }
+
+	#[\Override]
+    public function getRelativePath($path)
+    {
+    }
+
+	#[\Override]
+    public function getParentId(): int
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @return array<string, int|string|bool|float|string[]|int[]>
 	 */
-	public function getMetadata(): array
- {
- }
+	#[\Override]
+    public function getMetadata(): array
+    {
+    }
 
-	public function verifyPath($fileName, $readonly = false): void
- {
- }
+	#[\Override]
+    public function getData(): ICacheEntry
+    {
+    }
+
+	#[\Override]
+    public function verifyPath($fileName, $readonly = false): void
+    {
+    }
 }

--- a/tests/stubs/oc_files_node_node.php
+++ b/tests/stubs/oc_files_node_node.php
@@ -8,15 +8,16 @@
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;
-use OC\Files\Mount\MoveableMount;
 use OC\Files\Utils\PathHelper;
 use OC\Files\View;
 use OCP\Constants;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMovableMount;
 use OCP\Files\Node as INode;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -40,8 +41,8 @@ class Node implements INode {
 	 * @param FileInfo $fileInfo
 	 */
 	public function __construct(IRootFolder $root, $view, protected $path, protected ?FileInfo $fileInfo = null, protected ?INode $parent = null, private bool $infoHasSubMountsIncluded = true)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a Node of the same type that represents a non-existing path
@@ -51,8 +52,8 @@ class Node implements INode {
 	 * @throws \Exception
 	 */
 	protected function createNonExistingNode($path)
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the matching file info
@@ -62,15 +63,15 @@ class Node implements INode {
 	 * @throws NotFoundException
 	 */
 	public function getFileInfo(bool $includeMountPoint = true)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string[] $hooks
 	 */
 	protected function sendHooks($hooks, ?array $args = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $permissions
@@ -79,9 +80,10 @@ class Node implements INode {
 	 * @throws NotFoundException
 	 */
 	protected function checkPermissions($permissions)
- {
- }
+    {
+    }
 
+	#[\Override]
 	public function delete() {
 	}
 
@@ -91,52 +93,59 @@ class Node implements INode {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException
 	 */
-	public function touch($mtime = null)
- {
- }
+	#[\Override]
+    public function touch($mtime = null)
+    {
+    }
 
-	public function getStorage()
- {
- }
-
-	/**
-	 * @return string
-	 */
-	public function getPath()
- {
- }
+	#[\Override]
+    public function getStorage()
+    {
+    }
 
 	/**
 	 * @return string
 	 */
-	public function getInternalPath()
- {
- }
+	#[\Override]
+    public function getPath()
+    {
+    }
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getInternalPath()
+    {
+    }
 
 	/**
 	 * @return int
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function getId()
- {
- }
+	#[\Override]
+    public function getId()
+    {
+    }
 
 	/**
 	 * @return array
 	 */
-	public function stat()
- {
- }
+	#[\Override]
+    public function stat()
+    {
+    }
 
 	/**
 	 * @return int
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function getMTime()
- {
- }
+	#[\Override]
+    public function getMTime()
+    {
+    }
 
 	/**
 	 * @param bool $includeMounts
@@ -144,91 +153,101 @@ class Node implements INode {
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function getSize($includeMounts = true): int|float
- {
- }
+	#[\Override]
+    public function getSize($includeMounts = true): int|float
+    {
+    }
 
 	/**
 	 * @return string
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function getEtag()
- {
- }
+	#[\Override]
+    public function getEtag()
+    {
+    }
 
 	/**
 	 * @return int
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function getPermissions()
- {
- }
+	#[\Override]
+    public function getPermissions()
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function isReadable()
- {
- }
+	#[\Override]
+    public function isReadable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function isUpdateable()
- {
- }
+	#[\Override]
+    public function isUpdateable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function isDeletable()
- {
- }
+	#[\Override]
+    public function isDeletable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function isShareable()
- {
- }
+	#[\Override]
+    public function isShareable()
+    {
+    }
 
 	/**
 	 * @return bool
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */
-	public function isCreatable()
- {
- }
+	#[\Override]
+    public function isCreatable()
+    {
+    }
 
-	public function getParent(): INode|IRootFolder
- {
- }
+	#[\Override]
+    public function getParent(): INode|IRootFolder
+    {
+    }
 
 	/**
 	 * @return string
 	 */
-	public function getName()
- {
- }
+	#[\Override]
+    public function getName()
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return string
 	 */
 	protected function normalizePath($path)
- {
- }
+    {
+    }
 
 	/**
 	 * check if the requested path is valid
@@ -237,71 +256,84 @@ class Node implements INode {
 	 * @return bool
 	 */
 	public function isValidPath($path)
- {
- }
+    {
+    }
 
-	public function isMounted()
- {
- }
+	#[\Override]
+    public function isMounted()
+    {
+    }
 
-	public function isShared()
- {
- }
+	#[\Override]
+    public function isShared()
+    {
+    }
 
-	public function getMimeType(): string
- {
- }
+	#[\Override]
+    public function getMimeType(): string
+    {
+    }
 
-	public function getMimePart()
- {
- }
+	#[\Override]
+    public function getMimePart()
+    {
+    }
 
-	public function getType()
- {
- }
+	#[\Override]
+    public function getType()
+    {
+    }
 
-	public function isEncrypted()
- {
- }
+	#[\Override]
+    public function isEncrypted()
+    {
+    }
 
-	public function getMountPoint()
- {
- }
+	#[\Override]
+    public function getMountPoint()
+    {
+    }
 
-	public function getOwner()
- {
- }
+	#[\Override]
+    public function getOwner()
+    {
+    }
 
+	#[\Override]
 	public function getChecksum() {
 	}
 
-	public function getExtension(): string
- {
- }
+	#[\Override]
+    public function getExtension(): string
+    {
+    }
 
 	/**
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @throws LockedException
 	 */
-	public function lock($type)
- {
- }
+	#[\Override]
+    public function lock($type)
+    {
+    }
 
 	/**
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @throws LockedException
 	 */
-	public function changeLock($type)
- {
- }
+	#[\Override]
+    public function changeLock($type)
+    {
+    }
 
 	/**
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
 	 * @throws LockedException
 	 */
-	public function unlock($type)
- {
- }
+	#[\Override]
+    public function unlock($type)
+    {
+    }
 
 	/**
 	 * @param string $targetPath
@@ -310,9 +342,10 @@ class Node implements INode {
 	 * @throws NotFoundException
 	 * @throws NotPermittedException if copy not allowed or failed
 	 */
-	public function copy($targetPath)
- {
- }
+	#[\Override]
+    public function copy($targetPath)
+    {
+    }
 
 	/**
 	 * @param string $targetPath
@@ -322,31 +355,42 @@ class Node implements INode {
 	 * @throws NotPermittedException if move not allowed or failed
 	 * @throws LockedException
 	 */
-	public function move($targetPath)
- {
- }
+	#[\Override]
+    public function move($targetPath)
+    {
+    }
 
-	public function getCreationTime(): int
- {
- }
+	#[\Override]
+    public function getCreationTime(): int
+    {
+    }
 
-	public function getUploadTime(): int
- {
- }
+	#[\Override]
+    public function getUploadTime(): int
+    {
+    }
 
-	public function getLastActivity(): int
- {
- }
+	#[\Override]
+    public function getLastActivity(): int
+    {
+    }
 
-	public function getParentId(): int
- {
- }
+	#[\Override]
+    public function getParentId(): int
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @return array<string, int|string|bool|float|string[]|int[]>
 	 */
-	public function getMetadata(): array
- {
- }
+	#[\Override]
+    public function getMetadata(): array
+    {
+    }
+
+	#[\Override]
+    public function getData(): ICacheEntry
+    {
+    }
 }

--- a/tests/stubs/oc_files_objectstore_objectstorescanner.php
+++ b/tests/stubs/oc_files_objectstore_objectstorescanner.php
@@ -12,19 +12,23 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\FileInfo;
 
 class ObjectStoreScanner extends Scanner {
-	public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null)
- {
- }
+	#[\Override]
+    public function scanFile($file, $reuseExisting = 0, $parentId = -1, $cacheData = null, $lock = true, $data = null)
+    {
+    }
 
-	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true)
- {
- }
+	#[\Override]
+    public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true)
+    {
+    }
 
-	protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize, &$etagChanged = false)
- {
- }
+	#[\Override]
+    protected function scanChildren(string $path, $recursive, int $reuse, int $folderId, bool $lock, int|float $oldSize, &$etagChanged = false)
+    {
+    }
 
-	public function backgroundScan()
- {
- }
+	#[\Override]
+    public function backgroundScan()
+    {
+    }
 }

--- a/tests/stubs/oc_files_objectstore_objectstorestorage.php
+++ b/tests/stubs/oc_files_objectstore_objectstorestorage.php
@@ -48,44 +48,51 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 	 * @throws \Exception
 	 */
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
-	public function mkdir(string $path, bool $force = false, array $metadata = []): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path, bool $force = false, array $metadata = []): bool
+    {
+    }
 
 	/**
 	 * Object Stores use a NoopScanner because metadata is directly stored in
 	 * the file cache and cannot really scan the filesystem. The storage passed in is not used anywhere.
 	 */
-	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
- {
- }
+	#[\Override]
+    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
+    {
+    }
 
-	public function getId(): string
- {
- }
+	#[\Override]
+    public function getId(): string
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
 	public function rmObject(ICacheEntry $entry): bool
- {
- }
+    {
+    }
 
-	public function stat(string $path): array|false
- {
- }
+	#[\Override]
+    public function stat(string $path): array|false
+    {
+    }
 
-	public function getPermissions(string $path): int
- {
- }
+	#[\Override]
+    public function getPermissions(string $path): int
+    {
+    }
 
 	/**
 	 * Override this method if you need a different unique resource identifier for your object storage implementation.
@@ -95,107 +102,126 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 	 * @return string the unified resource name used to identify the object
 	 */
 	public function getURN(int $fileId): string
- {
- }
+    {
+    }
 
-	public function opendir(string $path)
- {
- }
+	#[\Override]
+    public function opendir(string $path)
+    {
+    }
 
-	public function filetype(string $path): string|false
- {
- }
+	#[\Override]
+    public function filetype(string $path): string|false
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
-	public function file_exists(string $path): bool
- {
- }
+	#[\Override]
+    public function file_exists(string $path): bool
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function getMimeType(string $path): string|false
- {
- }
+	#[\Override]
+    public function getMimeType(string $path): string|false
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
 	public function writeBack(string $tmpFile, string $path)
- {
- }
+    {
+    }
 
-	public function hasUpdated(string $path, int $time): bool
- {
- }
+	#[\Override]
+    public function hasUpdated(string $path, int $time): bool
+    {
+    }
 
-	public function needsPartFile(): bool
- {
- }
+	#[\Override]
+    public function needsPartFile(): bool
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 
 	public function getObjectStore(): IObjectStore
- {
- }
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, ?ICacheEntry $sourceCacheEntry = null): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, ?ICacheEntry $sourceCacheEntry = null): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function startChunkedWrite(string $targetPath): string
- {
- }
+	#[\Override]
+    public function startChunkedWrite(string $targetPath): string
+    {
+    }
 
 	/**
 	 * @throws GenericFileException
 	 */
-	public function putChunkedWritePart(string $targetPath, string $writeToken, string $chunkId, $data, $size = null): ?array
- {
- }
+	#[\Override]
+    public function putChunkedWritePart(string $targetPath, string $writeToken, string $chunkId, $data, $size = null): ?array
+    {
+    }
 
-	public function completeChunkedWrite(string $targetPath, string $writeToken): int
- {
- }
+	#[\Override]
+    public function completeChunkedWrite(string $targetPath, string $writeToken): int
+    {
+    }
 
-	public function cancelChunkedWrite(string $targetPath, string $writeToken): void
- {
- }
+	#[\Override]
+    public function cancelChunkedWrite(string $targetPath, string $writeToken): void
+    {
+    }
 
 	public function setPreserveCacheOnDelete(bool $preserve)
- {
- }
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
-
-	#[Override]
- public function getDirectDownloadById(string $fileId): array|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
 	#[Override]
- public function getDirectDownload(string $path): array|false
- {
- }
+    public function getDirectDownloadById(string $fileId): array|false
+    {
+    }
+
+	#[Override]
+    public function getDirectDownload(string $path): array|false
+    {
+    }
 }

--- a/tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php
+++ b/tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php
@@ -27,60 +27,60 @@ class PrimaryObjectStoreConfig {
 	 * @param ObjectStoreConfig $config
 	 */
 	public function buildObjectStore(array $config): IObjectStore
- {
- }
+    {
+    }
 
 	/**
 	 * @return ?ObjectStoreConfig
 	 */
 	public function getObjectStoreConfigForRoot(): ?array
- {
- }
+    {
+    }
 
 	/**
 	 * @return ?ObjectStoreConfig
 	 */
 	public function getObjectStoreConfigForUser(IUser $user): ?array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 * @return ObjectStoreConfig
 	 */
 	public function getObjectStoreConfiguration(string $name): array
- {
- }
+    {
+    }
 
 	public function resolveAlias(string $name): string
- {
- }
+    {
+    }
 
 	public function hasObjectStore(): bool
- {
- }
+    {
+    }
 
 	public function hasMultipleObjectStorages(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return ?array<string, ObjectStoreConfig|string>
 	 * @throws InvalidObjectStoreConfigurationException
 	 */
 	public function getObjectStoreConfigs(): ?array
- {
- }
+    {
+    }
 
 	public function getBucketForUser(IUser $user, array $config): string
- {
- }
+    {
+    }
 
 	public function getSetBucketForUser(IUser $user): ?string
- {
- }
+    {
+    }
 
 	public function getObjectStoreForUser(IUser $user): string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_setupmanager.php
+++ b/tests/stubs/oc_files_setupmanager.php
@@ -42,6 +42,7 @@ use OCP\Files\Events\BeforeFileSystemSetupEvent;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\Events\Node\FilesystemTornDownEvent;
+use OCP\Files\Events\UserHomeSetupEvent;
 use OCP\Files\ISetupManager;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
@@ -71,43 +72,43 @@ class SetupManager implements ISetupManager {
 	private const SETUP_WITHOUT_CHILDREN = 0;
 
 	public function __construct(private IEventLogger $eventLogger, private MountProviderCollection $mountProviderCollection, private IMountManager $mountManager, private IUserManager $userManager, private IEventDispatcher $eventDispatcher, private IUserMountCache $userMountCache, private ILockdownManager $lockdownManager, private IUserSession $userSession, ICacheFactory $cacheFactory, private LoggerInterface $logger, private IConfig $config, private ShareDisableChecker $shareDisableChecker, private IAppManager $appManager, private FileAccess $fileAccess, private IAppConfig $appConfig)
- {
- }
+    {
+    }
 
 	#[Override]
- public function isSetupComplete(IUser $user): bool
- {
- }
+    public function isSetupComplete(IUser $user): bool
+    {
+    }
 
 	#[Override]
- public function setupForUser(IUser $user): void
- {
- }
+    public function setupForUser(IUser $user): void
+    {
+    }
 
 	/**
 	 * Set up the root filesystem
 	 */
 	public function setupRoot(): void
- {
- }
+    {
+    }
 
 	#[Override]
- public function setupForPath(string $path, bool $includeChildren = false): void
- {
- }
+    public function setupForPath(string $path, bool $includeChildren = false): void
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @param string[] $providers
 	 */
 	public function setupForProvider(string $path, array $providers): void
- {
- }
+    {
+    }
 
 	#[Override]
- public function tearDown(): void
- {
- }
+    public function tearDown(): void
+    {
+    }
 
 	/**
 	 * Drops partially set-up mounts for the given user
@@ -115,6 +116,6 @@ class SetupManager implements ISetupManager {
 	 * @param class-string<IMountProvider>[] $providers
 	 */
 	public function dropPartialMountsForUser(IUser $user, array $providers = []): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_common.php
+++ b/tests/stubs/oc_files_storage_common.php
@@ -74,80 +74,97 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	}
 
 	protected function remove(string $path): bool
- {
- }
+    {
+    }
 
-	public function is_dir(string $path): bool
- {
- }
+	#[\Override]
+    public function is_dir(string $path): bool
+    {
+    }
 
-	public function is_file(string $path): bool
- {
- }
+	#[\Override]
+    public function is_file(string $path): bool
+    {
+    }
 
-	public function filesize(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function filesize(string $path): int|float|false
+    {
+    }
 
-	public function isReadable(string $path): bool
- {
- }
+	#[\Override]
+    public function isReadable(string $path): bool
+    {
+    }
 
-	public function isUpdatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isUpdatable(string $path): bool
+    {
+    }
 
-	public function isCreatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isCreatable(string $path): bool
+    {
+    }
 
-	public function isDeletable(string $path): bool
- {
- }
+	#[\Override]
+    public function isDeletable(string $path): bool
+    {
+    }
 
-	public function isSharable(string $path): bool
- {
- }
+	#[\Override]
+    public function isSharable(string $path): bool
+    {
+    }
 
-	public function getPermissions(string $path): int
- {
- }
+	#[\Override]
+    public function getPermissions(string $path): int
+    {
+    }
 
-	public function filemtime(string $path): int|false
- {
- }
+	#[\Override]
+    public function filemtime(string $path): int|false
+    {
+    }
 
-	public function file_get_contents(string $path): string|false
- {
- }
+	#[\Override]
+    public function file_get_contents(string $path): string|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function getMimeType(string $path): string|false
- {
- }
+	#[\Override]
+    public function getMimeType(string $path): string|false
+    {
+    }
 
-	public function hash(string $type, string $path, bool $raw = false): string|false
- {
- }
+	#[\Override]
+    public function hash(string $type, string $path, bool $raw = false): string|false
+    {
+    }
 
-	public function getLocalFile(string $path): string|false
- {
- }
+	#[\Override]
+    public function getLocalFile(string $path): string|false
+    {
+    }
 
 	protected function searchInDir(string $query, string $dir = ''): array
- {
- }
+    {
+    }
 
 	/**
 	 * @inheritDoc
@@ -158,45 +175,54 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * exclusive access to the backend and will not pick up files that have been added in a way that circumvents
 	 * Nextcloud filesystem.
 	 */
-	public function hasUpdated(string $path, int $time): bool
- {
- }
+	#[\Override]
+    public function hasUpdated(string $path, int $time): bool
+    {
+    }
 
 	protected function getCacheDependencies(): CacheDependencies
- {
- }
+    {
+    }
 
-	public function getCache(string $path = '', ?IStorage $storage = null): ICache
- {
- }
+	#[\Override]
+    public function getCache(string $path = '', ?IStorage $storage = null): ICache
+    {
+    }
 
-	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
- {
- }
+	#[\Override]
+    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
+    {
+    }
 
-	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
- {
- }
+	#[\Override]
+    public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
+    {
+    }
 
-	public function getPropagator(?IStorage $storage = null): IPropagator
- {
- }
+	#[\Override]
+    public function getPropagator(?IStorage $storage = null): IPropagator
+    {
+    }
 
-	public function getUpdater(?IStorage $storage = null): IUpdater
- {
- }
+	#[\Override]
+    public function getUpdater(?IStorage $storage = null): IUpdater
+    {
+    }
 
-	public function getStorageCache(?IStorage $storage = null): \OC\Files\Cache\Storage
- {
- }
+	#[\Override]
+    public function getStorageCache(?IStorage $storage = null): \OC\Files\Cache\Storage
+    {
+    }
 
-	public function getOwner(string $path): string|false
- {
- }
+	#[\Override]
+    public function getOwner(string $path): string|false
+    {
+    }
 
-	public function getETag(string $path): string|false
- {
- }
+	#[\Override]
+    public function getETag(string $path): string|false
+    {
+    }
 
 	/**
 	 * clean a path, i.e. remove all redundant '.' and '..'
@@ -206,109 +232,126 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * @return string cleaned path
 	 */
 	public function cleanPath(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * Test a storage for availability
 	 */
-	public function test(): bool
- {
- }
+	#[\Override]
+    public function test(): bool
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
-	public function isLocal(): bool
- {
- }
+	#[\Override]
+    public function isLocal(): bool
+    {
+    }
 
 	/**
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
 	 */
-	public function instanceOfStorage(string $class): bool
- {
- }
+	#[\Override]
+    public function instanceOfStorage(string $class): bool
+    {
+    }
 
 	#[Override]
- public function getDirectDownload(string $path): array|false
- {
- }
+    public function getDirectDownload(string $path): array|false
+    {
+    }
 
 	#[Override]
- public function getDirectDownloadById(string $fileId): array|false
- {
- }
+    public function getDirectDownloadById(string $fileId): array|false
+    {
+    }
 
-	public function verifyPath(string $path, string $fileName): void
- {
- }
+	#[\Override]
+    public function verifyPath(string $path, string $fileName): void
+    {
+    }
 
 	/**
 	 * Get the filename validator
 	 * (cached for performance)
 	 */
 	protected function getFilenameValidator(): IFilenameValidator
- {
- }
+    {
+    }
 
 	public function setMountOptions(array $options): void
- {
- }
+    {
+    }
 
 	public function getMountOption(string $name, mixed $default = null): mixed
- {
- }
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function acquireLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function acquireLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function releaseLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function releaseLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function changeLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function changeLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
 	/**
 	 * @return array{available: bool, last_checked: int}
 	 */
-	public function getAvailability(): array
- {
- }
+	#[\Override]
+    public function getAvailability(): array
+    {
+    }
 
-	public function setAvailability(bool $isAvailable): void
- {
- }
+	#[\Override]
+    public function setAvailability(bool $isAvailable): void
+    {
+    }
 
-	public function setOwner(?string $user): void
- {
- }
+	#[\Override]
+    public function setOwner(?string $user): void
+    {
+    }
 
-	public function needsPartFile(): bool
- {
- }
+	#[\Override]
+    public function needsPartFile(): bool
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 
-	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+	#[\Override]
+    public function getDirectoryContent(string $directory): \Traversable
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_local.php
+++ b/tests/stubs/oc_files_storage_local.php
@@ -39,119 +39,145 @@ class Local extends Common {
 	protected bool $caseInsensitive = false;
 
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
 	public function __destruct() {
 	}
 
-	public function getId(): string
- {
- }
+	#[\Override]
+    public function getId(): string
+    {
+    }
 
-	public function mkdir(string $path): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function opendir(string $path)
- {
- }
+	#[\Override]
+    public function opendir(string $path)
+    {
+    }
 
-	public function is_dir(string $path): bool
- {
- }
+	#[\Override]
+    public function is_dir(string $path): bool
+    {
+    }
 
-	public function is_file(string $path): bool
- {
- }
+	#[\Override]
+    public function is_file(string $path): bool
+    {
+    }
 
-	public function stat(string $path): array|false
- {
- }
+	#[\Override]
+    public function stat(string $path): array|false
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function filetype(string $path): string|false
- {
- }
+	#[\Override]
+    public function filetype(string $path): string|false
+    {
+    }
 
-	public function filesize(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function filesize(string $path): int|float|false
+    {
+    }
 
-	public function isReadable(string $path): bool
- {
- }
+	#[\Override]
+    public function isReadable(string $path): bool
+    {
+    }
 
-	public function isUpdatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isUpdatable(string $path): bool
+    {
+    }
 
-	public function file_exists(string $path): bool
- {
- }
+	#[\Override]
+    public function file_exists(string $path): bool
+    {
+    }
 
-	public function filemtime(string $path): int|false
- {
- }
+	#[\Override]
+    public function filemtime(string $path): int|false
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
-	public function file_get_contents(string $path): string|false
- {
- }
+	#[\Override]
+    public function file_get_contents(string $path): string|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
-	public function hash(string $type, string $path, bool $raw = false): string|false
- {
- }
+	#[\Override]
+    public function hash(string $type, string $path, bool $raw = false): string|false
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
 	public function search(string $query): array
- {
- }
+    {
+    }
 
-	public function getLocalFile(string $path): string|false
- {
- }
+	#[\Override]
+    public function getLocalFile(string $path): string|false
+    {
+    }
 
-	protected function searchInDir(string $query, string $dir = ''): array
- {
- }
+	#[\Override]
+    protected function searchInDir(string $query, string $dir = ''): array
+    {
+    }
 
-	public function hasUpdated(string $path, int $time): bool
- {
- }
+	#[\Override]
+    public function hasUpdated(string $path, int $time): bool
+    {
+    }
 
 	/**
 	 * Get the source path (on disk) of a given path
@@ -159,26 +185,31 @@ class Local extends Common {
 	 * @throws ForbiddenException
 	 */
 	public function getSourcePath(string $path): string
- {
- }
+    {
+    }
 
-	public function isLocal(): bool
- {
- }
+	#[\Override]
+    public function isLocal(): bool
+    {
+    }
 
-	public function getETag(string $path): string|false
- {
- }
+	#[\Override]
+    public function getETag(string $path): string|false
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_storage.php
+++ b/tests/stubs/oc_files_storage_storage.php
@@ -23,36 +23,41 @@ use OCP\Files\Storage\IStorage;
  * All paths passed to the storage are relative to the storage and should NOT have a leading slash.
  */
 interface Storage extends IStorage, ILockingStorage {
-	public function getCache(string $path = '', ?IStorage $storage = null): ICache
- {
- }
+	#[\Override]
+    public function getCache(string $path = '', ?IStorage $storage = null): ICache
+    {
+    }
 
-	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
- {
- }
+	#[\Override]
+    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
+    {
+    }
 
-	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
- {
- }
+	#[\Override]
+    public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
+    {
+    }
 
-	public function getPropagator(?IStorage $storage = null): IPropagator
- {
- }
+	#[\Override]
+    public function getPropagator(?IStorage $storage = null): IPropagator
+    {
+    }
 
-	public function getUpdater(?IStorage $storage = null): IUpdater
- {
- }
+	#[\Override]
+    public function getUpdater(?IStorage $storage = null): IUpdater
+    {
+    }
 
 	public function getStorageCache(): \OC\Files\Cache\Storage
- {
- }
+    {
+    }
 
 	/**
 	 * @return ?array<string, mixed>
 	 */
 	public function getMetaData(string $path): ?array
- {
- }
+    {
+    }
 
 	/**
 	 * Get the contents of a directory with metadata
@@ -70,6 +75,6 @@ interface Storage extends IStorage, ILockingStorage {
 	 * @return \Traversable<array<string, mixed>>
 	 */
 	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_temporary.php
+++ b/tests/stubs/oc_files_storage_temporary.php
@@ -16,18 +16,19 @@ use OCP\Server;
  */
 class Temporary extends Local {
 	public function __construct(array $parameters = [])
- {
- }
+    {
+    }
 
 	public function cleanUp(): void
- {
- }
+    {
+    }
 
-	public function __destruct()
- {
- }
+	#[\Override]
+    public function __destruct()
+    {
+    }
 
 	public function getDataDir(): array|string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_wrapper_encryption.php
+++ b/tests/stubs/oc_files_storage_wrapper_encryption.php
@@ -37,52 +37,63 @@ class Encryption extends Wrapper {
 	 * @param array{storage: Storage\IStorage, ...} $parameters
 	 */
 	public function __construct(array $parameters, private IManager $encryptionManager, private Util $util, private LoggerInterface $logger, private IFile $fileHelper, private ?string $uid, private IStorage $keyStorage, private Manager $mountManager, private ArrayCache $arrayCache)
- {
- }
+    {
+    }
 
-	public function filesize(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function filesize(string $path): int|float|false
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+	#[\Override]
+    public function getDirectoryContent(string $directory): \Traversable
+    {
+    }
 
-	public function file_get_contents(string $path): string|false
- {
- }
+	#[\Override]
+    public function file_get_contents(string $path): string|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function isReadable(string $path): bool
- {
- }
+	#[\Override]
+    public function isReadable(string $path): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
 
 	/**
@@ -95,8 +106,8 @@ class Encryption extends Wrapper {
 	 * @return int unencrypted size
 	 */
 	protected function verifyUnencryptedSize(string $path, int $unencryptedSize): int
- {
- }
+    {
+    }
 
 	/**
 	 * calculate the unencrypted size
@@ -106,32 +117,38 @@ class Encryption extends Wrapper {
 	 * @param int $unencryptedSize size of the unencrypted file
 	 */
 	protected function fixUnencryptedSize(string $path, int $size, int $unencryptedSize): int|float
- {
- }
+    {
+    }
 
-	public function moveFromStorage(Storage\IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, $preserveMtime = true): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(Storage\IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, $preserveMtime = true): bool
+    {
+    }
 
-	public function copyFromStorage(Storage\IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, $preserveMtime = false, $isRename = false): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(Storage\IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, $preserveMtime = false, $isRename = false): bool
+    {
+    }
 
-	public function getLocalFile(string $path): string|false
- {
- }
+	#[\Override]
+    public function getLocalFile(string $path): string|false
+    {
+    }
 
-	public function isLocal(): bool
- {
- }
+	#[\Override]
+    public function isLocal(): bool
+    {
+    }
 
-	public function stat(string $path): array|false
- {
- }
+	#[\Override]
+    public function stat(string $path): array|false
+    {
+    }
 
-	public function hash(string $type, string $path, bool $raw = false): string|false
- {
- }
+	#[\Override]
+    public function hash(string $type, string $path, bool $raw = false): string|false
+    {
+    }
 
 	/**
 	 * return full path, including mount point
@@ -140,30 +157,30 @@ class Encryption extends Wrapper {
 	 * @return string full path including mount point
 	 */
 	protected function getFullPath(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * read first block of encrypted file, typically this will contain the
 	 * encryption header
 	 */
 	protected function readFirstBlock(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * return header size of given file
 	 */
 	protected function getHeaderSize(string $path): int
- {
- }
+    {
+    }
 
 	/**
 	 * read header from file
 	 */
 	protected function getHeader(string $path): array
- {
- }
+    {
+    }
 
 	/**
 	 * read encryption module needed to read/write the file located at $path
@@ -172,12 +189,12 @@ class Encryption extends Wrapper {
 	 * @throws \Exception
 	 */
 	protected function getEncryptionModule(string $path): ?IEncryptionModule
- {
- }
+    {
+    }
 
 	public function updateUnencryptedSize(string $path, int|float $unencryptedSize): void
- {
- }
+    {
+    }
 
 	/**
 	 * copy keys to new location
@@ -186,37 +203,38 @@ class Encryption extends Wrapper {
 	 * @param string $target path relative to data/
 	 */
 	protected function copyKeys(string $source, string $target): bool
- {
- }
+    {
+    }
 
 	/**
 	 * check if path points to a files version
 	 */
 	protected function isVersion(string $path): bool
- {
- }
+    {
+    }
 
 	/**
 	 * check if the given storage should be encrypted or not
 	 */
 	public function shouldEncrypt(string $path): bool
- {
- }
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 
 	public function clearIsEncryptedCache(): void
- {
- }
+    {
+    }
 
 	/**
 	 * Allow temporarily disabling the wrapper
 	 */
 	public function setEnabled(bool $enabled): void
- {
- }
+    {
+    }
 
 	/**
 	 * Check if the on-disk data for a file has a valid encrypted header
@@ -225,6 +243,6 @@ class Encryption extends Wrapper {
 	 * @return bool
 	 */
 	public function hasValidHeader(string $path): bool
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_wrapper_jail.php
+++ b/tests/stubs/oc_files_storage_wrapper_jail.php
@@ -41,172 +41,209 @@ class Jail extends Wrapper {
 	 * $root: The folder in the wrapped storage that will become the root folder of the wrapped storage
 	 */
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
 	public function getUnjailedPath(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * This is separate from Wrapper::getWrapperStorage so we can get the jailed storage consistently even if the jail is inside another wrapper
 	 */
 	public function getUnjailedStorage(): IStorage
- {
- }
+    {
+    }
 
 
 	public function getJailedPath(string $path): ?string
- {
- }
+    {
+    }
 
-	public function getId(): string
- {
- }
+	#[\Override]
+    public function getId(): string
+    {
+    }
 
-	public function mkdir(string $path): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function opendir(string $path)
- {
- }
+	#[\Override]
+    public function opendir(string $path)
+    {
+    }
 
-	public function is_dir(string $path): bool
- {
- }
+	#[\Override]
+    public function is_dir(string $path): bool
+    {
+    }
 
-	public function is_file(string $path): bool
- {
- }
+	#[\Override]
+    public function is_file(string $path): bool
+    {
+    }
 
-	public function stat(string $path): array|false
- {
- }
+	#[\Override]
+    public function stat(string $path): array|false
+    {
+    }
 
-	public function filetype(string $path): string|false
- {
- }
+	#[\Override]
+    public function filetype(string $path): string|false
+    {
+    }
 
-	public function filesize(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function filesize(string $path): int|float|false
+    {
+    }
 
-	public function isCreatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isCreatable(string $path): bool
+    {
+    }
 
-	public function isReadable(string $path): bool
- {
- }
+	#[\Override]
+    public function isReadable(string $path): bool
+    {
+    }
 
-	public function isUpdatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isUpdatable(string $path): bool
+    {
+    }
 
-	public function isDeletable(string $path): bool
- {
- }
+	#[\Override]
+    public function isDeletable(string $path): bool
+    {
+    }
 
-	public function isSharable(string $path): bool
- {
- }
+	#[\Override]
+    public function isSharable(string $path): bool
+    {
+    }
 
-	public function getPermissions(string $path): int
- {
- }
+	#[\Override]
+    public function getPermissions(string $path): int
+    {
+    }
 
-	public function file_exists(string $path): bool
- {
- }
+	#[\Override]
+    public function file_exists(string $path): bool
+    {
+    }
 
-	public function filemtime(string $path): int|false
- {
- }
+	#[\Override]
+    public function filemtime(string $path): int|false
+    {
+    }
 
-	public function file_get_contents(string $path): string|false
- {
- }
+	#[\Override]
+    public function file_get_contents(string $path): string|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
-	public function getMimeType(string $path): string|false
- {
- }
+	#[\Override]
+    public function getMimeType(string $path): string|false
+    {
+    }
 
-	public function hash(string $type, string $path, bool $raw = false): string|false
- {
- }
+	#[\Override]
+    public function hash(string $type, string $path, bool $raw = false): string|false
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
-	public function getLocalFile(string $path): string|false
- {
- }
+	#[\Override]
+    public function getLocalFile(string $path): string|false
+    {
+    }
 
-	public function hasUpdated(string $path, int $time): bool
- {
- }
+	#[\Override]
+    public function hasUpdated(string $path, int $time): bool
+    {
+    }
 
-	public function getCache(string $path = '', ?IStorage $storage = null): ICache
- {
- }
+	#[\Override]
+    public function getCache(string $path = '', ?IStorage $storage = null): ICache
+    {
+    }
 
-	public function getOwner(string $path): string|false
- {
- }
+	#[\Override]
+    public function getOwner(string $path): string|false
+    {
+    }
 
-	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
- {
- }
+	#[\Override]
+    public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
+    {
+    }
 
-	public function getETag(string $path): string|false
- {
- }
+	#[\Override]
+    public function getETag(string $path): string|false
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function acquireLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function acquireLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function releaseLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function releaseLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function changeLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function changeLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
 	/**
 	 * Resolve the path for the source of the share.
@@ -214,26 +251,31 @@ class Jail extends Wrapper {
 	 * @return array{0: IStorage, 1: string}
 	 */
 	public function resolvePath(string $path): array
- {
- }
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function getPropagator(?IStorage $storage = null): IPropagator
- {
- }
+	#[\Override]
+    public function getPropagator(?IStorage $storage = null): IPropagator
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 
-	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+	#[\Override]
+    public function getDirectoryContent(string $directory): \Traversable
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_wrapper_permissionsmask.php
+++ b/tests/stubs/oc_files_storage_wrapper_permissionsmask.php
@@ -34,74 +34,91 @@ class PermissionsMask extends Wrapper {
 	 * $mask: The permission bits that should be kept, a combination of the \OCP\Constant::PERMISSION_ constants
 	 */
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
-	public function isUpdatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isUpdatable(string $path): bool
+    {
+    }
 
-	public function isCreatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isCreatable(string $path): bool
+    {
+    }
 
-	public function isDeletable(string $path): bool
- {
- }
+	#[\Override]
+    public function isDeletable(string $path): bool
+    {
+    }
 
-	public function isSharable(string $path): bool
- {
- }
+	#[\Override]
+    public function isSharable(string $path): bool
+    {
+    }
 
-	public function getPermissions(string $path): int
- {
- }
+	#[\Override]
+    public function getPermissions(string $path): int
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
-	public function mkdir(string $path): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
-	public function getCache(string $path = '', ?IStorage $storage = null): ICache
- {
- }
+	#[\Override]
+    public function getCache(string $path = '', ?IStorage $storage = null): ICache
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
- {
- }
+	#[\Override]
+    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
+    {
+    }
 
-	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+	#[\Override]
+    public function getDirectoryContent(string $directory): \Traversable
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_wrapper_quota.php
+++ b/tests/stubs/oc_files_storage_wrapper_quota.php
@@ -24,57 +24,65 @@ class Quota extends Wrapper {
 	 * @param array $parameters
 	 */
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
 	public function getQuota(): int|float
- {
- }
+    {
+    }
 
 	protected function getSize(string $path, ?IStorage $storage = null): int|float
- {
- }
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
 	/**
 	 * Only apply quota for files, not metadata, trash or others
 	 */
 	protected function shouldApplyQuota(string $path): bool
- {
- }
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function mkdir(string $path): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path): bool
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
 	public function enableQuota(bool $enabled): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_files_storage_wrapper_wrapper.php
+++ b/tests/stubs/oc_files_storage_wrapper_wrapper.php
@@ -42,172 +42,212 @@ class Wrapper implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @param array{storage: IStorage, ...} $parameters
 	 */
 	public function __construct(array $parameters)
- {
- }
+    {
+    }
 
 	public function getWrapperStorage(): Storage
- {
- }
+    {
+    }
 
-	public function getId(): string
- {
- }
+	#[\Override]
+    public function getId(): string
+    {
+    }
 
-	public function mkdir(string $path): bool
- {
- }
+	#[\Override]
+    public function mkdir(string $path): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
-	public function opendir(string $path)
- {
- }
+	#[\Override]
+    public function opendir(string $path)
+    {
+    }
 
-	public function is_dir(string $path): bool
- {
- }
+	#[\Override]
+    public function is_dir(string $path): bool
+    {
+    }
 
-	public function is_file(string $path): bool
- {
- }
+	#[\Override]
+    public function is_file(string $path): bool
+    {
+    }
 
-	public function stat(string $path): array|false
- {
- }
+	#[\Override]
+    public function stat(string $path): array|false
+    {
+    }
 
-	public function filetype(string $path): string|false
- {
- }
+	#[\Override]
+    public function filetype(string $path): string|false
+    {
+    }
 
-	public function filesize(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function filesize(string $path): int|float|false
+    {
+    }
 
-	public function isCreatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isCreatable(string $path): bool
+    {
+    }
 
-	public function isReadable(string $path): bool
- {
- }
+	#[\Override]
+    public function isReadable(string $path): bool
+    {
+    }
 
-	public function isUpdatable(string $path): bool
- {
- }
+	#[\Override]
+    public function isUpdatable(string $path): bool
+    {
+    }
 
-	public function isDeletable(string $path): bool
- {
- }
+	#[\Override]
+    public function isDeletable(string $path): bool
+    {
+    }
 
-	public function isSharable(string $path): bool
- {
- }
+	#[\Override]
+    public function isSharable(string $path): bool
+    {
+    }
 
-	public function getPermissions(string $path): int
- {
- }
+	#[\Override]
+    public function getPermissions(string $path): int
+    {
+    }
 
-	public function file_exists(string $path): bool
- {
- }
+	#[\Override]
+    public function file_exists(string $path): bool
+    {
+    }
 
-	public function filemtime(string $path): int|false
- {
- }
+	#[\Override]
+    public function filemtime(string $path): int|false
+    {
+    }
 
-	public function file_get_contents(string $path): string|false
- {
- }
+	#[\Override]
+    public function file_get_contents(string $path): string|false
+    {
+    }
 
-	public function file_put_contents(string $path, mixed $data): int|float|false
- {
- }
+	#[\Override]
+    public function file_put_contents(string $path, mixed $data): int|float|false
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function rename(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function rename(string $source, string $target): bool
+    {
+    }
 
-	public function copy(string $source, string $target): bool
- {
- }
+	#[\Override]
+    public function copy(string $source, string $target): bool
+    {
+    }
 
-	public function fopen(string $path, string $mode)
- {
- }
+	#[\Override]
+    public function fopen(string $path, string $mode)
+    {
+    }
 
-	public function getMimeType(string $path): string|false
- {
- }
+	#[\Override]
+    public function getMimeType(string $path): string|false
+    {
+    }
 
-	public function hash(string $type, string $path, bool $raw = false): string|false
- {
- }
+	#[\Override]
+    public function hash(string $type, string $path, bool $raw = false): string|false
+    {
+    }
 
-	public function free_space(string $path): int|float|false
- {
- }
+	#[\Override]
+    public function free_space(string $path): int|float|false
+    {
+    }
 
-	public function touch(string $path, ?int $mtime = null): bool
- {
- }
+	#[\Override]
+    public function touch(string $path, ?int $mtime = null): bool
+    {
+    }
 
-	public function getLocalFile(string $path): string|false
- {
- }
+	#[\Override]
+    public function getLocalFile(string $path): string|false
+    {
+    }
 
-	public function hasUpdated(string $path, int $time): bool
- {
- }
+	#[\Override]
+    public function hasUpdated(string $path, int $time): bool
+    {
+    }
 
-	public function getCache(string $path = '', ?IStorage $storage = null): ICache
- {
- }
+	#[\Override]
+    public function getCache(string $path = '', ?IStorage $storage = null): ICache
+    {
+    }
 
-	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
- {
- }
+	#[\Override]
+    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
+    {
+    }
 
-	public function getOwner(string $path): string|false
- {
- }
+	#[\Override]
+    public function getOwner(string $path): string|false
+    {
+    }
 
-	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
- {
- }
+	#[\Override]
+    public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
+    {
+    }
 
-	public function getPropagator(?IStorage $storage = null): IPropagator
- {
- }
+	#[\Override]
+    public function getPropagator(?IStorage $storage = null): IPropagator
+    {
+    }
 
-	public function getUpdater(?IStorage $storage = null): IUpdater
- {
- }
+	#[\Override]
+    public function getUpdater(?IStorage $storage = null): IUpdater
+    {
+    }
 
-	public function getStorageCache(): \OC\Files\Cache\Storage
- {
- }
+	#[\Override]
+    public function getStorageCache(): \OC\Files\Cache\Storage
+    {
+    }
 
-	public function getETag(string $path): string|false
- {
- }
+	#[\Override]
+    public function getETag(string $path): string|false
+    {
+    }
 
-	public function test(): bool
- {
- }
+	#[\Override]
+    public function test(): bool
+    {
+    }
 
-	public function isLocal(): bool
- {
- }
+	#[\Override]
+    public function isLocal(): bool
+    {
+    }
 
-	public function instanceOfStorage(string $class): bool
- {
- }
+	#[\Override]
+    public function instanceOfStorage(string $class): bool
+    {
+    }
 
 	/**
 	 * @psalm-template T of IStorage
@@ -215,8 +255,8 @@ class Wrapper implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @psalm-return T|null
 	 */
 	public function getInstanceOfStorage(string $class): ?IStorage
- {
- }
+    {
+    }
 
 	/**
 	 * Pass any methods custom to specific storage implementations to the wrapped storage
@@ -224,72 +264,85 @@ class Wrapper implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @return mixed
 	 */
 	public function __call(string $method, array $args)
- {
- }
+    {
+    }
 
 	#[Override]
- public function getDirectDownload(string $path): array|false
- {
- }
+    public function getDirectDownload(string $path): array|false
+    {
+    }
 
 	#[Override]
- public function getDirectDownloadById(string $fileId): array|false
- {
- }
+    public function getDirectDownloadById(string $fileId): array|false
+    {
+    }
 
-	public function getAvailability(): array
- {
- }
+	#[\Override]
+    public function getAvailability(): array
+    {
+    }
 
-	public function setAvailability(bool $isAvailable): void
- {
- }
+	#[\Override]
+    public function setAvailability(bool $isAvailable): void
+    {
+    }
 
-	public function verifyPath(string $path, string $fileName): void
- {
- }
+	#[\Override]
+    public function verifyPath(string $path, string $fileName): void
+    {
+    }
 
-	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
-	public function getMetaData(string $path): ?array
- {
- }
+	#[\Override]
+    public function getMetaData(string $path): ?array
+    {
+    }
 
-	public function acquireLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function acquireLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function releaseLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function releaseLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function changeLock(string $path, int $type, ILockingProvider $provider): void
- {
- }
+	#[\Override]
+    public function changeLock(string $path, int $type, ILockingProvider $provider): void
+    {
+    }
 
-	public function needsPartFile(): bool
- {
- }
+	#[\Override]
+    public function needsPartFile(): bool
+    {
+    }
 
-	public function writeStream(string $path, $stream, ?int $size = null): int
- {
- }
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
 
-	public function getDirectoryContent(string $directory): \Traversable
- {
- }
+	#[\Override]
+    public function getDirectoryContent(string $directory): \Traversable
+    {
+    }
 
 	public function isWrapperOf(IStorage $storage): bool
- {
- }
+    {
+    }
 
-	public function setOwner(?string $user): void
- {
- }
+	#[\Override]
+    public function setOwner(?string $user): void
+    {
+    }
 }

--- a/tests/stubs/oc_files_view.php
+++ b/tests/stubs/oc_files_view.php
@@ -11,7 +11,6 @@ use Icewind\Streams\CallbackWrapper;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\Scanner;
 use OC\Files\Mount\MountPoint;
-use OC\Files\Mount\MoveableMount;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Wrapper\Quota;
 use OC\Files\Utils\PathHelper;
@@ -35,6 +34,7 @@ use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Mount\IMovableMount;
 use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\IStorage;
@@ -77,8 +77,8 @@ class View {
 	 * @throws \Exception If $root contains an invalid path
 	 */
 	public function __construct(string $root = '')
- {
- }
+    {
+    }
 
 	/**
 	 * Returns an absolute path in Nextcloud's virtual filesystem for this view.
@@ -90,8 +90,8 @@ class View {
 	 * @psalm-return (S is string ? string : null)
 	 */
 	public function getAbsolutePath(?string $path = '/'): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * Change the root to a fake root
@@ -99,15 +99,15 @@ class View {
 	 * @param string $fakeRoot
 	 */
 	public function chroot($fakeRoot): void
- {
- }
+    {
+    }
 
 	/**
 	 * Get the fake root
 	 */
 	public function getRoot(): string
- {
- }
+    {
+    }
 
 	/**
 	 * get path relative to the root of the view
@@ -115,8 +115,8 @@ class View {
 	 * @param string $path
 	 */
 	public function getRelativePath($path): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * Get the mountpoint of the storage object for a path
@@ -127,8 +127,8 @@ class View {
 	 * @param string $path
 	 */
 	public function getMountPoint($path): string
- {
- }
+    {
+    }
 
 	/**
 	 * Get the mountpoint of the storage object for a path
@@ -139,8 +139,8 @@ class View {
 	 * @param string $path
 	 */
 	public function getMount($path): IMountPoint
- {
- }
+    {
+    }
 
 	/**
 	 * Resolve a path to a storage and internal path.
@@ -153,8 +153,8 @@ class View {
 	 * @return array{?IStorage, string} An array containing [storage, internalPath]
 	 */
 	public function resolvePath(string $path): array
- {
- }
+    {
+    }
 
 	/**
 	 * Return the path to a local representation of a file.
@@ -166,8 +166,8 @@ class View {
 	 * @return string|false Local file path, or false if unavailable
 	 */
 	public function getLocalFile(string $path): string|false
- {
- }
+    {
+    }
 
 	/**
 	 * the following functions operate with arguments and return values identical
@@ -175,8 +175,8 @@ class View {
 	 * for \OC\Files\Storage\Storage via basicOperation().
 	 */
 	public function mkdir($path)
- {
- }
+    {
+    }
 
 	/**
 	 * remove mount point
@@ -185,88 +185,88 @@ class View {
 	 * @param string $path relative to data/
 	 */
 	protected function removeMount($mount, $path): bool
- {
- }
+    {
+    }
 
 	public function disableCacheUpdate(): void
- {
- }
+    {
+    }
 
 	public function enableCacheUpdate(): void
- {
- }
+    {
+    }
 
 	protected function writeUpdate(Storage $storage, string $internalPath, ?int $time = null, ?int $sizeDifference = null): void
- {
- }
+    {
+    }
 
 	protected function removeUpdate(Storage $storage, string $internalPath): void
- {
- }
+    {
+    }
 
 	protected function renameUpdate(Storage $sourceStorage, Storage $targetStorage, string $sourceInternalPath, string $targetInternalPath): void
- {
- }
+    {
+    }
 
 	protected function copyUpdate(Storage $sourceStorage, Storage $targetStorage, string $sourceInternalPath, string $targetInternalPath): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function rmdir($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return resource|false
 	 */
 	public function opendir($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function is_dir($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function is_file($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function stat($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function filetype($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function filesize(string $path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -274,8 +274,8 @@ class View {
 	 * @throws InvalidPathException
 	 */
 	public function readfile($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -286,72 +286,72 @@ class View {
 	 * @throws UnseekableException
 	 */
 	public function readfilePart($path, $from, $to)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function isCreatable($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function isReadable($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function isUpdatable($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function isDeletable($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function isSharable($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function file_exists($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return mixed
 	 */
 	public function filemtime($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @param int|string $mtime
 	 */
 	public function touch($path, $mtime = null): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -359,16 +359,16 @@ class View {
 	 * @throws LockedException
 	 */
 	public function file_get_contents($path)
- {
- }
+    {
+    }
 
 	protected function emit_file_hooks_pre(bool $exists, string $path, bool &$run): void
- {
- }
+    {
+    }
 
 	protected function emit_file_hooks_post(bool $exists, string $path): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -377,24 +377,24 @@ class View {
 	 * @throws LockedException
 	 */
 	public function file_put_contents($path, $data)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @return bool|mixed
 	 */
 	public function unlink($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $directory
 	 * @return bool|mixed
 	 */
 	public function deleteAll($directory)
- {
- }
+    {
+    }
 
 	/**
 	 * Rename/move a file or folder from the source path to target path.
@@ -407,8 +407,8 @@ class View {
 	 * @throws LockedException
 	 */
 	public function rename($source, $target, array $options = [])
- {
- }
+    {
+    }
 
 	/**
 	 * Copy a file/folder from the source path to target path
@@ -420,8 +420,8 @@ class View {
 	 * @return bool|mixed
 	 */
 	public function copy($source, $target, $preserveMtime = false)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -430,16 +430,16 @@ class View {
 	 * @throws LockedException
 	 */
 	public function fopen($path, $mode)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @throws InvalidPathException
 	 */
 	public function toTmpFile($path): string|false
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $tmpFile
@@ -448,8 +448,8 @@ class View {
 	 * @throws InvalidPathException
 	 */
 	public function fromTmpFile($tmpFile, $path)
- {
- }
+    {
+    }
 
 
 	/**
@@ -458,8 +458,8 @@ class View {
 	 * @throws InvalidPathException
 	 */
 	public function getMimeType($path)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $type
@@ -467,8 +467,8 @@ class View {
 	 * @param bool $raw
 	 */
 	public function hash($type, $path, $raw = false): string|bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -476,8 +476,8 @@ class View {
 	 * @throws InvalidPathException
 	 */
 	public function free_space($path = '/')
- {
- }
+    {
+    }
 
 	/**
 	 * check if a file or folder has been updated since $time
@@ -487,8 +487,8 @@ class View {
 	 * @return bool
 	 */
 	public function hasUpdated($path, $time)
- {
- }
+    {
+    }
 
 	/**
 	 * get the filesystem info
@@ -499,15 +499,15 @@ class View {
 	 * @return FileInfo|false False if file does not exist
 	 */
 	public function getFileInfo($path, $includeMountPoints = true)
- {
- }
+    {
+    }
 
 	/**
 	 * Extend a FileInfo that was previously requested with `$includeMountPoints = false` to include the sub mounts
 	 */
 	public function addSubMounts(FileInfo $info, $extOnly = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * get the content of a directory
@@ -517,8 +517,8 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function getDirectoryContent(string $directory, ?string $mimeTypeFilter = null, ?\OCP\Files\FileInfo $directoryInfo = null)
- {
- }
+    {
+    }
 
 	/**
 	 * change file metadata
@@ -530,8 +530,8 @@ class View {
 	 * returns the fileid of the updated file
 	 */
 	public function putFileInfo($path, $data)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files with the name matching $query
@@ -540,8 +540,8 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function search($query)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files with the name matching $query
@@ -550,8 +550,8 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function searchRaw($query)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files by mimetype
@@ -560,8 +560,8 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function searchByMime($mimetype)
- {
- }
+    {
+    }
 
 	/**
 	 * search for files by tag
@@ -571,8 +571,8 @@ class View {
 	 * @return FileInfo[]
 	 */
 	public function searchByTag($tag, $userId)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the owner for a file or folder
@@ -580,8 +580,8 @@ class View {
 	 * @throws NotFoundException
 	 */
 	public function getOwner(string $path): string
- {
- }
+    {
+    }
 
 	/**
 	 * get the ETag for a file or folder
@@ -590,8 +590,8 @@ class View {
 	 * @return string|false
 	 */
 	public function getETag($path)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the path of a file by id, relative to the view
@@ -604,8 +604,8 @@ class View {
 	 * @throws NotFoundException
 	 */
 	public function getPath($id, ?int $storageId = null): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $path
@@ -614,8 +614,8 @@ class View {
 	 * @throws InvalidPathException
 	 */
 	public function verifyPath($path, $fileName, $readonly = false): void
- {
- }
+    {
+    }
 
 	/**
 	 * Change the lock type
@@ -628,8 +628,8 @@ class View {
 	 * @throws LockedException if the path is already locked
 	 */
 	public function changeLock($path, $type, $lockMountPoint = false)
- {
- }
+    {
+    }
 
 	/**
 	 * Lock a path and all its parents up to the root of the view
@@ -642,8 +642,8 @@ class View {
 	 * @throws LockedException
 	 */
 	public function lockFile($path, $type, $lockMountPoint = false)
- {
- }
+    {
+    }
 
 	/**
 	 * Unlock a path and all its parents up to the root of the view
@@ -656,8 +656,8 @@ class View {
 	 * @throws LockedException
 	 */
 	public function unlockFile($path, $type, $lockMountPoint = false)
- {
- }
+    {
+    }
 
 	/**
 	 * Only lock files in data/user/files/
@@ -666,8 +666,8 @@ class View {
 	 * @return bool
 	 */
 	protected function shouldLockFile($path)
- {
- }
+    {
+    }
 
 	/**
 	 * Shortens the given absolute path to be relative to
@@ -682,8 +682,8 @@ class View {
 	 * @since 8.1.0
 	 */
 	public function getPathRelativeToFiles($absolutePath)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $filename
@@ -692,6 +692,6 @@ class View {
 	 * @throws NotFoundException
 	 */
 	public function getUidAndFilename($filename)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_group_database.php
+++ b/tests/stubs/oc_group_database.php
@@ -53,9 +53,10 @@ class Database extends ABackend implements
 	) {
 	}
 
-	public function createGroup(string $name): ?string
- {
- }
+	#[\Override]
+    public function createGroup(string $name): ?string
+    {
+    }
 
 	/**
 	 * delete a group
@@ -64,9 +65,10 @@ class Database extends ABackend implements
 	 *
 	 * Deletes a group and removes it from the group_user-table
 	 */
-	public function deleteGroup(string $gid): bool
- {
- }
+	#[\Override]
+    public function deleteGroup(string $gid): bool
+    {
+    }
 
 	/**
 	 * is user in group?
@@ -76,9 +78,10 @@ class Database extends ABackend implements
 	 *
 	 * Checks whether the user is member of a group or not.
 	 */
-	public function inGroup($uid, $gid)
- {
- }
+	#[\Override]
+    public function inGroup($uid, $gid)
+    {
+    }
 
 	/**
 	 * Add a user to a group
@@ -88,9 +91,10 @@ class Database extends ABackend implements
 	 *
 	 * Adds a user to a group.
 	 */
-	public function addToGroup(string $uid, string $gid): bool
- {
- }
+	#[\Override]
+    public function addToGroup(string $uid, string $gid): bool
+    {
+    }
 
 	/**
 	 * Removes a user from a group
@@ -100,9 +104,10 @@ class Database extends ABackend implements
 	 *
 	 * removes the user from a group.
 	 */
-	public function removeFromGroup(string $uid, string $gid): bool
- {
- }
+	#[\Override]
+    public function removeFromGroup(string $uid, string $gid): bool
+    {
+    }
 
 	/**
 	 * Get all groups a user belongs to
@@ -112,9 +117,10 @@ class Database extends ABackend implements
 	 * This function fetches all groups a user belongs to. It does not check
 	 * if the user exists at all.
 	 */
-	public function getUserGroups($uid)
- {
- }
+	#[\Override]
+    public function getUserGroups($uid)
+    {
+    }
 
 	/**
 	 * get a list of all groups
@@ -125,25 +131,28 @@ class Database extends ABackend implements
 	 *
 	 * Returns a list with all groups
 	 */
-	public function getGroups(string $search = '', int $limit = -1, int $offset = 0)
- {
- }
+	#[\Override]
+    public function getGroups(string $search = '', int $limit = -1, int $offset = 0)
+    {
+    }
 
 	/**
 	 * check if a group exists
 	 * @param string $gid
 	 * @return bool
 	 */
-	public function groupExists($gid)
- {
- }
+	#[\Override]
+    public function groupExists($gid)
+    {
+    }
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function groupsExists(array $gids): array
- {
- }
+	#[\Override]
+    public function groupsExists(array $gids): array
+    {
+    }
 
 	/**
 	 * Get a list of all users in a group
@@ -153,13 +162,15 @@ class Database extends ABackend implements
 	 * @param int $offset
 	 * @return array<int,string> an array of user ids
 	 */
-	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0): array
- {
- }
+	#[\Override]
+    public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0): array
+    {
+    }
 
-	public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array
- {
- }
+	#[\Override]
+    public function searchInGroup(string $gid, string $search = '', int $limit = -1, int $offset = 0): array
+    {
+    }
 
 	/**
 	 * get the number of all users matching the search string in a group
@@ -167,9 +178,10 @@ class Database extends ABackend implements
 	 * @param string $search
 	 * @return int
 	 */
-	public function countUsersInGroup(string $gid, string $search = ''): int
- {
- }
+	#[\Override]
+    public function countUsersInGroup(string $gid, string $search = ''): int
+    {
+    }
 
 	/**
 	 * get the number of disabled users in a group
@@ -178,35 +190,41 @@ class Database extends ABackend implements
 	 *
 	 * @return int
 	 */
-	public function countDisabledInGroup(string $gid): int
- {
- }
+	#[\Override]
+    public function countDisabledInGroup(string $gid): int
+    {
+    }
 
-	public function getDisplayName(string $gid): string
- {
- }
+	#[\Override]
+    public function getDisplayName(string $gid): string
+    {
+    }
 
-	public function getGroupDetails(string $gid): array
- {
- }
+	#[\Override]
+    public function getGroupDetails(string $gid): array
+    {
+    }
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getGroupsDetails(array $gids): array
- {
- }
+	#[\Override]
+    public function getGroupsDetails(array $gids): array
+    {
+    }
 
-	public function setDisplayName(string $gid, string $displayName): bool
- {
- }
+	#[\Override]
+    public function setDisplayName(string $gid, string $displayName): bool
+    {
+    }
 
 	/**
 	 * Backend name to be shown in group management
 	 * @return string the name of the backend to be shown
 	 * @since 21.0.0
 	 */
-	public function getBackendName(): string
- {
- }
+	#[\Override]
+    public function getBackendName(): string
+    {
+    }
 }

--- a/tests/stubs/oc_group_manager.php
+++ b/tests/stubs/oc_group_manager.php
@@ -47,8 +47,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 	private const MAX_GROUP_LENGTH = 255;
 
 	public function __construct(private \OC\User\Manager $userManager, private IEventDispatcher $dispatcher, private LoggerInterface $logger, ICacheFactory $cacheFactory, private IRemoteAddress $remoteAddress)
- {
- }
+    {
+    }
 
 	/**
 	 * Checks whether a given backend is used
@@ -56,42 +56,47 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param string $backendClass Full classname including complete namespace
 	 * @return bool
 	 */
-	public function isBackendUsed($backendClass)
- {
- }
+	#[\Override]
+    public function isBackendUsed($backendClass)
+    {
+    }
 
 	/**
 	 * @param GroupInterface $backend
 	 */
-	public function addBackend($backend)
- {
- }
+	#[\Override]
+    public function addBackend($backend)
+    {
+    }
 
-	public function clearBackends()
- {
- }
+	#[\Override]
+    public function clearBackends()
+    {
+    }
 
 	/**
 	 * Get the active backends
 	 *
 	 * @return GroupInterface[]
 	 */
-	public function getBackends()
- {
- }
+	#[\Override]
+    public function getBackends()
+    {
+    }
 
 
 	protected function clearCaches()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return IGroup|null
 	 */
-	public function get($gid)
- {
- }
+	#[\Override]
+    public function get($gid)
+    {
+    }
 
 	/**
 	 * @param string $gid
@@ -99,8 +104,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return IGroup|null
 	 */
 	protected function getGroupObject($gid, $displayName = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @brief Batch method to create group objects
@@ -110,44 +115,48 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return array<string, IGroup>
 	 */
 	protected function getGroupsObjects(array $gids, array $displayNames = []): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return bool
 	 */
-	public function groupExists($gid)
- {
- }
+	#[\Override]
+    public function groupExists($gid)
+    {
+    }
 
 	/**
 	 * @param string $gid
 	 * @return IGroup|null
 	 */
-	public function createGroup($gid)
- {
- }
+	#[\Override]
+    public function createGroup($gid)
+    {
+    }
 
-	public function search(string $search, ?int $limit = null, ?int $offset = 0)
- {
- }
+	#[\Override]
+    public function search(string $search, ?int $limit = null, ?int $offset = 0)
+    {
+    }
 
 	/**
 	 * @param IUser|null $user
 	 * @return array<string, IGroup>
 	 */
-	public function getUserGroups(?IUser $user = null): array
- {
- }
+	#[\Override]
+    public function getUserGroups(?IUser $user = null): array
+    {
+    }
 
 	/**
 	 * @param string $uid the user id
 	 * @return array<string, IGroup>
 	 */
 	public function getUserIdGroups(string $uid): array
- {
- }
+    {
+    }
 
 	/**
 	 * Checks if a userId is in the admin group
@@ -155,13 +164,15 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param string $userId
 	 * @return bool if admin
 	 */
-	public function isAdmin($userId)
- {
- }
+	#[\Override]
+    public function isAdmin($userId)
+    {
+    }
 
-	public function isDelegatedAdmin(string $userId): bool
- {
- }
+	#[\Override]
+    public function isDelegatedAdmin(string $userId): bool
+    {
+    }
 
 	/**
 	 * Checks if a userId is in a group
@@ -170,21 +181,24 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @param string $group
 	 * @return bool if in group
 	 */
-	public function isInGroup($userId, $group)
- {
- }
+	#[\Override]
+    public function isInGroup($userId, $group)
+    {
+    }
 
-	public function getUserGroupIds(IUser $user): array
- {
- }
+	#[\Override]
+    public function getUserGroupIds(IUser $user): array
+    {
+    }
 
 	/**
 	 * @param string $groupId
 	 * @return ?string
 	 */
-	public function getDisplayName(string $groupId): ?string
- {
- }
+	#[\Override]
+    public function getDisplayName(string $groupId): ?string
+    {
+    }
 
 	/**
 	 * get an array of groupid and displayName for a user
@@ -193,17 +207,18 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return array ['displayName' => displayname]
 	 */
 	public function getUserGroupNames(IUser $user)
- {
- }
+    {
+    }
 
-	public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0)
- {
- }
+	#[\Override]
+    public function displayNamesInGroup($gid, $search = '', $limit = -1, $offset = 0)
+    {
+    }
 
 	/**
 	 * @return SubAdmin
 	 */
 	public function getSubAdmin()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hook.php
+++ b/tests/stubs/oc_hook.php
@@ -27,8 +27,8 @@ class OC_Hook {
 	 * TODO: write example
 	 */
 	public static function connect($signalClass, $signalName, $slotClass, $slotName)
- {
- }
+    {
+    }
 
 	/**
 	 * emits a signal
@@ -43,8 +43,8 @@ class OC_Hook {
 	 * TODO: write example
 	 */
 	public static function emit($signalClass, $signalName, $params = [])
- {
- }
+    {
+    }
 
 	/**
 	 * clear hooks
@@ -52,14 +52,14 @@ class OC_Hook {
 	 * @param string $signalName
 	 */
 	public static function clear($signalClass = '', $signalName = '')
- {
- }
+    {
+    }
 
 	/**
 	 * DO NOT USE!
 	 * For unit tests ONLY!
 	 */
 	public static function getHooks()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -26,8 +26,8 @@ interface Emitter {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
 	public function listen($scope, $method, callable $callback)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $scope optional
@@ -37,6 +37,6 @@ interface Emitter {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
 	public function removeListener($scope = null, $method = null, ?callable $callback = null)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hooks_emittertrait.php
+++ b/tests/stubs/oc_hooks_emittertrait.php
@@ -23,8 +23,8 @@ trait EmitterTrait {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
 	public function listen($scope, $method, callable $callback)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $scope optional
@@ -33,8 +33,8 @@ trait EmitterTrait {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
 	public function removeListener($scope = null, $method = null, ?callable $callback = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $scope
@@ -43,6 +43,6 @@ trait EmitterTrait {
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::dispatchTyped
 	 */
 	protected function emit($scope, $method, array $arguments = [])
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_hooks_publicemitter.php
+++ b/tests/stubs/oc_hooks_publicemitter.php
@@ -19,7 +19,8 @@ class PublicEmitter extends BasicEmitter {
 	 *
 	 * @suppress PhanAccessMethodProtected
 	 */
-	public function emit($scope, $method, array $arguments = [])
- {
- }
+	#[\Override]
+    public function emit($scope, $method, array $arguments = [])
+    {
+    }
 }

--- a/tests/stubs/oc_server.php
+++ b/tests/stubs/oc_server.php
@@ -308,12 +308,12 @@ use Psr\Log\LoggerInterface;
  */
 class Server extends ServerContainer implements IServerContainer {
 	public function __construct(private string $webRoot, Config $config)
- {
- }
+    {
+    }
 
 	public function boot()
- {
- }
+    {
+    }
 
 	/**
 	 * Returns a view to ownCloud's files folder
@@ -322,13 +322,14 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @return Folder|null
 	 * @deprecated 20.0.0
 	 */
-	public function getUserFolder($userId = null): ?Folder
- {
- }
+	#[\Override]
+    public function getUserFolder($userId = null): ?Folder
+    {
+    }
 
 	public function setSession(ISession $session): void
- {
- }
+    {
+    }
 
 	/**
 	 * Get the webroot
@@ -336,9 +337,10 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @return string
 	 * @deprecated 20.0.0
 	 */
-	public function getWebRoot(): string
- {
- }
+	#[\Override]
+    public function getWebRoot(): string
+    {
+    }
 
 	/**
 	 * get an L10N instance
@@ -348,7 +350,8 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @return IL10N
 	 * @deprecated 20.0.0 use DI of {@see IL10N} or {@see IFactory} instead, or {@see \OCP\Util::getL10N()} as a last resort
 	 */
-	public function getL10N($app, $lang = null)
- {
- }
+	#[\Override]
+    public function getL10N($app, $lang = null)
+    {
+    }
 }

--- a/tests/stubs/oc_servercontainer.php
+++ b/tests/stubs/oc_servercontainer.php
@@ -34,24 +34,24 @@ class ServerContainer extends SimpleContainer {
 	 * ServerContainer constructor.
 	 */
 	public function __construct()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
 	 * @param string $appNamespace
 	 */
 	public function registerNamespace(string $appName, string $appNamespace): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
 	 * @param DIContainer $container
 	 */
 	public function registerAppContainer(string $appName, DIContainer $container): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $appName
@@ -59,8 +59,8 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 */
 	public function getRegisteredAppContainer(string $appName): DIContainer
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $namespace
@@ -69,12 +69,13 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 */
 	protected function getAppContainer(string $namespace, string $sensitiveNamespace): DIContainer
- {
- }
+    {
+    }
 
-	public function has($id, bool $noRecursion = false): bool
- {
- }
+	#[\Override]
+    public function has($id, bool $noRecursion = false): bool
+    {
+    }
 
 	/**
 	 * @template T
@@ -87,9 +88,10 @@ class ServerContainer extends SimpleContainer {
 	 * @throws QueryException
 	 * @deprecated 20.0.0 use \Psr\Container\ContainerInterface::get
 	 */
-	public function query(string $name, bool $autoload = true, array $chain = []): mixed
- {
- }
+	#[\Override]
+    public function query(string $name, bool $autoload = true, array $chain = []): mixed
+    {
+    }
 
 	/**
 	 * @internal
@@ -97,10 +99,10 @@ class ServerContainer extends SimpleContainer {
 	 * @return DIContainer|null
 	 */
 	public function getAppContainerForService(string $id): ?DIContainer
- {
- }
+    {
+    }
 
 	public function getWebRoot()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_settings_authorizedgroup.php
+++ b/tests/stubs/oc_settings_authorizedgroup.php
@@ -16,6 +16,8 @@ use OCP\AppFramework\Db\Entity;
  * @method setClass(string $class)
  * @method string getGroupId()
  * @method string getClass()
+ *
+ * @psalm-api - we cannot use final as this will break unit tests
  */
 class AuthorizedGroup extends Entity implements JsonSerializable {
 	public $id;
@@ -27,7 +29,8 @@ class AuthorizedGroup extends Entity implements JsonSerializable {
 	/**
 	 * @return array<string, mixed>
 	 */
-	public function jsonSerialize(): array
- {
- }
+	#[\Override]
+    public function jsonSerialize(): array
+    {
+    }
 }

--- a/tests/stubs/oc_settings_authorizedgroupmapper.php
+++ b/tests/stubs/oc_settings_authorizedgroupmapper.php
@@ -21,18 +21,19 @@ use OCP\Server;
 
 /**
  * @template-extends QBMapper<AuthorizedGroup>
+ * @psalm-api - we cannot use final as this will break unit tests
  */
 class AuthorizedGroupMapper extends QBMapper {
 	public function __construct(IDBConnection $db)
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Exception
 	 */
 	public function findAllClassesForUser(IUser $user): array
- {
- }
+    {
+    }
 
 	/**
 	 * @throws DoesNotExistException
@@ -40,8 +41,8 @@ class AuthorizedGroupMapper extends QBMapper {
 	 * @throws Exception
 	 */
 	public function find(int $id): AuthorizedGroup
- {
- }
+    {
+    }
 
 	/**
 	 * Get all the authorizations stored in the database.
@@ -50,8 +51,8 @@ class AuthorizedGroupMapper extends QBMapper {
 	 * @throws Exception
 	 */
 	public function findAll(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @throws DoesNotExistException
@@ -59,21 +60,21 @@ class AuthorizedGroupMapper extends QBMapper {
 	 * @throws MultipleObjectsReturnedException
 	 */
 	public function findByGroupIdAndClass(string $groupId, string $class): AuthorizedGroup
- {
- }
+    {
+    }
 
 	/**
 	 * @return list<AuthorizedGroup>
 	 * @throws Exception
 	 */
 	public function findExistingGroupsForClass(string $class): array
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Exception
 	 */
 	public function removeGroup(string $gid): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oc_user_user.php
+++ b/tests/stubs/oc_user_user.php
@@ -52,19 +52,21 @@ class User implements IUser {
 	protected ?IAccountManager $accountManager = null;
 
 	public function __construct(private string $uid, private ?UserInterface $backend, private IEventDispatcher $dispatcher, private Emitter|Manager|null $emitter = null, ?IConfig $config = null, $urlGenerator = null)
- {
- }
+    {
+    }
 
-	public function getUID(): string
- {
- }
+	#[\Override]
+    public function getUID(): string
+    {
+    }
 
 	/**
 	 * Get the display name for the user, if no specific display name is set it will fallback to the user id
 	 */
-	public function getDisplayName(): string
- {
- }
+	#[\Override]
+    public function getDisplayName(): string
+    {
+    }
 
 	/**
 	 * Set the displayname for the user
@@ -74,60 +76,68 @@ class User implements IUser {
 	 * @since 25.0.0 Throw InvalidArgumentException
 	 * @throws \InvalidArgumentException
 	 */
-	public function setDisplayName($displayName): bool
- {
- }
+	#[\Override]
+    public function setDisplayName($displayName): bool
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function setEMailAddress($mailAddress): void
- {
- }
+	#[\Override]
+    public function setEMailAddress($mailAddress): void
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function setSystemEMailAddress(string $mailAddress): void
- {
- }
+	#[\Override]
+    public function setSystemEMailAddress(string $mailAddress): void
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function setPrimaryEMailAddress(string $mailAddress): void
- {
- }
+	#[\Override]
+    public function setPrimaryEMailAddress(string $mailAddress): void
+    {
+    }
 
 	/**
 	 * returns the timestamp of the user's last login or 0 if the user did never
 	 * login
 	 */
-	public function getLastLogin(): int
- {
- }
+	#[\Override]
+    public function getLastLogin(): int
+    {
+    }
 
 	/**
 	 * returns the timestamp of the user's last login or 0 if the user did never
 	 * login
 	 */
-	public function getFirstLogin(): int
- {
- }
+	#[\Override]
+    public function getFirstLogin(): int
+    {
+    }
 
 	/**
 	 * updates the timestamp of the most recent login of this user
 	 */
-	public function updateLastLoginTimestamp(): bool
- {
- }
+	#[\Override]
+    public function updateLastLoginTimestamp(): bool
+    {
+    }
 
 	/**
 	 * Delete the user
 	 */
-	public function delete(): bool
- {
- }
+	#[\Override]
+    public function delete(): bool
+    {
+    }
 
 	/**
 	 * Set the password of the user
@@ -135,110 +145,128 @@ class User implements IUser {
 	 * @param string $password
 	 * @param string $recoveryPassword for the encryption app to reset encryption keys
 	 */
-	public function setPassword($password, $recoveryPassword = null): bool
- {
- }
+	#[\Override]
+    public function setPassword($password, $recoveryPassword = null): bool
+    {
+    }
 
-	public function getPasswordHash(): ?string
- {
- }
+	#[\Override]
+    public function getPasswordHash(): ?string
+    {
+    }
 
-	public function setPasswordHash(string $passwordHash): bool
- {
- }
+	#[\Override]
+    public function setPasswordHash(string $passwordHash): bool
+    {
+    }
 
 	/**
 	 * Get the users home folder to mount
 	 */
-	public function getHome(): string
- {
- }
+	#[\Override]
+    public function getHome(): string
+    {
+    }
 
 	/**
 	 * Get the name of the backend class the user is connected with
 	 */
-	public function getBackendClassName(): string
- {
- }
+	#[\Override]
+    public function getBackendClassName(): string
+    {
+    }
 
-	public function getBackend(): ?UserInterface
- {
- }
+	#[\Override]
+    public function getBackend(): ?UserInterface
+    {
+    }
 
-	public function canChangeAvatar(): bool
- {
- }
+	#[\Override]
+    public function canChangeAvatar(): bool
+    {
+    }
 
-	public function canChangePassword(): bool
- {
- }
+	#[\Override]
+    public function canChangePassword(): bool
+    {
+    }
 
-	public function canChangeDisplayName(): bool
- {
- }
+	#[\Override]
+    public function canChangeDisplayName(): bool
+    {
+    }
 
-	public function canChangeEmail(): bool
- {
- }
+	#[\Override]
+    public function canChangeEmail(): bool
+    {
+    }
 
 	/**
 	 * @param IAccountManager::PROPERTY_*|IAccountManager::COLLECTION_* $property
 	 */
-	public function canEditProperty(string $property): bool
- {
- }
+	#[\Override]
+    public function canEditProperty(string $property): bool
+    {
+    }
 
 	/**
 	 * Check if the user is enabled
 	 */
-	public function isEnabled(): bool
- {
- }
+	#[\Override]
+    public function isEnabled(): bool
+    {
+    }
 
 	/**
 	 * set the enabled status for the user
 	 *
 	 * @return void
 	 */
-	public function setEnabled(bool $enabled = true)
- {
- }
+	#[\Override]
+    public function setEnabled(bool $enabled = true)
+    {
+    }
 
 	/**
 	 * Get the users email address
 	 *
 	 * @since 9.0.0
 	 */
-	public function getEMailAddress(): ?string
- {
- }
+	#[\Override]
+    public function getEMailAddress(): ?string
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getSystemEMailAddress(): ?string
- {
- }
+	#[\Override]
+    public function getSystemEMailAddress(): ?string
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getPrimaryEMailAddress(): ?string
- {
- }
+	#[\Override]
+    public function getPrimaryEMailAddress(): ?string
+    {
+    }
 
 	/**
 	 * get the users' quota
 	 *
 	 * @since 9.0.0
 	 */
-	public function getQuota(): string
- {
- }
+	#[\Override]
+    public function getQuota(): string
+    {
+    }
 
-	public function getQuotaBytes(): int|float
- {
- }
+	#[\Override]
+    public function getQuotaBytes(): int|float
+    {
+    }
 
 	/**
 	 * Set the users' quota
@@ -247,17 +275,20 @@ class User implements IUser {
 	 * @throws InvalidArgumentException
 	 * @since 9.0.0
 	 */
-	public function setQuota($quota): void
- {
- }
+	#[\Override]
+    public function setQuota($quota): void
+    {
+    }
 
-	public function getManagerUids(): array
- {
- }
+	#[\Override]
+    public function getManagerUids(): array
+    {
+    }
 
-	public function setManagerUids(array $uids): void
- {
- }
+	#[\Override]
+    public function setManagerUids(array $uids): void
+    {
+    }
 
 	/**
 	 * get the avatar image if it exists
@@ -265,20 +296,22 @@ class User implements IUser {
 	 * @param int $size
 	 * @since 9.0.0
 	 */
-	public function getAvatarImage($size): ?IImage
- {
- }
+	#[\Override]
+    public function getAvatarImage($size): ?IImage
+    {
+    }
 
 	/**
 	 * get the federation cloud id
 	 *
 	 * @since 9.0.0
 	 */
-	public function getCloudId(): string
- {
- }
+	#[\Override]
+    public function getCloudId(): string
+    {
+    }
 
 	public function triggerChange($feature, $value = null, $oldValue = null): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_circlesmanager.php
+++ b/tests/stubs/oca_circles_circlesmanager.php
@@ -62,8 +62,8 @@ class CirclesManager {
 	 * @param CirclesQueryHelper $circlesQueryHelper
 	 */
 	public function __construct(FederatedUserService $federatedUserService, CircleService $circleService, MemberService $memberService, MembershipService $membershipService, ConfigService $configService, CirclesQueryHelper $circlesQueryHelper)
- {
- }
+    {
+    }
 
 
 	/**
@@ -87,8 +87,8 @@ class CirclesManager {
 	 * @throws UserTypeNotFoundException
 	 */
 	public function getFederatedUser(string $federatedId, int $type = Member::TYPE_SINGLE): FederatedUser
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $userId
@@ -110,8 +110,8 @@ class CirclesManager {
 	 * @throws UserTypeNotFoundException
 	 */
 	public function getLocalFederatedUser(string $userId): FederatedUser
- {
- }
+    {
+    }
 
 
 	/**
@@ -122,15 +122,15 @@ class CirclesManager {
 	 * @throws FederatedUserException
 	 */
 	public function startSession(?FederatedUser $federatedUser = null, bool $forceSync = false): void
- {
- }
+    {
+    }
 
 	/**
 	 *
 	 */
 	public function startSuperSession(bool $forceSync = false): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -146,8 +146,8 @@ class CirclesManager {
 	 * @throws SingleCircleNotFoundException
 	 */
 	public function startAppSession(string $appId, int $appSerial = Member::APP_DEFAULT): void
- {
- }
+    {
+    }
 
 	/**
 	 * $userId - userId to emulate as initiator (can be empty)
@@ -174,16 +174,16 @@ class CirclesManager {
 	 * @throws UserTypeNotFoundException
 	 */
 	public function startOccSession(string $userId, int $userType = Member::TYPE_SINGLE, string $circleId = ''): void
- {
- }
+    {
+    }
 
 
 	/**
 	 *
 	 */
 	public function stopSession(): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -191,16 +191,16 @@ class CirclesManager {
 	 * @throws FederatedUserNotFoundException
 	 */
 	public function getCurrentFederatedUser(): IFederatedUser
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return CirclesQueryHelper
 	 */
 	public function getQueryHelper(): CirclesQueryHelper
- {
- }
+    {
+    }
 
 
 	/**
@@ -223,8 +223,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function createCircle(string $name, ?FederatedUser $owner = null, bool $personal = false, bool $local = false): Circle
- {
- }
+    {
+    }
 
 
 	/**
@@ -243,8 +243,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function destroyCircle(string $singleId): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -262,8 +262,8 @@ class CirclesManager {
 	 * @throws RequestBuilderException
 	 */
 	public function getCircles(?CircleProbe $probe = null, bool $refreshCache = false): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -276,8 +276,8 @@ class CirclesManager {
 	 * @throws RequestBuilderException
 	 */
 	public function getCircle(string $singleId, ?CircleProbe $probe = null): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * better than using getCircle() if only interested in teams current user is member of
@@ -285,8 +285,8 @@ class CirclesManager {
 	 * @since 33.0.0
 	 */
 	public function probeCircle(string $singleId, ?CircleProbe $probe = null, ?DataProbe $dataProbe = null): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * get details from a list of circles the current user is a member of
@@ -294,8 +294,8 @@ class CirclesManager {
 	 * @since 33.0.0
 	 */
 	public function getCirclesByIds(array $ids, ?DataProbe $dataProbe = null): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -314,8 +314,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function updateConfig(Circle $circle): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -336,8 +336,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function flagAsAppManaged(string $circleId, bool $enabled = true): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -365,8 +365,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function addMember(string $circleId, FederatedUser $federatedUser): Member
- {
- }
+    {
+    }
 
 
 	/**
@@ -387,8 +387,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function levelMember(string $memberId, int $level): Member
- {
- }
+    {
+    }
 
 
 	/**
@@ -406,8 +406,8 @@ class CirclesManager {
 	 * @throws UnknownRemoteException
 	 */
 	public function removeMember(string $memberId): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -420,8 +420,8 @@ class CirclesManager {
 	 * @throws RequestBuilderException
 	 */
 	public function getLink(string $circleId, string $singleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 
 
 	/**
@@ -430,8 +430,8 @@ class CirclesManager {
 	 * @return string
 	 */
 	public function getDefinition(IEntity $circle): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -449,8 +449,8 @@ class CirclesManager {
 	 * @throws RequestBuilderException
 	 */
 	public function probeCircles(?CircleProbe $circleProbe = null, ?DataProbe $dataProbe = null): array
- {
- }
+    {
+    }
 
 
 	/**

--- a/tests/stubs/oca_circles_circlesqueryhelper.php
+++ b/tests/stubs/oca_circles_circlesqueryhelper.php
@@ -35,16 +35,16 @@ class CirclesQueryHelper {
 	 * @param FederatedUserService $federatedUserService
 	 */
 	public function __construct(CoreRequestBuilder $coreRequestBuilder, FederatedUserService $federatedUserService)
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return CoreQueryBuilder&IQueryBuilder
 	 */
 	public function getQueryBuilder(): CoreQueryBuilder
- {
- }
+    {
+    }
 
 
 	/**
@@ -57,8 +57,8 @@ class CirclesQueryHelper {
 	 * @throws FederatedUserNotFoundException
 	 */
 	public function limitToSession(string $alias, string $field, bool $fullDetails = false): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
@@ -71,15 +71,15 @@ class CirclesQueryHelper {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToInheritedMembers(string $alias, string $field, IFederatedUser $federatedUser, bool $fullDetails = false): ICompositeExpression
- {
- }
+    {
+    }
 
 	/**
 	 * lighter version with small inner join
 	 */
 	public function limitToMemberships(string $alias, string $field, IFederatedUser $federatedUser): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -89,8 +89,8 @@ class CirclesQueryHelper {
 	 * @throws RequestBuilderException
 	 */
 	public function addCircleDetails(string $alias, string $field): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -100,6 +100,6 @@ class CirclesQueryHelper {
 	 * @throws CircleNotFoundException
 	 */
 	public function extractCircle(array $data): Circle
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_db_corequerybuilder.php
+++ b/tests/stubs/oca_circles_db_corequerybuilder.php
@@ -214,8 +214,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * CoreQueryBuilder constructor.
 	 */
 	public function __construct()
- {
- }
+    {
+    }
 
 
 	/**
@@ -224,138 +224,138 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @return string
 	 */
 	public function getInstance(IFederatedModel $federatedModel): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $id
 	 */
 	public function limitToCircleId(string $id): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 */
 	public function limitToName(string $name): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 */
 	public function limitToDisplayName(string $name): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $name
 	 */
 	public function limitToSanitizedName(string $name): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $config
 	 */
 	public function limitToConfig(int $config): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $source
 	 */
 	public function limitToSource(int $source): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $config
 	 * @param string $alias
 	 */
 	public function limitToConfigFlag(int $config, string $alias = ''): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $singleId
 	 */
 	public function limitToSingleId(string $singleId, string $alias = ''): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $itemId
 	 */
 	public function limitToItemId(string $itemId): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $host
 	 */
 	public function limitToInstance(string $host): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param int $userType
 	 */
 	public function limitToUserType(int $userType): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param int $shareType
 	 */
 	public function limitToShareType(int $shareType): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $shareWith
 	 */
 	public function limitToShareWith(string $shareWith): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param int $nodeId
 	 */
 	public function limitToFileSource(int $nodeId): void
- {
- }
+    {
+    }
 
 	public function limitToFileTarget(string $target, string $alias): void
- {
- }
+    {
+    }
 
 	public function limitToFileTargetLike(string $target, string $alias): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param array $files
 	 */
 	public function limitToFileSourceArray(array $files): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param int $shareId
 	 */
 	public function limitToShareParent(int $shareId): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -364,16 +364,16 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param Circle $circle
 	 */
 	public function filterCircleDetails(Circle $circle): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * left join RemoteInstance based on a Member
 	 */
 	public function leftJoinRemoteInstance(string $alias): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -385,8 +385,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToRemoteInstance(string $alias, RemoteInstance $remoteInstance, bool $filterSensitiveData = true, string $aliasCircle = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -398,8 +398,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinRemoteInstanceIncomingRequest(string $alias, RemoteInstance $remoteInstance): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -419,8 +419,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	protected function limitRemoteVisibility(string $alias, bool $sensitive, string $aliasCircle)
- {
- }
+    {
+    }
 
 
 	/**
@@ -430,8 +430,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToDirectMembership(string $alias, Member $member): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -442,8 +442,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToFederatedUserMemberships(string $alias, string $aliasCircle, FederatedUser $federatedUser): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -451,8 +451,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param Member $member
 	 */
 	public function filterDirectMembership(string $aliasMember, Member $member): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -464,8 +464,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinCircle(string $alias, ?IFederatedUser $initiator = null, string $field = 'circle_id', string $helperAlias = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -474,8 +474,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinInvitedBy(string $aliasMember): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -485,8 +485,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinBasedOn(string $aliasMember, ?IFederatedUser $initiator = null): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -496,8 +496,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinOwner(string $alias, string $field = 'unique_id'): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -506,8 +506,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param string $field
 	 */
 	public function innerJoinMembership(?CircleProbe $probe, string $alias, string $field = 'unique_id'): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -518,8 +518,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinMember(string $alias, string $fieldCircleId = 'circle_id', string $fieldSingleId = 'single_id'): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -533,16 +533,16 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinInheritedMembers(string $alias, string $field = '', string $aliasInheritedBy = ''): void
- {
- }
+    {
+    }
 
 
 	/**
 	 * @throws RequestBuilderException
 	 */
 	public function limitToInheritedMemberships(string $alias, string $singleId, string $field = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -555,8 +555,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToMembersByInheritance(string $alias, string $singleId, int $level = 0): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -571,8 +571,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinMembersByInheritance(string $alias, string $field = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -582,8 +582,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToShareToken(string $alias, string $token): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $alias
@@ -592,8 +592,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinShareToken(string $alias, string $field = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -608,16 +608,16 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function limitToInitiator(string $alias, IFederatedUser $user, string $field = '', string $helperAlias = ''): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param string $alias
 	 */
 	public function leftJoinCircleConfig(string $alias): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -631,13 +631,13 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinInitiator(string $alias, IFederatedUser $initiator, string $field = '', string $helperAlias = ''): void
- {
- }
+    {
+    }
 
 
 	public function completeProbeWithInitiator(string $alias, string $field = 'single_id', string $helperAlias = ''): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $alias
@@ -646,8 +646,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	protected function limitInitiatorVisibility(string $alias): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
@@ -655,8 +655,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param CircleProbe $probe
 	 */
 	public function filterCircles(string $aliasCircle, CircleProbe $probe): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -667,8 +667,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinFileCache(string $aliasShare)
- {
- }
+    {
+    }
 
 
 	/**
@@ -680,8 +680,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinShareChild(string $aliasShare, string $aliasShareMemberships = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -690,8 +690,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @param bool $reshares
 	 */
 	public function limitToShareOwner(string $alias, FederatedUser $federatedUser, bool $reshares, int $nodeId = 0): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -701,8 +701,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function leftJoinMountpoint(string $aliasMount, IFederatedUser $federatedUser, string $aliasMountMemberships = '')
- {
- }
+    {
+    }
 
 
 	/**
@@ -712,8 +712,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @return CoreQueryBuilder&IQueryBuilder
 	 */
 	public function setOptions(array $path, array $options): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -725,8 +725,8 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @throws RequestBuilderException
 	 */
 	public function generateAlias(string $base, string $extension, ?array &$options = []): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -735,16 +735,16 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @return array
 	 */
 	public function getAvailablePath(string $prefix): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function getSqlPath(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -756,10 +756,10 @@ class CoreQueryBuilder extends ExtendedQueryBuilder {
 	 * @return $this
 	 */
 	public function setSqlPath(string $key, array $path = []): self
- {
- }
+    {
+    }
 
 	public function resetSqlPath(): self
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_events_circledestroyedevent.php
+++ b/tests/stubs/oca_circles_events_circledestroyedevent.php
@@ -34,6 +34,6 @@ class CircleDestroyedEvent extends CircleResultGenericEvent {
 	 * @param array $results
 	 */
 	public function __construct(FederatedEvent $federatedEvent, array $results)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_events_circleresultgenericevent.php
+++ b/tests/stubs/oca_circles_events_circleresultgenericevent.php
@@ -30,45 +30,45 @@ class CircleResultGenericEvent extends Event {
 	 * @param SimpleDataStore[] $results
 	 */
 	public function __construct(FederatedEvent $federatedEvent, array $results)
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return FederatedEvent
 	 */
 	public function getFederatedEvent(): FederatedEvent
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return SimpleDataStore[]
 	 */
 	public function getResults(): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return Circle
 	 */
 	public function getCircle(): Circle
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasMember(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member|null
 	 */
 	public function getMember(): ?Member
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_exceptions_federateditemexception.php
+++ b/tests/stubs/oca_circles_exceptions_federateditemexception.php
@@ -42,29 +42,29 @@ class FederatedItemException extends Exception implements JsonSerializable {
 	 * @param Throwable|null $previous
 	 */
 	public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
- {
- }
+    {
+    }
 
 
 	/**
 	 * @param int $status
 	 */
 	protected function setStatus(int $status): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getStatus(): int
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function jsonSerialize(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_exceptions_federateditemnotfoundexception.php
+++ b/tests/stubs/oca_circles_exceptions_federateditemnotfoundexception.php
@@ -30,6 +30,6 @@ class FederatedItemNotFoundException extends FederatedItemException {
 	 * @param Throwable|null $previous
 	 */
 	public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_ientity.php
+++ b/tests/stubs/oca_circles_ientity.php
@@ -24,8 +24,8 @@ interface IEntity {
 	 * @return string
 	 */
 	public function getSingleId(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param Membership[] $memberships
@@ -33,15 +33,15 @@ interface IEntity {
 	 * @return $this
 	 */
 	public function setMemberships(array $memberships): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Membership[]
 	 */
 	public function getMemberships(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $singleId
@@ -51,6 +51,6 @@ interface IEntity {
 	 * @throws MembershipNotFoundException
 	 */
 	public function getLink(string $singleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_ifederatedmodel.php
+++ b/tests/stubs/oca_circles_ifederatedmodel.php
@@ -21,13 +21,13 @@ interface IFederatedModel {
 	 * @return string
 	 */
 	public function getInstance(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function isLocal(): bool
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_ifederateduser.php
+++ b/tests/stubs/oca_circles_ifederateduser.php
@@ -25,15 +25,15 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return self
 	 */
 	public function setSingleId(string $singleId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getSingleId(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $userId
@@ -41,15 +41,15 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return self
 	 */
 	public function setUserId(string $userId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getUserId(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $userType
@@ -57,15 +57,15 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return self
 	 */
 	public function setUserType(int $userType): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getUserType(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $displayName
@@ -73,15 +73,15 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return IFederatedUser
 	 */
 	public function setDisplayName(string $displayName): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getDisplayName(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param ?Circle $basedOn
@@ -89,22 +89,22 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return $this
 	 */
 	public function setBasedOn(?Circle $basedOn): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getBasedOn(): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasBasedOn(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $instance
@@ -112,6 +112,6 @@ interface IFederatedUser extends IFederatedModel {
 	 * @return self
 	 */
 	public function setInstance(string $instance): self
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_iqueryprobe.php
+++ b/tests/stubs/oca_circles_iqueryprobe.php
@@ -25,22 +25,22 @@ interface IQueryProbe {
 	 * @return int
 	 */
 	public function getItemsOffset(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getItemsLimit(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getDetails(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $detail
@@ -48,55 +48,55 @@ interface IQueryProbe {
 	 * @return bool
 	 */
 	public function showDetail(int $detail): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getFilterCircle(): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterCircle(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member
 	 */
 	public function getFilterMember(): Member
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterMember(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return RemoteInstance
 	 */
 	public function getFilterRemoteInstance(): RemoteInstance
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterRemoteInstance(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return array
 	 */
 	public function getAsOptions(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_circle.php
+++ b/tests/stubs/oca_circles_model_circle.php
@@ -168,23 +168,23 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setSingleId(string $singleId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getSingleId(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 * @deprecated - removed in NC23
 	 */
 	public function getUniqueId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -193,15 +193,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setConfig(int $config): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getConfig(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $flag
@@ -210,22 +210,22 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return bool
 	 */
 	public function isConfig(int $flag, int $test = 0): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $flag
 	 */
 	public function addConfig(int $flag): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $flag
 	 */
 	public function remConfig(int $flag): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -234,15 +234,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setName(string $name): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getName(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -251,15 +251,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setDisplayName(string $displayName): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getDisplayName(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -268,15 +268,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setSanitizedName(string $sanitizedName): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getSanitizedName(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -285,15 +285,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setSource(int $source): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getSource(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -302,30 +302,30 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setOwner(?Member $owner): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member
 	 */
 	public function getOwner(): Member
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasOwner(): bool
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasMembers(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param Member[] $members
@@ -333,15 +333,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setMembers(array $members): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member[]
 	 */
 	public function getMembers(int $limit = 0): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -351,8 +351,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setInheritedMembers(array $members, bool $detailed): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param Member[] $members
@@ -360,8 +360,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function addInheritedMembers(array $members): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -382,16 +382,16 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws UnknownRemoteException
 	 */
 	public function getInheritedMembers(bool $detailed = false, bool $remote = false): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasMemberships(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param array $memberships
@@ -399,15 +399,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setMemberships(array $memberships): IEntity
- {
- }
+    {
+    }
 
 	/**
 	 * @return Membership[]
 	 */
 	public function getMemberships(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -419,8 +419,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws RequestBuilderException
 	 */
 	public function getLink(string $singleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 
 
 	/**
@@ -429,22 +429,22 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setInitiator(?Member $initiator): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member
 	 */
 	public function getInitiator(): Member
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasInitiator(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param Member|null $directInitiator
@@ -452,8 +452,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return $this
 	 */
 	public function setDirectInitiator(?Member $directInitiator): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -462,16 +462,16 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setInstance(string $instance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 * @throws OwnerNotFoundException
 	 */
 	public function getInstance(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -479,8 +479,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws OwnerNotFoundException
 	 */
 	public function isLocal(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -489,15 +489,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setPopulation(int $population): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getPopulation(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -506,15 +506,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return Circle
 	 */
 	public function setPopulationInherited(int $population): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getPopulationInherited(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -523,15 +523,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setSettings(array $settings): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return array
 	 */
 	public function getSettings(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -540,23 +540,23 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setDescription(string $description): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getDescription(): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return string
 	 */
 	public function getUrl(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -565,15 +565,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setContactAddressBook(int $contactAddressBook): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getContactAddressBook(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -582,15 +582,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setContactGroupName(string $contactGroupName): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getContactGroupName(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -599,15 +599,15 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return self
 	 */
 	public function setCreation(int $creation): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getCreation(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -617,8 +617,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws InvalidItemException
 	 */
 	public function import(array $data): IDeserializable
- {
- }
+    {
+    }
 
 
 	/**
@@ -631,8 +631,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws UnknownRemoteException
 	 */
 	public function jsonSerialize(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -643,8 +643,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws CircleNotFoundException
 	 */
 	public function importFromDatabase(array $data, string $prefix = ''): IQueryRow
- {
- }
+    {
+    }
 
 
 	/**
@@ -654,8 +654,8 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @throws OwnerNotFoundException
 	 */
 	public function compareWith(Circle $circle): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -665,6 +665,6 @@ class Circle extends ManagedModel implements IEntity, IDeserializable, IQueryRow
 	 * @return array
 	 */
 	public static function getCircleFlags(Circle $circle, int $display = self::FLAGS_LONG): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_federateduser.php
+++ b/tests/stubs/oca_circles_model_federateduser.php
@@ -57,8 +57,8 @@ class FederatedUser extends ManagedModel implements
 	 * @return $this
 	 */
 	public function set(string $userId, string $instance = '', int $type = Member::TYPE_USER, string $displayName = '', ?Circle $basedOn = null): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -67,15 +67,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setSingleId(string $singleId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getSingleId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -84,15 +84,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setUserId(string $userId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getUserId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -101,15 +101,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setUserType(int $userType): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getUserType(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $displayName
@@ -117,23 +117,23 @@ class FederatedUser extends ManagedModel implements
 	 * @return FederatedUser
 	 */
 	public function setDisplayName(string $displayName): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getDisplayName(): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasBasedOn(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param ?Circle $basedOn
@@ -141,15 +141,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setBasedOn(?Circle $basedOn): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getBasedOn(): Circle
- {
- }
+    {
+    }
 
 
 	/**
@@ -158,15 +158,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setConfig(int $config): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getConfig(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -175,30 +175,30 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setInstance(string $instance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getInstance(): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function isLocal(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasInheritance(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param Membership $inheritance
@@ -206,23 +206,23 @@ class FederatedUser extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setInheritance(Membership $inheritance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Membership
 	 */
 	public function getInheritance(): Membership
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasMemberships(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param array $memberships
@@ -230,15 +230,15 @@ class FederatedUser extends ManagedModel implements
 	 * @return self
 	 */
 	public function setMemberships(array $memberships): IEntity
- {
- }
+    {
+    }
 
 	/**
 	 * @return Membership[]
 	 */
 	public function getMemberships(): array
- {
- }
+    {
+    }
 
 
 
@@ -251,8 +251,8 @@ class FederatedUser extends ManagedModel implements
 	 * @throws RequestBuilderException
 	 */
 	public function getLink(string $singleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 
 
 	/**
@@ -262,8 +262,8 @@ class FederatedUser extends ManagedModel implements
 	 * @throws InvalidItemException
 	 */
 	public function import(array $data): IDeserializable
- {
- }
+    {
+    }
 
 
 	/**
@@ -273,8 +273,8 @@ class FederatedUser extends ManagedModel implements
 	 * @throws OwnerNotFoundException
 	 */
 	public function importFromCircle(Circle $circle): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -285,8 +285,8 @@ class FederatedUser extends ManagedModel implements
 	 * @throws FederatedUserNotFoundException
 	 */
 	public function importFromDatabase(array $data, string $prefix = ''): IQueryRow
- {
- }
+    {
+    }
 
 
 	/**
@@ -294,8 +294,8 @@ class FederatedUser extends ManagedModel implements
 	 * @throws UnknownInterfaceException
 	 */
 	public function jsonSerialize(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -304,6 +304,6 @@ class FederatedUser extends ManagedModel implements
 	 * @return bool
 	 */
 	public function compareWith(IFederatedUser $member): bool
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_managedmodel.php
+++ b/tests/stubs/oca_circles_model_managedmodel.php
@@ -27,12 +27,12 @@ class ManagedModel {
 	 * @return ModelManager
 	 */
 	protected function getManager(): ModelManager
- {
- }
+    {
+    }
 
 
 	/** @noinspection PhpPossiblePolymorphicInvocationInspection */
 	public function importFromIFederatedUser(IFederatedUser $orig): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_member.php
+++ b/tests/stubs/oca_circles_model_member.php
@@ -116,15 +116,15 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setId(string $id): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -133,15 +133,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setCircleId(string $circleId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getCircleId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -153,15 +153,15 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setSingleId(string $singleId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getSingleId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -170,15 +170,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setUserId(string $userId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getUserId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -187,23 +187,23 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setUserType(int $userType): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getUserType(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 * @deprecated 22.0.0 Use `getUserType()` instead
 	 */
 	public function getType(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -212,23 +212,23 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setInstance(string $instance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getInstance(): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function isLocal(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -237,30 +237,30 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setInvitedBy(FederatedUser $invitedBy): Member
- {
- }
+    {
+    }
 
 	/**
 	 * @return FederatedUser
 	 */
 	public function getInvitedBy(): FederatedUser
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasInvitedBy(): bool
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasRemoteInstance(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param RemoteInstance $remoteInstance
@@ -268,23 +268,23 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setRemoteInstance(RemoteInstance $remoteInstance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return RemoteInstance
 	 */
 	public function getRemoteInstance(): RemoteInstance
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasBasedOn(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param ?Circle $basedOn
@@ -292,23 +292,23 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setBasedOn(?Circle $basedOn): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getBasedOn(): Circle
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasInheritedBy(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param FederatedUser $inheritedBy
@@ -316,23 +316,23 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setInheritedBy(FederatedUser $inheritedBy): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return FederatedUser
 	 */
 	public function getInheritedBy(): FederatedUser
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasInheritanceFrom(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param Member $inheritanceFrom
@@ -340,15 +340,15 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setInheritanceFrom(Member $inheritanceFrom): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member|null
 	 */
 	public function getInheritanceFrom(): ?Member
- {
- }
+    {
+    }
 
 
 	/**
@@ -357,15 +357,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setLevel(int $level): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getLevel(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -374,15 +374,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setStatus(string $status): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getStatus(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -391,15 +391,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setNotes(array $notes): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return array
 	 */
 	public function getNotes(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -408,8 +408,8 @@ class Member extends ManagedModel implements
 	 * @return string
 	 */
 	public function getNote(string $key): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -417,8 +417,8 @@ class Member extends ManagedModel implements
 	 * @return array
 	 */
 	public function getNoteArray(string $key): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -427,8 +427,8 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setNote(string $key, string $note): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -437,8 +437,8 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setNoteArray(string $key, array $note): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -447,8 +447,8 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setNoteObj(string $key, JsonSerializable $obj): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -457,8 +457,8 @@ class Member extends ManagedModel implements
 	 * @return $this
 	 */
 	public function setDisplayName(string $displayName): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -467,23 +467,23 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setDisplayUpdate(int $displayUpdate): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getDisplayUpdate(): int
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return string
 	 */
 	public function getDisplayName(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -492,15 +492,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setContactId(string $contactId): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getContactId(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -509,15 +509,15 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setContactMeta(string $contactMeta): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getContactMeta(): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -526,22 +526,22 @@ class Member extends ManagedModel implements
 	 * @return self
 	 */
 	public function setCircle(Circle $circle): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getCircle(): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasCircle(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -550,23 +550,23 @@ class Member extends ManagedModel implements
 	 * @return Member
 	 */
 	public function setJoined(int $joined): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getJoined(): int
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return bool
 	 */
 	public function hasMemberships(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param array $memberships
@@ -574,15 +574,15 @@ class Member extends ManagedModel implements
 	 * @return self
 	 */
 	public function setMemberships(array $memberships): IEntity
- {
- }
+    {
+    }
 
 	/**
 	 * @return Membership[]
 	 */
 	public function getMemberships(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -594,8 +594,8 @@ class Member extends ManagedModel implements
 	 * @throws RequestBuilderException
 	 */
 	public function getLink(string $singleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $circleId
@@ -607,8 +607,8 @@ class Member extends ManagedModel implements
 	 * @deprecated - use getLink();
 	 */
 	public function getMembership(string $circleId, bool $detailed = false): Membership
- {
- }
+    {
+    }
 
 
 	/**
@@ -618,8 +618,8 @@ class Member extends ManagedModel implements
 	 * @return bool
 	 */
 	public function compareWith(Member $member, bool $full = true): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -629,8 +629,8 @@ class Member extends ManagedModel implements
 	 * @throws InvalidItemException
 	 */
 	public function import(array $data): IDeserializable
- {
- }
+    {
+    }
 
 
 	/**
@@ -641,8 +641,8 @@ class Member extends ManagedModel implements
 	 * @throws MemberNotFoundException
 	 */
 	public function importFromDatabase(array $data, string $prefix = ''): IQueryRow
- {
- }
+    {
+    }
 
 
 	/**
@@ -650,8 +650,8 @@ class Member extends ManagedModel implements
 	 * @throws UnknownInterfaceException
 	 */
 	public function jsonSerialize(): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -661,8 +661,8 @@ class Member extends ManagedModel implements
 	 * @throws ParseMemberLevelException
 	 */
 	public static function parseLevelInt(int $level): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -672,8 +672,8 @@ class Member extends ManagedModel implements
 	 * @throws ParseMemberLevelException
 	 */
 	public static function parseLevelString(string $levelString): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $typeString
@@ -682,6 +682,6 @@ class Member extends ManagedModel implements
 	 * @throws UserTypeNotFoundException
 	 */
 	public static function parseTypeString(string $typeString): int
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_probes_basicprobe.php
+++ b/tests/stubs/oca_circles_model_probes_basicprobe.php
@@ -33,15 +33,15 @@ class BasicProbe implements IQueryProbe {
 	 * @return BasicProbe
 	 */
 	public function setItemsOffset(int $itemsOffset): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getItemsOffset(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -50,15 +50,15 @@ class BasicProbe implements IQueryProbe {
 	 * @return BasicProbe
 	 */
 	public function setItemsLimit(int $itemsLimit): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getItemsLimit(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -67,15 +67,15 @@ class BasicProbe implements IQueryProbe {
 	 * @return $this
 	 */
 	public function setDetails(int $details): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return int
 	 */
 	public function getDetails(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $detail
@@ -83,8 +83,8 @@ class BasicProbe implements IQueryProbe {
 	 * @return $this
 	 */
 	public function addDetail(int $detail): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $detail
@@ -92,8 +92,8 @@ class BasicProbe implements IQueryProbe {
 	 * @return bool
 	 */
 	public function showDetail(int $detail): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -102,22 +102,22 @@ class BasicProbe implements IQueryProbe {
 	 * @return CircleProbe
 	 */
 	public function setFilterCircle(Circle $filterCircle): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Circle
 	 */
 	public function getFilterCircle(): Circle
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterCircle(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -126,22 +126,22 @@ class BasicProbe implements IQueryProbe {
 	 * @return CircleProbe
 	 */
 	public function setFilterMember(Member $filterMember): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return Member
 	 */
 	public function getFilterMember(): Member
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterMember(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -150,22 +150,22 @@ class BasicProbe implements IQueryProbe {
 	 * @return CircleProbe
 	 */
 	public function setFilterRemoteInstance(RemoteInstance $filterRemoteInstance): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return RemoteInstance
 	 */
 	public function getFilterRemoteInstance(): RemoteInstance
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function hasFilterRemoteInstance(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -175,8 +175,8 @@ class BasicProbe implements IQueryProbe {
 	 * @return $this
 	 */
 	public function addOption(string $key, string $value): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -185,8 +185,8 @@ class BasicProbe implements IQueryProbe {
 	 * @return $this
 	 */
 	public function addOptionInt(string $key, int $value): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -195,21 +195,21 @@ class BasicProbe implements IQueryProbe {
 	 * @return $this
 	 */
 	public function addOptionBool(string $key, bool $value): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return array
 	 */
 	public function getAsOptions(): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function JsonSerialize(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_probes_circleprobe.php
+++ b/tests/stubs/oca_circles_model_probes_circleprobe.php
@@ -34,8 +34,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includePersonalCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether single circles are included in the probe
@@ -45,8 +45,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeSingleCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether system circles are included in the probe
@@ -56,8 +56,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeSystemCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether hidden circles are included in the probe
@@ -67,8 +67,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeHiddenCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether backend circles are included in the probe
@@ -78,8 +78,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeBackendCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether non-visible circles are included in the probe
@@ -89,8 +89,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function includeNonVisibleCircles(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Return whether non-visible circles are included in the probe
@@ -98,8 +98,8 @@ class CircleProbe extends MemberProbe {
 	 * @return bool
 	 */
 	public function nonVisibleCirclesIncluded(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -110,8 +110,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function visitSingleCircles(bool $visit = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Return whether single circles are visited in the probe
@@ -119,8 +119,8 @@ class CircleProbe extends MemberProbe {
 	 * @return bool
 	 */
 	public function visitingSingleCircles(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -129,8 +129,8 @@ class CircleProbe extends MemberProbe {
 	 * @return int
 	 */
 	public function included(): int
- {
- }
+    {
+    }
 
 	/**
 	 * Return whether a config is included in the probe (bitwise comparison)
@@ -140,8 +140,8 @@ class CircleProbe extends MemberProbe {
 	 * @return bool
 	 */
 	public function isIncluded(int $config): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -152,16 +152,16 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function limitConfig(int $config = 0): self
- {
- }
+    {
+    }
 
 	public function hasLimitConfig(): bool
- {
- }
+    {
+    }
 
 	public function getLimitConfig(): int
- {
- }
+    {
+    }
 
 
 	/**
@@ -172,8 +172,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterPersonalCircles(bool $filter = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether single circles are filtered in the probe
@@ -183,8 +183,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterSingleCircles(bool $filter = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether system circles are filtered in the probe
@@ -194,8 +194,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterSystemCircles(bool $filter = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether hidden circles are filtered in the probe
@@ -205,8 +205,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterHiddenCircles(bool $filter = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * Configure whether backend circles are filtered in the probe
@@ -216,8 +216,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterBackendCircles(bool $filter = true): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -229,8 +229,8 @@ class CircleProbe extends MemberProbe {
 	 * @return $this
 	 */
 	public function filterConfig(int $config, bool $filter = true): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -239,8 +239,8 @@ class CircleProbe extends MemberProbe {
 	 * @return int
 	 */
 	public function filtered(): int
- {
- }
+    {
+    }
 
 	/**
 	 * Return whether a config is filtered in the probe (bitwise comparison)
@@ -250,8 +250,8 @@ class CircleProbe extends MemberProbe {
 	 * @return bool
 	 */
 	public function isFiltered(int $config): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -260,16 +260,16 @@ class CircleProbe extends MemberProbe {
 	 * @return array
 	 */
 	public function getAsOptions(): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return string
 	 */
 	public function getChecksum(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Return a JSON object with includes as options
@@ -277,6 +277,6 @@ class CircleProbe extends MemberProbe {
 	 * @return array
 	 */
 	public function JsonSerialize(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_model_probes_memberprobe.php
+++ b/tests/stubs/oca_circles_model_probes_memberprobe.php
@@ -27,15 +27,15 @@ class MemberProbe extends BasicProbe {
 	 * @return $this
 	 */
 	public function canBeRequestingMembership(bool $can = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function isRequestingMembership(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -44,15 +44,15 @@ class MemberProbe extends BasicProbe {
 	 * @return $this
 	 */
 	public function initiatorAsDirectMember(bool $include = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool
 	 */
 	public function directMemberInitiator(): bool
- {
- }
+    {
+    }
 
 
 	/**
@@ -61,62 +61,62 @@ class MemberProbe extends BasicProbe {
 	 * @return $this
 	 */
 	public function emulateVisitor(): self
- {
- }
+    {
+    }
 
 	public function isEmulatingVisitor(): bool
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return int
 	 */
 	public function getMinimumLevel(): int
- {
- }
+    {
+    }
 
 	/**
 	 * @return $this
 	 */
 	public function mustBeMember(bool $must = true): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return $this
 	 */
 	public function mustBeModerator(): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return $this
 	 */
 	public function mustBeAdmin(): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return $this
 	 */
 	public function mustBeOwner(): self
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function getAsOptions(): array
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function JsonSerialize(): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_tools_db_extendedquerybuilder.php
+++ b/tests/stubs/oca_circles_tools_db_extendedquerybuilder.php
@@ -32,8 +32,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 
 
 	public function __construct()
- {
- }
+    {
+    }
 
 
 	/**
@@ -42,23 +42,23 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return self
 	 */
 	public function setDefaultSelectAlias(string $alias): self
- {
- }
+    {
+    }
 
 	/**
 	 * @return string
 	 */
 	public function getDefaultSelectAlias(): string
- {
- }
+    {
+    }
 
 
 	/**
 	 * @return array
 	 */
 	public function getDefaultValues(): array
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $key
@@ -67,24 +67,24 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return $this
 	 */
 	public function addDefaultValue(string $key, string $value): self
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $size
 	 * @param int $page
 	 */
 	public function paginate(int $size, int $page = 0): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $offset
 	 * @param int $limit
 	 */
 	public function chunk(int $offset, int $limit): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -93,71 +93,71 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param int $id
 	 */
 	public function limitToId(int $id): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param array $ids
 	 */
 	public function limitToIds(array $ids): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $id
 	 */
 	public function limitToIdString(string $id): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $userId
 	 */
 	public function limitToUserId(string $userId): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $uniqueId
 	 */
 	public function limitToUniqueId(string $uniqueId): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $memberId
 	 */
 	public function limitToMemberId(string $memberId): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $status
 	 */
 	public function limitToStatus(string $status): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $type
 	 */
 	public function limitToType(int $type): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $type
 	 */
 	public function limitToTypeString(string $type): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $token
 	 */
 	public function limitToToken(string $token): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -169,8 +169,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws Exception
 	 */
 	public function limitToCreation(int $delay = 0): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -179,8 +179,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $orNull
 	 */
 	public function limitToDBFieldDateTime(string $field, DateTime $date, bool $orNull = false): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -190,8 +190,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws DateTimeException
 	 */
 	public function limitToSince(int $timestamp, string $field): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -199,8 +199,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $value
 	 */
 	public function searchInDBField(string $field, string $value): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -210,8 +210,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function like(string $field, string $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -221,8 +221,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function limit(string $field, string $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -230,8 +230,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function limitInt(string $field, int $value, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -239,8 +239,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function limitBool(string $field, bool $value, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -248,8 +248,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function limitEmpty(string $field, bool $orNull = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -257,8 +257,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function limitNull(string $field, bool $orEmpty = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -267,8 +267,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function limitArray(string $field, array $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -277,8 +277,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param int $type
 	 */
 	public function limitInArray(string $field, array $value, string $alias = '', int $type = IQueryBuilder::PARAM_STR_ARRAY): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -286,8 +286,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function limitBitwise(string $field, int $flag, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -296,8 +296,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function gt(string $field, int $value, bool $gte = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -306,8 +306,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function lt(string $field, int $value, bool $lte = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -319,16 +319,16 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprLike(string $field, string $value, string $alias = '', bool $cs = true): string
- {
- }
+    {
+    }
 
 	public function exprLimit(string $field, string $value, string $alias = '', bool $cs = true): string
- {
- }
+    {
+    }
 
 	public function exprLimitInt(string $field, int $value, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -339,8 +339,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprLimitBool(string $field, bool $value, string $alias = ''): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -350,8 +350,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprLimitEmpty(string $field, bool $orNull = false, string $alias = ''): ICompositeExpression
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -361,8 +361,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprLimitNull(string $field, bool $orEmpty = false, string $alias = ''): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
@@ -374,8 +374,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprLimitArray(string $field, array $values, string $alias = '', bool $cs = true): ICompositeExpression
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -386,8 +386,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprLimitInArray(string $field, array $values, string $alias = '', int $type = IQueryBuilder::PARAM_STR_ARRAY): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -398,8 +398,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprLimitBitwise(string $field, int $flag, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -411,8 +411,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprLt(string $field, int $value, bool $lte = false, string $alias = ''): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -423,8 +423,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprGt(string $field, int $value, bool $gte = false, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -434,8 +434,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function unlike(string $field, string $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -445,8 +445,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function filter(string $field, string $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -454,8 +454,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterInt(string $field, int $value, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -463,8 +463,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterBool(string $field, bool $value, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -472,8 +472,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterEmpty(string $field, bool $norNull = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -481,8 +481,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterNull(string $field, bool $norEmpty = false, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -491,8 +491,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param bool $cs
 	 */
 	public function filterArray(string $field, array $value, string $alias = '', bool $cs = true): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -500,8 +500,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterInArray(string $field, array $value, string $alias = ''): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -509,8 +509,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @param string $alias
 	 */
 	public function filterBitwise(string $field, int $flag, string $alias = ''): void
- {
- }
+    {
+    }
 
 
 	/**
@@ -522,8 +522,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprUnlike(string $field, string $value, string $alias = '', bool $cs = true): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -535,8 +535,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprFilter(string $field, string $value, string $alias = '', bool $cs = true): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -547,8 +547,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprFilterInt(string $field, int $value, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -559,8 +559,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprFilterBool(string $field, bool $value, string $alias = ''): string
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -570,8 +570,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprFilterEmpty(string $field, bool $norNull = false, string $alias = ''): ICompositeExpression
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -581,8 +581,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprFilterNull(string $field, bool $norEmpty = false, string $alias = ''): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
@@ -594,8 +594,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return ICompositeExpression
 	 */
 	public function exprFilterArray(string $field, array $values, string $alias = '', bool $cs = true): ICompositeExpression
- {
- }
+    {
+    }
 
 
 	/**
@@ -606,8 +606,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprFilterInArray(string $field, array $values, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -618,8 +618,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return string
 	 */
 	public function exprFilterBitwise(string $field, int $flag, string $alias = ''): string
- {
- }
+    {
+    }
 
 
 	/**
@@ -631,8 +631,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws InvalidItemException
 	 */
 	public function asItem(string $object, array $params = []): IQueryRow
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $object
@@ -641,8 +641,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return list<IQueryRow>
 	 */
 	public function asItems(string $object, array $params = []): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -654,8 +654,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws RowNotFoundException
 	 */
 	public function asItemFromField(string $field, array $params = []): IQueryRow
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $field
@@ -664,8 +664,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return IQueryRow[]
 	 */
 	public function asItemsFromField(string $field, array $params = []): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -677,8 +677,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @throws RowNotFoundException
 	 */
 	public function getRow(callable $method, string $object = '', array $params = []): IQueryRow
- {
- }
+    {
+    }
 
 
 	/**
@@ -689,8 +689,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return list<IQueryRow>
 	 */
 	public function getRows(callable $method, string $object = '', array $params = []): array
- {
- }
+    {
+    }
 
 
 	/**
@@ -701,8 +701,8 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return $this
 	 */
 	public function generateSelect(string $table, array $fields, string $alias = ''): self
- {
- }
+    {
+    }
 
 
 	/**
@@ -714,6 +714,6 @@ class ExtendedQueryBuilder extends QueryBuilder {
 	 * @return $this
 	 */
 	public function generateSelectAlias(array $fields, string $alias, string $prefix, array $default = []): self
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_tools_db_iqueryrow.php
+++ b/tests/stubs/oca_circles_tools_db_iqueryrow.php
@@ -25,6 +25,6 @@ interface IQueryRow {
 	 * @return IQueryRow
 	 */
 	public function importFromDatabase(array $data): self
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_circles_tools_ideserializable.php
+++ b/tests/stubs/oca_circles_tools_ideserializable.php
@@ -18,6 +18,6 @@ interface IDeserializable {
 	 * @return self
 	 */
 	public function import(array $data): self
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_dav_connector_sabre_directory.php
+++ b/tests/stubs/oca_dav_connector_sabre_directory.php
@@ -7,7 +7,6 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
-use OC\Files\Mount\MoveableMount;
 use OC\Files\Utils\PathHelper;
 use OC\Files\View;
 use OCA\DAV\AppInfo\Application;
@@ -22,6 +21,7 @@ use OCP\Files\Folder;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMovableMount;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
@@ -51,8 +51,8 @@ class Directory extends Node implements
 	 * Sets up the node, expects a full path name
 	 */
 	public function __construct(View $view, FileInfo $info, private ?CachingTree $tree = null, ?IShareManager $shareManager = null)
- {
- }
+    {
+    }
 
 	/**
 	 * Creates a new file in the directory
@@ -86,9 +86,10 @@ class Directory extends Node implements
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
-	public function createFile($name, $data = null)
- {
- }
+	#[\Override]
+    public function createFile($name, $data = null)
+    {
+    }
 
 	/**
 	 * Creates a new subdirectory
@@ -99,9 +100,10 @@ class Directory extends Node implements
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
-	public function createDirectory($name)
- {
- }
+	#[\Override]
+    public function createDirectory($name)
+    {
+    }
 
 	/**
 	 * Returns a specific child node, referenced by its name
@@ -113,9 +115,10 @@ class Directory extends Node implements
 	 * @throws \Sabre\DAV\Exception\NotFound
 	 * @throws \Sabre\DAV\Exception\ServiceUnavailable
 	 */
-	public function getChild($name, $info = null, ?IRequest $request = null, ?IL10N $l10n = null)
- {
- }
+	#[\Override]
+    public function getChild($name, $info = null, ?IRequest $request = null, ?IL10N $l10n = null)
+    {
+    }
 
 	/**
 	 * Returns an array with all the child nodes
@@ -124,9 +127,10 @@ class Directory extends Node implements
 	 * @throws \Sabre\DAV\Exception\Locked
 	 * @throws Forbidden
 	 */
-	public function getChildren()
- {
- }
+	#[\Override]
+    public function getChildren()
+    {
+    }
 
 	/**
 	 * Checks if a child exists.
@@ -134,9 +138,10 @@ class Directory extends Node implements
 	 * @param string $name
 	 * @return bool
 	 */
-	public function childExists($name)
- {
- }
+	#[\Override]
+    public function childExists($name)
+    {
+    }
 
 	/**
 	 * Deletes all files in this directory, and then itself
@@ -145,18 +150,20 @@ class Directory extends Node implements
 	 * @throws FileLocked
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 */
-	public function delete()
- {
- }
+	#[\Override]
+    public function delete()
+    {
+    }
 
 	/**
 	 * Returns available diskspace information
 	 *
 	 * @return array
 	 */
-	public function getQuotaInfo()
- {
- }
+	#[\Override]
+    public function getQuotaInfo()
+    {
+    }
 
 	/**
 	 * Moves a node into this collection.
@@ -183,20 +190,24 @@ class Directory extends Node implements
 	 * @throws FileLocked
 	 * @throws \Sabre\DAV\Exception\Forbidden
 	 */
-	public function moveInto($targetName, $fullSourcePath, INode $sourceNode)
- {
- }
+	#[\Override]
+    public function moveInto($targetName, $fullSourcePath, INode $sourceNode)
+    {
+    }
 
 
-	public function copyInto($targetName, $sourcePath, INode $sourceNode)
- {
- }
+	#[\Override]
+    public function copyInto($targetName, $sourcePath, INode $sourceNode)
+    {
+    }
 
-	public function getNode(): Folder
- {
- }
+	#[\Override]
+    public function getNode(): Folder
+    {
+    }
 
-	public function getNodeForPath($path): INode
- {
- }
+	#[\Override]
+    public function getNodeForPath($path): INode
+    {
+    }
 }

--- a/tests/stubs/oca_dav_connector_sabre_exception_forbidden.php
+++ b/tests/stubs/oca_dav_connector_sabre_exception_forbidden.php
@@ -16,8 +16,8 @@ class Forbidden extends \Sabre\DAV\Exception\Forbidden {
 	 * @param \Exception $previous
 	 */
 	public function __construct($message, private $retry = false, ?\Exception $previous = null)
- {
- }
+    {
+    }
 
 	/**
 	 * This method allows the exception to include additional information
@@ -27,7 +27,8 @@ class Forbidden extends \Sabre\DAV\Exception\Forbidden {
 	 * @param \DOMElement $errorNode
 	 * @return void
 	 */
-	public function serialize(\Sabre\DAV\Server $server, \DOMElement $errorNode)
- {
- }
+	#[\Override]
+    public function serialize(\Sabre\DAV\Server $server, \DOMElement $errorNode)
+    {
+    }
 }

--- a/tests/stubs/oca_dav_connector_sabre_node.php
+++ b/tests/stubs/oca_dav_connector_sabre_node.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\Connector\Sabre;
 
-use OC\Files\Mount\MoveableMount;
 use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\Files\View;
@@ -19,6 +18,7 @@ use OCP\Files\DavUtil;
 use OCP\Files\FileInfo;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMovableMount;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\StorageNotAvailableException;
@@ -51,37 +51,38 @@ abstract class Node implements INode {
 	 * @throws PreConditionNotMetException
 	 */
 	public function __construct(protected View $fileView, FileInfo $info, ?IManager $shareManager = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Exception
 	 * @throws PreConditionNotMetException
 	 */
 	protected function refreshInfo(): void
- {
- }
+    {
+    }
 
 	/**
 	 *  Returns the name of the node
 	 */
-	public function getName(): string
- {
- }
+	#[\Override]
+    public function getName(): string
+    {
+    }
 
 	/**
 	 * Returns the full path
 	 */
 	public function getPath(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Check if this node can be renamed
 	 */
 	public function canRename(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Renames the node
@@ -93,18 +94,20 @@ abstract class Node implements INode {
 	 * @throws PreConditionNotMetException
 	 * @throws LockedException
 	 */
-	public function setName($name): void
- {
- }
+	#[\Override]
+    public function setName($name): void
+    {
+    }
 
 	/**
 	 * Returns the last modification time, as a unix timestamp
 	 *
 	 * @return int timestamp as integer
 	 */
-	public function getLastModified(): int
- {
- }
+	#[\Override]
+    public function getLastModified(): int
+    {
+    }
 
 	/**
 	 *  sets the last modification time of the file (mtime) to the value given
@@ -112,8 +115,8 @@ abstract class Node implements INode {
 	 *  Even if the modification time is set to a custom value the access time is set to now.
 	 */
 	public function touch(string $mtime): void
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the ETag for a file
@@ -125,8 +128,8 @@ abstract class Node implements INode {
 	 * Return null if the ETag can not effectively be determined
 	 */
 	public function getETag(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Sets the ETag
@@ -134,12 +137,12 @@ abstract class Node implements INode {
 	 * @return int file id of updated file or -1 on failure
 	 */
 	public function setETag(string $etag): int
- {
- }
+    {
+    }
 
 	public function setCreationTime(int $time): int
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the size of the node, in bytes
@@ -148,95 +151,95 @@ abstract class Node implements INode {
 	 * @psalm-suppress ImplementedReturnTypeMismatch \Sabre\DAV\IFile::getSize signature does not support 32bit
 	 */
 	public function getSize(): int|float
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the cache's file id
 	 */
 	public function getId(): ?int
- {
- }
+    {
+    }
 
 	public function getFileId(): ?string
- {
- }
+    {
+    }
 
 	public function getInternalFileId(): ?int
- {
- }
+    {
+    }
 
 	public function getInternalPath(): string
- {
- }
+    {
+    }
 
 	public function getSharePermissions(?string $user): int
- {
- }
+    {
+    }
 
 	public function getShareAttributes(): array
- {
- }
+    {
+    }
 
 	public function getNoteFromShare(?string $user): ?string
- {
- }
+    {
+    }
 
 	public function getDavPermissions(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the DAV Permissions with share and mount infromation stripped.
 	 */
 	public function getPublicDavPermissions(): string
- {
- }
+    {
+    }
 
 	public function getOwner(): ?IUser
- {
- }
+    {
+    }
 
 	/**
 	 * @throws InvalidPath
 	 */
 	protected function verifyPath(?string $path = null): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param ILockingProvider::LOCK_* $type
 	 * @throws LockedException
 	 */
 	public function acquireLock($type): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param ILockingProvider::LOCK_* $type
 	 * @throws LockedException
 	 */
 	public function releaseLock($type): void
- {
- }
+    {
+    }
 
 	/**
 	 * @param ILockingProvider::LOCK_* $type
 	 * @throws LockedException
 	 */
 	public function changeLock($type): void
- {
- }
+    {
+    }
 
 	public function getFileInfo(): FileInfo
- {
- }
+    {
+    }
 
 	public function getNode(): \OCP\Files\Node
- {
- }
+    {
+    }
 
 	protected function sanitizeMtime(string $mtimeFromRequest): int
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_dav_connector_sabre_principal.php
+++ b/tests/stubs/oca_dav_connector_sabre_principal.php
@@ -34,8 +34,8 @@ use Sabre\DAVACL\PrincipalBackend\BackendInterface;
 class Principal implements BackendInterface {
 
 	public function __construct(private IUserManager $userManager, private IGroupManager $groupManager, private IAccountManager $accountManager, private IShareManager $shareManager, private IUserSession $userSession, private IAppManager $appManager, private ProxyMapper $proxyMapper, private KnownUserService $knownUserService, private IConfig $config, private IFactory $languageFactory, string $principalPrefix = 'principals/users/')
- {
- }
+    {
+    }
 
 	use PrincipalProxyTrait {
 		getGroupMembership as protected traitGetGroupMembership;
@@ -54,9 +54,10 @@ class Principal implements BackendInterface {
 	 * @param string $prefixPath
 	 * @return string[]
 	 */
-	public function getPrincipalsByPrefix($prefixPath)
- {
- }
+	#[\Override]
+    public function getPrincipalsByPrefix($prefixPath)
+    {
+    }
 
 	/**
 	 * Returns a specific principal, specified by it's path.
@@ -66,9 +67,10 @@ class Principal implements BackendInterface {
 	 * @param string $path
 	 * @return array
 	 */
-	public function getPrincipalByPath($path)
- {
- }
+	#[\Override]
+    public function getPrincipalByPath($path)
+    {
+    }
 
 	/**
 	 * Returns a specific principal, specified by its path.
@@ -82,8 +84,8 @@ class Principal implements BackendInterface {
 	 * @param string[]|null $propertyFilter A list of properties to be retrieved or all if null. An empty array will cause a very shallow principal to be retrieved.
 	 */
 	public function getPrincipalPropertiesByPath($path, ?array $propertyFilter = null): ?array
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the list of groups a principal is a member of
@@ -93,18 +95,20 @@ class Principal implements BackendInterface {
 	 * @return array
 	 * @throws Exception
 	 */
-	public function getGroupMembership($principal, $needGroups = false)
- {
- }
+	#[\Override]
+    public function getGroupMembership($principal, $needGroups = false)
+    {
+    }
 
 	/**
 	 * @param string $path
 	 * @param PropPatch $propPatch
 	 * @return int
 	 */
-	public function updatePrincipal($path, PropPatch $propPatch)
- {
- }
+	#[\Override]
+    public function updatePrincipal($path, PropPatch $propPatch)
+    {
+    }
 
 	/**
 	 * Search user principals
@@ -114,8 +118,8 @@ class Principal implements BackendInterface {
 	 * @return array
 	 */
 	protected function searchUserPrincipals(array $searchProperties, $test = 'allof')
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $prefixPath
@@ -123,18 +127,20 @@ class Principal implements BackendInterface {
 	 * @param string $test
 	 * @return array
 	 */
-	public function searchPrincipals($prefixPath, array $searchProperties, $test = 'allof')
- {
- }
+	#[\Override]
+    public function searchPrincipals($prefixPath, array $searchProperties, $test = 'allof')
+    {
+    }
 
 	/**
 	 * @param string $uri
 	 * @param string $principalPrefix
 	 * @return string
 	 */
-	public function findByUri($uri, $principalPrefix)
- {
- }
+	#[\Override]
+    public function findByUri($uri, $principalPrefix)
+    {
+    }
 
 	/**
 	 * @param IUser $user
@@ -143,20 +149,20 @@ class Principal implements BackendInterface {
 	 * @throws PropertyDoesNotExistException
 	 */
 	protected function userToPrincipal($user, ?array $propertyFilter = null)
- {
- }
+    {
+    }
 
 	public function getPrincipalPrefix()
- {
- }
+    {
+    }
 
 	/**
 	 * @param string $circleUniqueId
 	 * @return array|null
 	 */
 	protected function circleToPrincipal($circleUniqueId)
- {
- }
+    {
+    }
 
 	/**
 	 * Returns the list of circles a principal is a member of
@@ -168,8 +174,8 @@ class Principal implements BackendInterface {
 	 * @suppress PhanUndeclaredClassMethod
 	 */
 	public function getCircleMembership($principal): array
- {
- }
+    {
+    }
 
 	/**
 	 * Get all email addresses associated to a principal.
@@ -178,6 +184,6 @@ class Principal implements BackendInterface {
 	 * @return string[] All email addresses without the mailto: prefix
 	 */
 	public function getEmailAddressesOfPrincipal(array $principal): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_sharing_event_beforetemplaterenderedevent.php
+++ b/tests/stubs/oca_files_sharing_event_beforetemplaterenderedevent.php
@@ -27,20 +27,20 @@ class BeforeTemplateRenderedEvent extends Event {
 	 * @since 20.0.0
 	 */
 	public function __construct(private IShare $share, private ?string $scope = null)
- {
- }
+    {
+    }
 
 	/**
 	 * @since 20.0.0
 	 */
 	public function getShare(): IShare
- {
- }
+    {
+    }
 
 	/**
 	 * @since 20.0.0
 	 */
 	public function getScope(): ?string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_trashbin_expiration.php
+++ b/tests/stubs/oca_files_trashbin_expiration.php
@@ -17,20 +17,20 @@ class Expiration {
 	public const NO_OBLIGATION = -1;
 
 	public function __construct(IConfig $config, private ITimeFactory $timeFactory)
- {
- }
+    {
+    }
 
 	public function setRetentionObligation(string $obligation)
- {
- }
+    {
+    }
 
 	/**
 	 * Is trashbin expiration enabled
 	 * @return bool
 	 */
 	public function isEnabled()
- {
- }
+    {
+    }
 
 	/**
 	 * Check if given timestamp in expiration range
@@ -39,8 +39,8 @@ class Expiration {
 	 * @return bool
 	 */
 	public function isExpired($timestamp, $quotaExceeded = false)
- {
- }
+    {
+    }
 
 	/**
 	 * Get minimal retention obligation as a timestamp
@@ -48,13 +48,13 @@ class Expiration {
 	 * @return int|false
 	 */
 	public function getMinAgeAsTimestamp()
- {
- }
+    {
+    }
 
 	/**
 	 * @return bool|int
 	 */
 	public function getMaxAgeAsTimestamp()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_trashbin_storage.php
+++ b/tests/stubs/oca_files_trashbin_storage.php
@@ -28,24 +28,26 @@ class Storage extends Wrapper {
 	 * @param array $parameters
 	 */
 	public function __construct($parameters, private ?ITrashManager $trashManager = null, private ?IUserManager $userManager = null, private ?LoggerInterface $logger = null, private ?IEventDispatcher $eventDispatcher = null, private ?IRootFolder $rootFolder = null, private ?IRequest $request = null)
- {
- }
+    {
+    }
 
-	public function unlink(string $path): bool
- {
- }
+	#[\Override]
+    public function unlink(string $path): bool
+    {
+    }
 
-	public function rmdir(string $path): bool
- {
- }
+	#[\Override]
+    public function rmdir(string $path): bool
+    {
+    }
 
 	/**
 	 * check if it is a file located in data/user/files only files in the
 	 * 'files' directory should be moved to the trash
 	 */
 	protected function shouldMoveToTrash(string $path): bool
- {
- }
+    {
+    }
 
 	/**
 	 * get move to trash event
@@ -54,29 +56,30 @@ class Storage extends Wrapper {
 	 * @return MoveToTrashEvent
 	 */
 	protected function createMoveToTrashEvent(Node $node): MoveToTrashEvent
- {
- }
+    {
+    }
 
 	/**
 	 * Setup the storage wrapper callback
 	 */
 	public static function setupStorage(): void
- {
- }
+    {
+    }
 
 	public function getMountPoint()
- {
- }
+    {
+    }
 
-	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
- {
- }
+	#[\Override]
+    public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool
+    {
+    }
 
 	protected function disableTrash(): void
- {
- }
+    {
+    }
 
 	protected function enableTrash(): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_trashbin_trash_itrashbackend.php
+++ b/tests/stubs/oca_files_trashbin_trash_itrashbackend.php
@@ -24,8 +24,8 @@ interface ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function listTrashRoot(IUser $user): array
- {
- }
+    {
+    }
 
 	/**
 	 * List all trash items in a subfolder in the trashbin
@@ -35,8 +35,8 @@ interface ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function listTrashFolder(ITrashItem $folder): array
- {
- }
+    {
+    }
 
 	/**
 	 * Restore a trashbin item
@@ -45,8 +45,8 @@ interface ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function restoreItem(ITrashItem $item)
- {
- }
+    {
+    }
 
 	/**
 	 * Permanently remove an item from trash
@@ -55,8 +55,8 @@ interface ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function removeItem(ITrashItem $item)
- {
- }
+    {
+    }
 
 	/**
 	 * Move a file or folder to trash
@@ -67,8 +67,8 @@ interface ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function moveToTrash(IStorage $storage, string $internalPath): bool
- {
- }
+    {
+    }
 
 	/**
 	 * @param IUser $user
@@ -76,6 +76,6 @@ interface ITrashBackend {
 	 * @return Node|null
 	 */
 	public function getTrashNodeById(IUser $user, int $fileId)
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_trashbin_trash_itrashitem.php
+++ b/tests/stubs/oca_files_trashbin_trash_itrashitem.php
@@ -22,8 +22,8 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function getTrashBackend(): ITrashBackend
- {
- }
+    {
+    }
 
 	/**
 	 * Get the original location for the trash item
@@ -32,8 +32,8 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function getOriginalLocation(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Get the timestamp that the file was moved to trash
@@ -42,8 +42,8 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function getDeletedTime(): int
- {
- }
+    {
+    }
 
 	/**
 	 * Get the path of the item relative to the users trashbin
@@ -52,8 +52,8 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function getTrashPath(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Whether the item is a deleted item in the root of the trash, or a file in a subfolder
@@ -62,8 +62,8 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function isRootItem(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Get the user for which this trash item applies
@@ -72,17 +72,17 @@ interface ITrashItem extends FileInfo {
 	 * @since 15.0.0
 	 */
 	public function getUser(): IUser
- {
- }
+    {
+    }
 
 	/**
 	 * @since 30.0.0
 	 */
 	public function getDeletedBy(): ?IUser
- {
- }
+    {
+    }
 
 	public function getTitle(): string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_trashbin_trash_trashitem.php
+++ b/tests/stubs/oca_files_trashbin_trash_trashitem.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Trashbin\Trash;
 
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\IUser;
 
@@ -22,155 +23,197 @@ class TrashItem implements ITrashItem {
 	) {
 	}
 
-	public function getTrashBackend(): ITrashBackend
- {
- }
+	#[\Override]
+    public function getTrashBackend(): ITrashBackend
+    {
+    }
 
-	public function getOriginalLocation(): string
- {
- }
+	#[\Override]
+    public function getOriginalLocation(): string
+    {
+    }
 
-	public function getDeletedTime(): int
- {
- }
+	#[\Override]
+    public function getDeletedTime(): int
+    {
+    }
 
-	public function getTrashPath(): string
- {
- }
+	#[\Override]
+    public function getTrashPath(): string
+    {
+    }
 
-	public function isRootItem(): bool
- {
- }
+	#[\Override]
+    public function isRootItem(): bool
+    {
+    }
 
-	public function getUser(): IUser
- {
- }
+	#[\Override]
+    public function getUser(): IUser
+    {
+    }
 
-	public function getEtag()
- {
- }
+	#[\Override]
+    public function getEtag()
+    {
+    }
 
-	public function getSize($includeMounts = true)
- {
- }
+	#[\Override]
+    public function getSize($includeMounts = true)
+    {
+    }
 
-	public function getMtime()
- {
- }
+	#[\Override]
+    public function getMtime()
+    {
+    }
 
-	public function getName()
- {
- }
+	#[\Override]
+    public function getName()
+    {
+    }
 
-	public function getInternalPath()
- {
- }
+	#[\Override]
+    public function getInternalPath()
+    {
+    }
 
-	public function getPath()
- {
- }
+	#[\Override]
+    public function getPath()
+    {
+    }
 
-	public function getMimetype(): string
- {
- }
+	#[\Override]
+    public function getMimetype(): string
+    {
+    }
 
-	public function getMimePart()
- {
- }
+	#[\Override]
+    public function getMimePart()
+    {
+    }
 
-	public function getStorage()
- {
- }
+	#[\Override]
+    public function getStorage()
+    {
+    }
 
-	public function getId()
- {
- }
+	#[\Override]
+    public function getId()
+    {
+    }
 
-	public function isEncrypted()
- {
- }
+	#[\Override]
+    public function isEncrypted()
+    {
+    }
 
-	public function getPermissions()
- {
- }
+	#[\Override]
+    public function getPermissions()
+    {
+    }
 
-	public function getType()
- {
- }
+	#[\Override]
+    public function getType()
+    {
+    }
 
-	public function isReadable()
- {
- }
+	#[\Override]
+    public function isReadable()
+    {
+    }
 
-	public function isUpdateable()
- {
- }
+	#[\Override]
+    public function isUpdateable()
+    {
+    }
 
-	public function isCreatable()
- {
- }
+	#[\Override]
+    public function isCreatable()
+    {
+    }
 
-	public function isDeletable()
- {
- }
+	#[\Override]
+    public function isDeletable()
+    {
+    }
 
-	public function isShareable()
- {
- }
+	#[\Override]
+    public function isShareable()
+    {
+    }
 
-	public function isShared()
- {
- }
+	#[\Override]
+    public function isShared()
+    {
+    }
 
-	public function isMounted()
- {
- }
+	#[\Override]
+    public function isMounted()
+    {
+    }
 
-	public function getMountPoint()
- {
- }
+	#[\Override]
+    public function getMountPoint()
+    {
+    }
 
-	public function getOwner()
- {
- }
+	#[\Override]
+    public function getOwner()
+    {
+    }
 
-	public function getChecksum()
- {
- }
+	#[\Override]
+    public function getChecksum()
+    {
+    }
 
-	public function getExtension(): string
- {
- }
+	#[\Override]
+    public function getExtension(): string
+    {
+    }
 
-	public function getTitle(): string
- {
- }
+	#[\Override]
+    public function getTitle(): string
+    {
+    }
 
-	public function getCreationTime(): int
- {
- }
+	#[\Override]
+    public function getCreationTime(): int
+    {
+    }
 
-	public function getUploadTime(): int
- {
- }
+	#[\Override]
+    public function getUploadTime(): int
+    {
+    }
 
-	public function getLastActivity(): int
- {
- }
+	#[\Override]
+    public function getLastActivity(): int
+    {
+    }
 
-	public function getParentId(): int
- {
- }
+	#[\Override]
+    public function getParentId(): int
+    {
+    }
 
-	public function getDeletedBy(): ?IUser
- {
- }
+	#[\Override]
+    public function getDeletedBy(): ?IUser
+    {
+    }
 
 	/**
 	 * @inheritDoc
 	 * @return array<string, int|string|bool|float|string[]|int[]>
 	 */
-	public function getMetadata(): array
- {
- }
+	#[\Override]
+    public function getMetadata(): array
+    {
+    }
+
+	#[\Override]
+    public function getData(): ICacheEntry
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_expiration.php
+++ b/tests/stubs/oca_files_versions_expiration.php
@@ -17,23 +17,23 @@ class Expiration {
 	public const NO_OBLIGATION = -1;
 
 	public function __construct(IConfig $config, private ITimeFactory $timeFactory, private LoggerInterface $logger)
- {
- }
+    {
+    }
 
 	/**
 	 * Is versions expiration enabled
 	 * @return bool
 	 */
 	public function isEnabled(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Is default expiration active
 	 */
 	public function shouldAutoExpire(): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Check if given timestamp in expiration range
@@ -42,8 +42,8 @@ class Expiration {
 	 * @return bool
 	 */
 	public function isExpired(int $timestamp, bool $quotaExceeded = false): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Get minimal retention obligation as a timestamp
@@ -51,8 +51,8 @@ class Expiration {
 	 * @return int|false
 	 */
 	public function getMinAgeAsTimestamp()
- {
- }
+    {
+    }
 
 	/**
 	 * Get maximal retention obligation as a timestamp
@@ -60,6 +60,6 @@ class Expiration {
 	 * @return int|false
 	 */
 	public function getMaxAgeAsTimestamp()
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_ideletableversionbackend.php
+++ b/tests/stubs/oca_files_versions_versions_ideletableversionbackend.php
@@ -18,6 +18,6 @@ interface IDeletableVersionBackend {
 	 * @since 26.0.0
 	 */
 	public function deleteVersion(IVersion $version): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_imetadataversion.php
+++ b/tests/stubs/oca_files_versions_versions_imetadataversion.php
@@ -20,8 +20,8 @@ interface IMetadataVersion {
 	 * @since 29.0.0
 	 */
 	public function getMetadata(): array
- {
- }
+    {
+    }
 
 	/**
 	 * retrieves the metadata value from our $key param
@@ -30,6 +30,6 @@ interface IMetadataVersion {
 	 * @since 29.0.0
 	 */
 	public function getMetadataValue(string $key): ?string
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_imetadataversionbackend.php
+++ b/tests/stubs/oca_files_versions_versions_imetadataversionbackend.php
@@ -26,6 +26,6 @@ interface IMetadataVersionBackend {
 	 * @since 29.0.0
 	 */
 	public function setMetadataValue(Node $node, int $revision, string $key, string $value): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_ineedsyncversionbackend.php
+++ b/tests/stubs/oca_files_versions_versions_ineedsyncversionbackend.php
@@ -20,12 +20,12 @@ interface INeedSyncVersionBackend {
 	 * @return null|VersionEntity
 	 */
 	public function createVersionEntity(File $file)
- {
- }
+    {
+    }
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void
- {
- }
+    {
+    }
 	public function deleteVersionsEntity(File $file): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_iversion.php
+++ b/tests/stubs/oca_files_versions_versions_iversion.php
@@ -20,8 +20,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getBackend(): IVersionBackend
- {
- }
+    {
+    }
 
 	/**
 	 * Get the file info of the source file
@@ -30,8 +30,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getSourceFile(): FileInfo
- {
- }
+    {
+    }
 
 	/**
 	 * Get the id of the revision for the file
@@ -40,8 +40,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getRevisionId()
- {
- }
+    {
+    }
 
 	/**
 	 * Get the timestamp this version was created
@@ -50,8 +50,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getTimestamp(): int
- {
- }
+    {
+    }
 
 	/**
 	 * Get the size of this version
@@ -60,8 +60,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getSize(): int|float
- {
- }
+    {
+    }
 
 	/**
 	 * Get the name of the source file at the time of making this version
@@ -70,8 +70,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getSourceFileName(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Get the mimetype of this version
@@ -80,8 +80,8 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getMimeType(): string
- {
- }
+    {
+    }
 
 	/**
 	 * Get the path of this version
@@ -90,14 +90,14 @@ interface IVersion {
 	 * @since 15.0.0
 	 */
 	public function getVersionPath(): string
- {
- }
+    {
+    }
 
 	/**
 	 * @return IUser
 	 * @since 15.0.0
 	 */
 	public function getUser(): IUser
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_iversionbackend.php
+++ b/tests/stubs/oca_files_versions_versions_iversionbackend.php
@@ -29,8 +29,8 @@ interface IVersionBackend {
 	 * @since 17.0.0
 	 */
 	public function useBackendForStorage(IStorage $storage): bool
- {
- }
+    {
+    }
 
 	/**
 	 * Get all versions for a file
@@ -41,8 +41,8 @@ interface IVersionBackend {
 	 * @since 15.0.0
 	 */
 	public function getVersionsForFile(IUser $user, FileInfo $file): array
- {
- }
+    {
+    }
 
 	/**
 	 * Create a new version for a file
@@ -52,8 +52,8 @@ interface IVersionBackend {
 	 * @since 15.0.0
 	 */
 	public function createVersion(IUser $user, FileInfo $file)
- {
- }
+    {
+    }
 
 	/**
 	 * Restore this version
@@ -62,8 +62,8 @@ interface IVersionBackend {
 	 * @since 15.0.0
 	 */
 	public function rollback(IVersion $version)
- {
- }
+    {
+    }
 
 	/**
 	 * Open the file for reading
@@ -74,8 +74,8 @@ interface IVersionBackend {
 	 * @since 15.0.0
 	 */
 	public function read(IVersion $version)
- {
- }
+    {
+    }
 
 	/**
 	 * Get the preview for a specific version of a file
@@ -89,8 +89,8 @@ interface IVersionBackend {
 	 * @since 15.0.0
 	 */
 	public function getVersionFile(IUser $user, FileInfo $sourceFile, $revision): File
- {
- }
+    {
+    }
 
 	/**
 	 * Get the revision for a node
@@ -98,6 +98,6 @@ interface IVersionBackend {
 	 * @since 32.0.0
 	 */
 	public function getRevision(Node $node): int
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_iversionsimporterbackend.php
+++ b/tests/stubs/oca_files_versions_versions_iversionsimporterbackend.php
@@ -23,8 +23,8 @@ interface IVersionsImporterBackend {
 	 * @since 29.0.0
 	 */
 	public function importVersionsForFile(IUser $user, Node $source, Node $target, array $versions): void
- {
- }
+    {
+    }
 
 	/**
 	 * Clear all versions for a file
@@ -32,6 +32,6 @@ interface IVersionsImporterBackend {
 	 * @since 29.0.0
 	 */
 	public function clearVersionsForFile(IUser $user, Node $source, Node $target): void
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_files_versions_versions_version.php
+++ b/tests/stubs/oca_files_versions_versions_version.php
@@ -26,47 +26,58 @@ class Version implements IVersion, IMetadataVersion {
 	) {
 	}
 
-	public function getBackend(): IVersionBackend
- {
- }
+	#[\Override]
+    public function getBackend(): IVersionBackend
+    {
+    }
 
-	public function getSourceFile(): FileInfo
- {
- }
+	#[\Override]
+    public function getSourceFile(): FileInfo
+    {
+    }
 
-	public function getRevisionId()
- {
- }
+	#[\Override]
+    public function getRevisionId()
+    {
+    }
 
-	public function getTimestamp(): int
- {
- }
+	#[\Override]
+    public function getTimestamp(): int
+    {
+    }
 
-	public function getSize(): int|float
- {
- }
+	#[\Override]
+    public function getSize(): int|float
+    {
+    }
 
-	public function getSourceFileName(): string
- {
- }
+	#[\Override]
+    public function getSourceFileName(): string
+    {
+    }
 
-	public function getMimeType(): string
- {
- }
+	#[\Override]
+    public function getMimeType(): string
+    {
+    }
 
-	public function getVersionPath(): string
- {
- }
+	#[\Override]
+    public function getVersionPath(): string
+    {
+    }
 
-	public function getUser(): IUser
- {
- }
+	#[\Override]
+    public function getUser(): IUser
+    {
+    }
 
-	public function getMetadata(): array
- {
- }
+	#[\Override]
+    public function getMetadata(): array
+    {
+    }
 
-	public function getMetadataValue(string $key): ?string
- {
- }
+	#[\Override]
+    public function getMetadataValue(string $key): ?string
+    {
+    }
 }

--- a/tests/stubs/oca_richdocuments_db_wopi.php
+++ b/tests/stubs/oca_richdocuments_db_wopi.php
@@ -126,36 +126,36 @@ class Wopi extends Entity implements \JsonSerializable {
 	protected $tokenType = 0;
 
 	public function __construct()
- {
- }
+    {
+    }
 
 	public function hasTemplateId()
- {
- }
+    {
+    }
 
 	public function isGuest()
- {
- }
+    {
+    }
 
 	public function isRemoteToken()
- {
- }
+    {
+    }
 
 	public function getUserForFileAccess()
- {
- }
+    {
+    }
 
 	public function getHideDownload()
- {
- }
+    {
+    }
 
 	public function getDirect()
- {
- }
+    {
+    }
 
 	#[\Override]
- #[\ReturnTypeWillChange]
- public function jsonSerialize()
- {
- }
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+    }
 }

--- a/tests/stubs/oca_richdocuments_db_wopimapper.php
+++ b/tests/stubs/oca_richdocuments_db_wopimapper.php
@@ -19,8 +19,8 @@ use Psr\Log\LoggerInterface;
 /** @template-extends QBMapper<Wopi> */
 class WopiMapper extends QBMapper {
 	public function __construct(IDBConnection $db, private ISecureRandom $random, private LoggerInterface $logger, private ITimeFactory $timeFactory, private AppConfig $appConfig)
- {
- }
+    {
+    }
 
 	/**
 	 * @param int $fileId
@@ -34,16 +34,16 @@ class WopiMapper extends QBMapper {
 	 * @return Wopi
 	 */
 	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, ?string $guestDisplayname = null, $hideDownload = false, $direct = false, $templateId = 0, $share = null)
- {
- }
+    {
+    }
 
 	public function generateUserSettingsToken($fileId, $userId, $version, $serverHost)
- {
- }
+    {
+    }
 
 	public function generateInitiatorToken($uid, $remoteServer)
- {
- }
+    {
+    }
 
 	/**
 	 *
@@ -53,10 +53,12 @@ class WopiMapper extends QBMapper {
 	 * @throws ExpiredTokenException
 	 * @throws UnknownTokenException
 	 */
-	public function getPathForToken(#[\SensitiveParameter]
-		$token): Wopi
- {
- }
+	public function getPathForToken(
+        #[\SensitiveParameter]
+		$token
+    ): Wopi
+    {
+    }
 
 	/**
 	 * Given a token, validates it and
@@ -68,10 +70,12 @@ class WopiMapper extends QBMapper {
 	 * @throws UnknownTokenException
 	 * @throws ExpiredTokenException
 	 */
-	public function getWopiForToken(#[\SensitiveParameter]
-		string $token): Wopi
- {
- }
+	public function getWopiForToken(
+        #[\SensitiveParameter]
+		string $token
+    ): Wopi
+    {
+    }
 
 	/**
 	 * @param int|null $limit
@@ -80,6 +84,6 @@ class WopiMapper extends QBMapper {
 	 * @throws \OCP\DB\Exception
 	 */
 	public function getExpiredTokenIds(?int $limit = null, ?int $offset = null): array
- {
- }
+    {
+    }
 }

--- a/tests/stubs/oca_settings_service_authorizedgroupservice.php
+++ b/tests/stubs/oca_settings_service_authorizedgroupservice.php
@@ -17,6 +17,9 @@ use OCP\DB\Exception;
 use OCP\IGroup;
 use Throwable;
 
+/**
+ * @psalm-api - we cannot use final as this will break unit tests
+ */
 readonly class AuthorizedGroupService {
 	public function __construct(
 		private AuthorizedGroupMapper $mapper,
@@ -28,8 +31,8 @@ readonly class AuthorizedGroupService {
 	 * @throws Exception
 	 */
 	public function findAll(): array
- {
- }
+    {
+    }
 
 	/**
 	 * Find AuthorizedGroup by id.
@@ -38,8 +41,8 @@ readonly class AuthorizedGroupService {
 	 * @throws MultipleObjectsReturnedException
 	 */
 	public function find(int $id): ?AuthorizedGroup
- {
- }
+    {
+    }
 
 	/**
 	 * Create a new AuthorizedGroup
@@ -49,29 +52,29 @@ readonly class AuthorizedGroupService {
 	 * @throws MultipleObjectsReturnedException
 	 */
 	public function create(string $groupId, string $class): AuthorizedGroup
- {
- }
+    {
+    }
 
 	/**
 	 * @throws NotFoundException
 	 * @throws Throwable
 	 */
 	public function delete(int $id): void
- {
- }
+    {
+    }
 
 	/**
 	 * @return list<AuthorizedGroup>
 	 */
 	public function findExistingGroupsForClass(string $class): array
- {
- }
+    {
+    }
 
 	/**
 	 * @throws Throwable
 	 * @throws NotFoundException
 	 */
 	public function removeAuthorizationAssociatedTo(IGroup $group): void
- {
- }
+    {
+    }
 }


### PR DESCRIPTION
If the original location of a trash item can't be determined, base the restore target on the path instead.

This usually ends up with it placing the restored item in the root of the groupfolder.

The current broken behavior ends up trying to use `''` as the target, which ends up conflict resolving into something like `' (2)'`.