### PR TITLE
fix: Repair invalid mountpoints to make partial mounts work

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,6 +52,7 @@ Folder.
 	<repair-steps>
 		<post-migration>
 			<step>OCA\GroupFolders\Migration\WrongDefaultQuotaRepairStep</step>
+			<step>OCA\GroupFolders\Migration\TrimMountpointsRepairStep</step>
 		</post-migration>
 	</repair-steps>
 

--- a/lib/Migration/TrimMountpointsRepairStep.php
+++ b/lib/Migration/TrimMountpointsRepairStep.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use OCA\GroupFolders\Folder\FolderManager;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class TrimMountpointsRepairStep implements IRepairStep {
+	public function __construct(
+		private readonly FolderManager $manager,
+	) {
+
+	}
+
+	#[\Override]
+	public function getName(): string {
+		return 'Fix invalid Team folders mountpoints';
+	}
+
+	#[\Override]
+	public function run(IOutput $output): void {
+		foreach ($this->manager->getAllFolders() as $id => $folder) {
+			$newMountpoint = $this->manager->trimMountpoint($folder->mountPoint);
+			if ($newMountpoint !== $folder->mountPoint) {
+				$this->manager->renameFolder($id, $newMountpoint);
+			}
+		}
+	}
+}


### PR DESCRIPTION
In https://github.com/nextcloud/groupfolders/blob/ef29cca3e3dfc7e9354fe9260e98e6345d189403/lib/Mount/MountProvider.php#L286 we get a normalized path which may not match the stored mountpoint as queried in https://github.com/nextcloud/groupfolders/blob/ef29cca3e3dfc7e9354fe9260e98e6345d189403/lib/Folder/FolderManager.php#L675 due to backslashes for example.

We already prevent creating new Team folders with invalid mountpoints, but we need to make sure that all existing mountpoints are fixed in order for the queries to work as intended.