### PR TITLE
fix(api): cleanly reject duplicate group assignment

### DIFF
--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -327,6 +327,7 @@ class FolderController extends OCSController {
 	 * @param string $group Group to add access for
 	 * @return DataResponse<Http::STATUS_OK, array{success: true, folder: GroupFoldersFolder}, array{}>
 	 * @throws OCSNotFoundException Groupfolder not found
+	 * @throws OCSBadRequestException Group already assigned to this Groupfolder
 	 *
 	 * 200: Group access added successfully
 	 */
@@ -335,7 +336,11 @@ class FolderController extends OCSController {
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/groups')]
 	public function addGroup(int $id, string $group): DataResponse {
-		$this->checkedGetFolder($id);
+		$folder = $this->checkedGetFolder($id);
+
+		if (array_key_exists($group, $folder->groups)) {
+			throw new OCSBadRequestException('Group already assigned to this Groupfolder');
+		}
 
 		$this->manager->addApplicableGroup($id, $group);
 

--- a/openapi.json
+++ b/openapi.json
@@ -1501,6 +1501,34 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Group already assigned to this Groupfolder",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Current user is not logged in",
                         "content": {

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -882,6 +882,20 @@ export interface operations {
                     };
                 };
             };
+            /** @description Group already assigned to this Groupfolder */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
             /** @description Current user is not logged in */
             401: {
                 headers: {


### PR DESCRIPTION
Closes #2180.

## What

When the same group was POSTed twice to `/folders/{id}/groups`, the second request hit a UNIQUE constraint violation deep inside `FolderManager::addApplicableGroup` and surfaced as an HTML 500 page that crashed XML clients — the user could not even see *which* error happened.

## Change

Pre-check the folder's existing groups (already loaded by `checkedGetFolder` at the top of the action) and throw `OCSBadRequestException` with a clear message when the requested group is already assigned. The existing OCS framework turns that into a well-formed XML/JSON `<ocs><meta><status>failure</status>…` payload, which is what the issue asked for.

This mirrors the pattern `FolderController` already uses elsewhere — for example, duplicate mount points at `addGroupFolder` (line 229). No new exception type, no new branch in `FolderManager`.

## Verification

- `php -l lib/Controller/FolderController.php` — no syntax errors.
- I do not have a Nextcloud test bench to run the full PHPUnit suite locally; flagging that explicitly. The change is one early-return guard at the controller layer, no behavior change on the success path.
- DCO sign-off included.

## Notes

- Reviewed manually after AI-assisted drafting.