### PR TITLE
Add E2E test for searching with restricted ACL read permissions

### DIFF
--- a/cypress/e2e/groupfolders.cy.ts
+++ b/cypress/e2e/groupfolders.cy.ts
@@ -28,6 +28,12 @@ import {
 	PERMISSION_READ,
 	PERMISSION_WRITE,
 } from './groupfoldersUtils.ts'
+import {
+	currentSearchSectionCanLoadMoreResults,
+	currentSearchSectionHasResult,
+	openSearchResultsFor,
+	searchFor,
+} from './unifiedSearchUtils.ts'
 import { randHash } from '../utils/index.js'
 import { triggerActionForFile } from './files/filesUtils.ts'
 
@@ -320,6 +326,93 @@ describe('Groupfolders ACLs and trashbin behavior', () => {
 		enterFolder('folder1')
 		fileOrFolderExists('subfolder1')
 		fileOrFolderExists('subfolder2')
+	})
+
+})
+
+describe('Groupfolders ACLs and unified search behavior', () => {
+	let user1: User
+	let user2: User
+	let managerUser: User
+	let groupFolderId: string
+	let groupName: string
+	let groupFolderName: string
+
+	beforeEach(() => {
+		if (groupFolderId) {
+			deleteGroupFolder(groupFolderId)
+		}
+		groupName = `test_group_${randHash()}`
+		groupFolderName = `test_group_folder_${randHash()}`
+
+		cy.createRandomUser()
+		.then(_user => {
+			user1 = _user
+		})
+		cy.createRandomUser()
+		.then(_user => {
+			user2 = _user
+		})
+		cy.createRandomUser()
+		.then(_user => {
+			managerUser = _user
+
+			createGroup(groupName)
+			.then(() => {
+				addUserToGroup(groupName, user1.userId)
+				addUserToGroup(groupName, user2.userId)
+				addUserToGroup(groupName, managerUser.userId)
+				createGroupFolder(groupFolderName, groupName, [PERMISSION_READ, PERMISSION_WRITE, PERMISSION_DELETE])
+				.then(_groupFolderId => {
+					groupFolderId = _groupFolderId
+					enableACLPermissions(groupFolderId)
+					addACLManagerUser(groupFolderId, managerUser.userId)
+				})
+			})
+		})
+	})
+
+	it('Search for files in groupfolders with restricted read permissions', () => {
+		// Create two subfolders and twelve files alterning between subfolders
+		cy.login(managerUser)
+		cy.mkdir(managerUser, `/${groupFolderName}/subfolder1`)
+		cy.mkdir(managerUser, `/${groupFolderName}/subfolder2`)
+		// Use incremental mtimes to have a specific order in the results
+		const mtime = Date.now() / 1000
+		for (let i = 0; i < 12; i = i + 2) {
+			cy.uploadContent(managerUser, new Blob([i]), 'text/plain', `/${groupFolderName}/subfolder1/test${i}.txt`, mtime + i)
+			cy.uploadContent(managerUser, new Blob([i + 1]), 'text/plain', `/${groupFolderName}/subfolder2/test${i + 1}.txt`, mtime + i + 1)
+		}
+
+		// Set ACL permissions
+		setACLPermissions(groupFolderId, '/subfolder1', [`+${PERMISSION_READ}`], undefined, user1.userId)
+		setACLPermissions(groupFolderId, '/subfolder1', [`+${PERMISSION_READ}`], undefined, user2.userId)
+		setACLPermissions(groupFolderId, '/subfolder2', [`+${PERMISSION_READ}`], undefined, user1.userId)
+		setACLPermissions(groupFolderId, '/subfolder2', [`-${PERMISSION_READ}`], undefined, user2.userId)
+
+		// user1 can find files in both subfolders
+		cy.login(user1)
+		cy.visit('/apps/files')
+		searchFor('test')
+		openSearchResultsFor('Files')
+		currentSearchSectionHasResult(`test11.txt in ${groupFolderName}/subfolder2`)
+		currentSearchSectionHasResult(`test10.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test9.txt in ${groupFolderName}/subfolder2`)
+		currentSearchSectionHasResult(`test8.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test7.txt in ${groupFolderName}/subfolder2`)
+		currentSearchSectionCanLoadMoreResults()
+
+		// user2 can find files only in subfolder1
+		cy.login(user2)
+		cy.visit('/apps/files')
+		searchFor('test')
+		openSearchResultsFor('Files')
+		currentSearchSectionHasResult(`test10.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test8.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test6.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test4.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionHasResult(`test2.txt in ${groupFolderName}/subfolder1`)
+		currentSearchSectionCanLoadMoreResults()
 	})
 
 })

--- a/cypress/e2e/unifiedSearchUtils.ts
+++ b/cypress/e2e/unifiedSearchUtils.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Searchs for the given string in the unified search modal
+ *
+ * @param string term the term to search for
+ */
+export function searchFor(term: string) {
+	cy.get('[class="unified-search-input__input"]').type(term)
+}
+
+/**
+ * Get search results main element
+ */
+export function getUnifiedSearchResults() {
+	return cy.get('#unified-search-results')
+}
+
+/**
+ * Opens the search results list for a specific section
+ *
+ * @param string section the section
+ */
+export function openSearchResultsFor(section: string) {
+	getUnifiedSearchResults().contains('button', `More from ${section}`).click()
+}
+
+/**
+ * Get search results list for the current open section
+ */
+export function getUnifiedSearchResultsForCurrentOpenSection() {
+	return getUnifiedSearchResults().find('[class="result-items"]')
+}
+
+/**
+ * Get search results footer for the current open section
+ */
+export function getUnifiedSearchResultsFooterForCurrentOpenSection() {
+	return getUnifiedSearchResults().find('[class="result-footer"]')
+}
+
+/**
+ * Checks that the given result is found in the current open section
+ *
+ * @param string result the result in the section
+ */
+export function currentSearchSectionHasResult(result: string) {
+	getUnifiedSearchResultsForCurrentOpenSection().contains(result).should('be.visible')
+}
+
+/**
+ * Checks that more results can be loaded for the current open section
+ */
+export function currentSearchSectionCanLoadMoreResults() {
+	const loadMoreResults = getUnifiedSearchResultsFooterForCurrentOpenSection().contains('Load more results')
+	loadMoreResults.scrollIntoView()
+	loadMoreResults.should('be.visible')
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -92,7 +92,7 @@ Cypress.Commands.add('uploadFile', (user, fixture = 'image.jpg', mimeType = 'ima
  * @param {string} mimeType e.g. image/png
  * @param {string} target the target of the file relative to the user root
  */
-Cypress.Commands.add('uploadContent', (user, blob, mimeType, target) => {
+Cypress.Commands.add('uploadContent', (user, blob, mimeType, target, mtime?) => {
 	cy.clearCookies()
 		.then({ timeout: 8000 }, async () => {
 			const fileName = basename(target)
@@ -108,6 +108,7 @@ Cypress.Commands.add('uploadContent', (user, blob, mimeType, target) => {
 					data: file,
 					headers: {
 						'Content-Type': mimeType,
+						'X-OC-MTime': mtime ? `${mtime}` : undefined,
 					},
 					auth: {
 						username: user.userId,


### PR DESCRIPTION
This is a E2E test for the issue in https://github.com/nextcloud/server/issues/60306. ~~Although the issue seems to be in server itself it looks like a good use case to have an explicit test for it in the _groupfolders_ app (and even if not at least provides an easy way to test the fix :-) ).~~ This will be fixed in the _groupfolders_ app itself in https://github.com/nextcloud/groupfolders/pull/4745 and its follow up https://github.com/nextcloud/groupfolders/pull/4817 Those pull requests already include a unit test for the issue, so this E2E test may or may not be needed. Up to the maintainers :-)

It is worth noting, though, that I noticed the regression in #4745 when I rebased this pull request and the test did not pass yet ;-)

~~It will need to be kept as a draft until the issue is fixed, but the test itself is ready for review.~~
