### PR TITLE
fix: Show new folder creation on top and pagination sticky, fix basic design issues

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #groupfolders-wrapper {
-	padding: 30px;
+	padding: calc(var(--default-grid-baseline) * 10) calc(var(--default-grid-baseline) * 10) calc(var(--default-grid-baseline) * 20);
 }
 
 #groupfolders-react-root, #groupfolders-root {
@@ -22,12 +22,12 @@
 	}
 
 	th {
-		border-bottom: 1px #ddd solid;
+		border-bottom: 2px solid var(--color-border);
 		cursor: pointer;
 
 		.sort_arrow {
 			padding-left: 10px;
-			color: #888;
+			color: var(--color-text-maxcontrast);
 		}
 	}
 
@@ -126,6 +126,10 @@
 		max-width: calc(100% - 40px);
 	}
 
+	.newgroup-permissions-default {
+		padding: calc(var(--default-grid-baseline) * 2);
+	}
+
 	thead {
 		tr {
 			th {
@@ -141,11 +145,9 @@
 	tbody {
 		tr {
 			&:not(:last-child) {
-				td {
-					border-bottom: var(--color-border) 1px solid;
-				}
+				border-bottom: 1px solid var(--color-border);
 			}
-			&:not(:last-child):hover {
+			&:hover {
 				td {
 					background-color: var(--color-background-dark);
 					&:first-child {
@@ -155,14 +157,6 @@
 						border-radius: 0 6px 6px 0;
 					}
 				}
-			}
-			&:last-child {
-				td {
-					padding: 35px 0;
-				}
-			}
-			&:last-child:hover {
-				background-color: transparent;
 			}
 			td {
 				a {
@@ -181,16 +175,23 @@
     .groupfolders-pagination {
       display: flex;
       align-items: center;
+	  position: absolute;
+	  bottom: calc(var(--default-grid-baseline) * 2);
+	  right: calc(var(--default-grid-baseline) * 2);
 
       .groupfolders-pagination__list {
         display: flex;
         gap: var(--default-grid-baseline);
         justify-content: center;
+		background-color: var(--color-main-background);
+		border-radius: var(--border-radius-container);
+		padding: var(--default-grid-baseline);
       }
 
-      .groupfolders-pagination__button {
+      .groupfolders-pagination__list button {
         height: var(--default-clickable-area);
         line-height: var(--default-clickable-area);
+		margin: var(--default-grid-baseline);
       }
 
       .groupfolders-pagination__goto-page {

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -377,6 +377,31 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 				this.setState({ editingGroup: 0, editingMountPoint: 0 })
 			}}>
 			{this.showAdminDelegationForms()}
+
+			<form action="#" onSubmit={this.createRow}>
+				<input
+					className="newgroup-name"
+					value={this.state.newMountPoint}
+					placeholder={t('groupfolders', 'Folder name')}
+					onChange={(event) => {
+						this.setState({ newMountPoint: event.target.value })
+					}}/>
+				<input type="submit"
+					value={t('groupfolders', 'Create')}/>
+				<label className="newgroup-permissions-default">
+					<input
+						type="checkbox"
+						style={{ 'vertical-align': 'middle' } as React.CSSProperties}
+						value={this.state.newACLDefaultNoPermission ? 'true' : 'false'}
+						onChange={(event) => {
+							this.setState({ newACLDefaultNoPermission: event.target.checked })
+						}}/>
+					<span
+						style={{ 'vertical-align': 'middle' } as React.CSSProperties}
+					>{t('groupfolders', 'Do not grant any advanced permissions by default')}</span>
+				</label>
+			</form>
+
 			<table>
 				<thead>
 					<tr>
@@ -406,36 +431,6 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 				</thead>
 				<FlipMove typeName='tbody' enterAnimation="accordionVertical" leaveAnimation="accordionVertical">
 					{rows}
-					<tr>
-						<td>
-							<form action="#" onSubmit={this.createRow}>
-								<input
-									className="newgroup-name"
-									value={this.state.newMountPoint}
-									placeholder={t('groupfolders', 'Folder name')}
-									onChange={(event) => {
-										this.setState({ newMountPoint: event.target.value })
-									}}/>
-								<br/>
-								<label>
-									<input
-										type="checkbox"
-										style={{ 'vertical-align': 'middle' } as React.CSSProperties}
-										value={this.state.newACLDefaultNoPermission ? 'true' : 'false'}
-										onChange={(event) => {
-											this.setState({ newACLDefaultNoPermission: event.target.checked })
-										}}/>
-									<span
-										style={{ 'vertical-align': 'middle' } as React.CSSProperties}
-									>{t('groupfolders', 'Do not grant any advanced permissions by default')}</span>
-								</label>
-								<br/>
-								<input type="submit"
-									value={t('groupfolders', 'Create')}/>
-							</form>
-						</td>
-						<td colSpan={3}/>
-					</tr>
 				</FlipMove>
 			</table>
 			<nav className="groupfolders-pagination" style={{ display: 'flex', alignItems: 'center' }} aria-label={t('groupfolders', 'Pagination of team folders')}>


### PR DESCRIPTION
Just tried to keep the code changes low as the app doesn’t use Vue components. This fixes 2 specific issues as reported in our design channel:

> 1. Adding new team folders you have to scroll to the bottom of the list to reach folder creation field and button. Why can't it be in the top of the list?
> 2. Also the buttons to next page can only be reached when you first scrolled down to bottom. Please think about users with a larger number of rows.

Thanks to **KIVG** for that feedback. :) 

Before | After
-|-
<img width="1575" height="1201" alt="Screenshot From 2026-05-13 15-44-33" src="https://github.com/user-attachments/assets/20c14281-6d94-4297-8301-11d971e7dcb5" />|<img width="1575" height="1201" alt="Screenshot From 2026-05-13 15-43-39" src="https://github.com/user-attachments/assets/332f1639-b445-4ad7-9b38-1763d32b0049" />
