### PR TITLE
feat: Implement UI for enabling Team Folders SSE in Nextcloud security settings

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,6 +71,7 @@ Folder.
 
 	<settings>
 		<admin>OCA\GroupFolders\Settings\Admin</admin>
+		<admin>OCA\GroupFolders\Settings\AdminSecurity</admin>
 		<admin-section>OCA\GroupFolders\Settings\Section</admin-section>
 	</settings>
 

--- a/lib/Settings/AdminSecurity.php
+++ b/lib/Settings/AdminSecurity.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Settings;
+
+use OCA\GroupFolders\AppInfo\Application;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
+use OCP\Settings\ISettings;
+use OCP\Util;
+
+class AdminSecurity implements ISettings {
+	public function __construct(
+		private readonly IInitialState $initialState,
+		private readonly IAppConfig $appConfig,
+	) {
+	}
+
+	/**
+	 * @return TemplateResponse<Http::STATUS_OK, array{}>
+	 */
+	#[\Override]
+	public function getForm(): TemplateResponse {
+		$this->initialState->provideInitialState(
+			'server_side_encryption',
+			$this->appConfig->getValueString('core', 'encryption_enabled', 'no'),
+		);
+		$this->initialState->provideInitialState(
+			'enable_encryption',
+			$this->appConfig->getValueBool(Application::APP_ID, 'enable_encryption', false),
+		);
+
+		Util::addStyle(Application::APP_ID, Application::APP_ID . '-settings-security');
+		Util::addScript(Application::APP_ID, Application::APP_ID . '-settings-security');
+
+		return new TemplateResponse(Application::APP_ID, 'settings-security', []);
+	}
+
+	#[\Override]
+	public function getSection(): string {
+		return 'security';
+	}
+
+	#[\Override]
+	public function getPriority(): int {
+		return 12;
+	}
+}

--- a/src/components/TeamFoldersEncryption.vue
+++ b/src/components/TeamFoldersEncryption.vue
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { NcNoteCard, NcCheckboxRadioSwitch, NcSettingsSection } from '@nextcloud/vue'
+import { loadState } from '@nextcloud/initial-state'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import { showError } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+
+const serverSideEncryptionEnabled = ref<string>(loadState<string>('groupfolders', 'server_side_encryption', 'no'))
+const folderEncryptionEnabled = ref<boolean>(loadState<boolean>('groupfolders', 'enable_encryption', false))
+
+const loading = ref(false)
+
+async function handleChange(isEnabled: boolean) {
+	if (loading.value || serverSideEncryptionEnabled.value === 'no' || (folderEncryptionEnabled.value == true && isEnabled == false)) {
+		return
+	}
+	const previous = folderEncryptionEnabled.value
+	folderEncryptionEnabled.value = isEnabled
+	loading.value = true
+	try {
+		const url = generateOcsUrl('/apps/provisioning_api/api/v1/config/apps/{appId}/{key}',
+			{ appId: 'groupfolders', key: 'enable_encryption' });
+		await axios.post(url, { value: isEnabled ? 'true' : 'false' })
+	} catch {
+		folderEncryptionEnabled.value = previous
+		showError(t('groupfolders', 'Failed to update encryption setting'))
+	} finally {
+		loading.value = false
+	}
+}
+</script>
+
+<template>
+	<NcSettingsSection :name="t('groupfolders', 'Team folders encryption')">
+		<NcCheckboxRadioSwitch
+			:class="{ disabled: folderEncryptionEnabled || serverSideEncryptionEnabled === 'no' }"
+			type="switch"
+			:model-value="folderEncryptionEnabled"
+			:aria-disabled="loading || serverSideEncryptionEnabled === 'no' || folderEncryptionEnabled == true"
+			:loading="loading"
+			:description="!folderEncryptionEnabled ? t('groupfolders', 'Encrypt team folders using server-side encryption. Remember that the data cannot be accessed if the encryption key is lost.') : null"
+			@update:model-value="handleChange">
+			{{ t('groupfolders', 'Enable Team Folders encryption') }}
+		</NcCheckboxRadioSwitch>
+
+		<p v-if=" serverSideEncryptionEnabled === 'yes' && folderEncryptionEnabled == true" id="team-folders-encryption-disable-hint" class="disable-hint">
+			{{ t('groupfolders', 'Disabling team folders encryption is only possible using OCC, please refer to the documentation.') }}
+		</p>
+
+		<NcNoteCard v-if="serverSideEncryptionEnabled === 'no'" type="warning"
+			:text="t('settings', 'Team Folders encryption cannot be enabled on the server because server-side encryption is disabled.')" />
+	</NcSettingsSection>
+</template>
+
+<style scoped>
+
+.disabled {
+	opacity: .75;
+}
+
+.disabled :deep(*) {
+	cursor: not-allowed !important;
+}
+
+.disable-hint {
+	color: var(--color-text-maxcontrast);
+	padding-inline-start: 10px;
+}
+</style>

--- a/src/settings-security/index.ts
+++ b/src/settings-security/index.ts
@@ -1,0 +1,10 @@
+/*!
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createApp } from 'vue'
+import TeamFoldersEncryption from '../components/TeamFoldersEncryption.vue'
+
+const app = createApp(TeamFoldersEncryption)
+app.mount('#groupfolders-settings-section')

--- a/templates/settings-security.php
+++ b/templates/settings-security.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+<div id="groupfolders-settings-section"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path'
 export default createAppConfig({
 	initFiles: join(__dirname, 'src/init-files.ts'),
 	settings: join(__dirname, 'src/settings/index.tsx'),
+	'settings-security': join(__dirname, 'src/settings-security/index.ts'),
 }, {
 	createEmptyCSSEntryPoints: true,
 	emptyOutputDirectory: {


### PR DESCRIPTION
### ☑️ Resolves

- #2899 

### Summary

This PR adds a UI in the Nextcloud security settings to manage Server-Side Encryption (SSE) for Team Folders.

The goal is to make SSE for Team Folders more accessible and centralized from the security settings page instead of relying only on OCC method.


### Notes

- Enabling SSE for Team Folders from the UI is only possible when SSE is already enabled.
- Disabling SSE for Team Folders from the UI is intentionally not supported, similar to the existing global SSE enablement behavior.
- Disabling SSE for Team Folders remains possible through the OCC command.
- Translations have not yet been submitted to Transifex

Suggestions are welcome.
