### PR TITLE
fix: properly distinguish unset ACL rules in UI

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -8,7 +8,7 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionRadio from '@nextcloud/vue/components/NcActionRadio'
 import { computed } from 'vue'
-import { mdiCancel, mdiCheck } from '@mdi/js'
+import { mdiCancel, mdiCheck, mdiMinus } from '@mdi/js'
 import { t } from '@nextcloud/l10n'
 import { NcIconSvgWrapper } from '@nextcloud/vue'
 import { STATES } from '../model/AclButtonStates'
@@ -21,13 +21,29 @@ const props = defineProps<{
 }>()
 
 const isAllowed = computed(() => state.value === STATES.INHERIT_ALLOW || state.value === STATES.SELF_ALLOW)
-const inheritedValue = computed(() => (state.value === STATES.INHERIT_ALLOW || state.value === STATES.INHERIT_DENY)
+const inheritedValue = computed(() => (state.value === STATES.INHERIT_DEFAULT || state.value === STATES.INHERIT_ALLOW || state.value === STATES.INHERIT_DENY)
 	? state.value
 	: -1
 )
 
+const icon = computed(() => {
+	switch (state.value) {
+	case STATES.INHERIT_DEFAULT:
+		return mdiMinus
+	case STATES.SELF_DENY:
+	case STATES.INHERIT_DENY:
+		return mdiCancel
+	case STATES.SELF_ALLOW:
+	case STATES.INHERIT_ALLOW:
+		return mdiCheck
+	}
+	return ''
+})
+
 const label = computed(() => {
 	switch (state.value) {
+	case STATES.INHERIT_DEFAULT:
+		return t('groupfolders', 'Unset')
 	case STATES.INHERIT_DENY:
 		return t('groupfolders', 'Denied (Inherited permission)')
 	case STATES.INHERIT_ALLOW:
@@ -64,7 +80,7 @@ const label = computed(() => {
 		<NcActions :aria-label="label" :title="label">
 			<template #icon>
 				<NcIconSvgWrapper :class="{ [$style.AclStateButton_inherited]: inherited }"
-					:path="isAllowed ? mdiCheck : mdiCancel" />
+					:path="icon" />
 			</template>
 			<NcActionRadio name="state"
 				v-model="state"

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -82,8 +82,10 @@ function getState(permission: number, item) {
 	// check if not inherited the permission
 	if ((permission & ~item.mask) === 0) {
 		return ((permission & item.permissions) > 0) ? STATES.SELF_ALLOW : STATES.SELF_DENY
-	} else {
+	} else if ((permission & ~item.inheritedMask) === 0) {
 		return ((permission & item.inheritedPermissions) > 0) ? STATES.INHERIT_ALLOW : STATES.INHERIT_DENY
+	} else {
+		return STATES.INHERIT_DEFAULT
 	}
 }
 

--- a/src/model/AclButtonStates.ts
+++ b/src/model/AclButtonStates.ts
@@ -6,6 +6,7 @@
 export const STATES = {
 	INHERIT_DENY: 0,
 	INHERIT_ALLOW: 1,
+	INHERIT_DEFAULT: 4,
 	SELF_DENY: 2,
 	SELF_ALLOW: 3,
 }

--- a/src/services/acl.ts
+++ b/src/services/acl.ts
@@ -122,6 +122,8 @@ function parseAclProps(props: Record<typeof AclRootProperties[keyof typeof AclRo
 			const inheritedRule = inheritedAclList.find((r) => r.getUniqueMappingIdentifier() === rule.getUniqueMappingIdentifier())
 			if (inheritedRule) {
 				rule.permissions = (rule.permissions & rule.mask) | (inheritedRule.permissions & ~rule.mask)
+				rule.inheritedPermissions = inheritedRule.permissions
+				rule.inheritedMask = inheritedRule.mask
 			}
 			return rule
 		})


### PR DESCRIPTION
Currently, the UI defaults to showing "Allow (Inherited permissions)" when no permission is set or inherited for a rule. This can lead to confusion since deny permissions from another rule might apply.

<img width="452" height="50" alt="image" src="https://github.com/user-attachments/assets/dfb78518-4e2b-46d8-a2a6-c76f1066176a" />
