### PR TITLE
fix: don't show inherited rule if there is a rule overwriting it

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -13,7 +13,7 @@ import { showError } from '@nextcloud/dialogs'
 import { Permission } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { nextTick, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
@@ -48,6 +48,11 @@ const groupFolderId = ref<number>()
 const aclBasePermission = ref<number>(Permission.ALL)
 const list = ref<Rule[]>([])
 const inheritedAcls = ref<Rule[]>([])
+const notSetInheritedAcl = computed(() => {
+	return inheritedAcls
+		.value
+		.filter((rule) => list.value.find((r) => r.getUniqueMappingIdentifier() === rule.getUniqueMappingIdentifier()) === undefined)
+});
 
 // component state
 const showAclCreate = ref(false)
@@ -359,7 +364,7 @@ async function changePermission(item: Rule, permission: number, state: number) {
 				</tr>
 			</tbody>
 			<tbody v-else>
-				<tr v-for="item in [...inheritedAcls, ...list]" :key="item.mappingType + '-' + item.mappingId">
+				<tr v-for="item in [...notSetInheritedAcl, ...list]" :key="item.mappingType + '-' + item.mappingId">
 					<td :title="getFullDisplayName(item.mappingDisplayName, item.mappingType)" class="username">
 						<NcAvatar :user="item.mappingId" :is-no-user="item.mappingType !== 'user'" :size="24" />
 						<span class="hidden-visually">{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}</span>


### PR DESCRIPTION
Currently we always show all inherited ACLs as rules, even if there is an explicitly set rule on the same path that overwrites the inherited rule

Before:
<img width="345" height="162" alt="image" src="https://github.com/user-attachments/assets/8679dc49-af28-423e-a806-6e471b630876" />
(group "admin" has two rows)

After:
<img width="347" height="124" alt="image" src="https://github.com/user-attachments/assets/4f697228-f29c-4a66-98f9-14ff1bb9ecea" />

(Both screenshots with https://github.com/nextcloud/groupfolders/pull/4713 applied)