### PR TITLE
Acl UI fixes

### DIFF
--- a/src/components/AclStateButton.vue
+++ b/src/components/AclStateButton.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
 }>()
 
 const isAllowed = computed(() => state.value === STATES.INHERIT_ALLOW || state.value === STATES.SELF_ALLOW)
+const isInherited = computed(() => state.value === STATES.INHERIT_ALLOW || state.value === STATES.INHERIT_DENY || state.value === STATES.INHERIT_DEFAULT)
 const inheritedValue = computed(() => (state.value === STATES.INHERIT_DEFAULT || state.value === STATES.INHERIT_ALLOW || state.value === STATES.INHERIT_DENY)
 	? state.value
 	: -1
@@ -79,7 +80,7 @@ const label = computed(() => {
 	<div v-else>
 		<NcActions :aria-label="label" :title="label">
 			<template #icon>
-				<NcIconSvgWrapper :class="{ [$style.AclStateButton_inherited]: inherited }"
+				<NcIconSvgWrapper :class="{ [$style.AclStateButton_inherited]: isInherited || inherited }"
 					:path="icon" />
 			</template>
 			<NcActionRadio name="state"

--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -13,7 +13,7 @@ import { showError } from '@nextcloud/dialogs'
 import { Permission } from '@nextcloud/files'
 import { t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { nextTick, ref, useTemplateRef, watch } from 'vue'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 import NcAvatar from '@nextcloud/vue/components/NcAvatar'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
@@ -48,6 +48,11 @@ const groupFolderId = ref<number>()
 const aclBasePermission = ref<number>(Permission.ALL)
 const list = ref<Rule[]>([])
 const inheritedAcls = ref<Rule[]>([])
+const notSetInheritedAcl = computed(() => {
+	return inheritedAcls
+		.value
+		.filter((rule) => list.value.find((r) => r.getUniqueMappingIdentifier() === rule.getUniqueMappingIdentifier()) === undefined)
+});
 
 // component state
 const showAclCreate = ref(false)
@@ -361,7 +366,7 @@ async function changePermission(item: Rule, permission: number, state: number) {
 				</tr>
 			</tbody>
 			<tbody v-else>
-				<tr v-for="item in [...inheritedAcls, ...list]" :key="item.mappingType + '-' + item.mappingId">
+				<tr v-for="item in [...notSetInheritedAcl, ...list]" :key="item.mappingType + '-' + item.mappingId">
 					<td :title="getFullDisplayName(item.mappingDisplayName, item.mappingType)" class="username">
 						<NcAvatar :user="item.mappingId" :is-no-user="item.mappingType !== 'user'" :size="24" />
 						<span class="hidden-visually">{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}</span>


### PR DESCRIPTION
# don't show inherited rule if there is a rule overwriting it

Currently we always show all inherited ACLs as rules, even if there is an explicitly set rule on the same path that overwrites the inherited rule

Before:
<img width="345" height="162" alt="image" src="https://github.com/user-attachments/assets/8679dc49-af28-423e-a806-6e471b630876" />
(group "admin" has two rows)

After:
<img width="347" height="124" alt="image" src="https://github.com/user-attachments/assets/4f697228-f29c-4a66-98f9-14ff1bb9ecea" />

# properly style inherited ACL rules in UI

Apply the "inherited" style to individual inherited permissions, not just entire inherited rules.

Before:

<img width="337" height="51" alt="image" src="https://github.com/user-attachments/assets/b5e28e09-c78e-4350-ad19-aad4ba0aab76" />

Note how you can't tell that the last rule is inherited.

After:

<img width="352" height="48" alt="image" src="https://github.com/user-attachments/assets/7c61d990-ff54-4902-88b6-3b8599e6c6f0" />
