### PR TITLE
show ACL group/user/team name in it's own row

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -324,10 +324,15 @@ async function changePermission(item: Rule, permission: number, state: number) {
 			</thead>
 			<tbody v-if="!aclCanManage">
 				<tr>
-					<td class="username">
+					<td>
 						<NcAvatar user="admin" :size="24" />
+					</td>
+					<td class="username">
 						{{ t('groupfolders', 'You') }}
 					</td>
+				</tr>
+				<tr>
+					<td/>
 					<td class="state-column">
 						<AclStateButton :model-value="getState(Permission.READ, {
 								permissions: node.permissions,
@@ -365,12 +370,17 @@ async function changePermission(item: Rule, permission: number, state: number) {
 					</td>
 				</tr>
 			</tbody>
-			<tbody v-else>
-				<tr v-for="item in [...notSetInheritedAcl, ...list]" :key="item.mappingType + '-' + item.mappingId">
-					<td :title="getFullDisplayName(item.mappingDisplayName, item.mappingType)" class="username">
+			<tbody v-else v-for="item in [...notSetInheritedAcl, ...list]" :key="item.mappingType + '-' + item.mappingId">
+				<tr>
+					<td class="username">
 						<NcAvatar :user="item.mappingId" :is-no-user="item.mappingType !== 'user'" :size="24" />
-						<span class="hidden-visually">{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}</span>
 					</td>
+					<td class="username" colspan = 6>
+						{{ getFullDisplayName(item.mappingDisplayName, item.mappingType) }}
+					</td>
+				</tr>
+				<tr>
+					<td/>
 					<td class="state-column">
 						<AclStateButton :model-value="getState(Permission.READ, item)"
 							:inherited="item.inherited"
@@ -466,7 +476,6 @@ async function changePermission(item: Rule, permission: number, state: number) {
 	}
 
 	.groupfolder-entry .username {
-		padding: 0 8px;
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
@@ -483,6 +492,10 @@ async function changePermission(item: Rule, permission: number, state: number) {
 
 	thead th {
 		height: var(--default-clickable-area);
+	}
+
+	tbody:hover {
+		background-color: var(--color-background-dark);
 	}
 
 	thead th:first-child,


### PR DESCRIPTION
Trying to fit both the name and permission icons in the same row doesn't really work, especially with longer names.

Currently the name is only visible in the hover-text, which is bad for usability once you deal with more than one or two rules.

By giving the name it's own row there should be enough space for most names without cutting to much of.

Design can probably be tweaked a bit by someone who's better at css

Before:

<img width="317" height="282" alt="image" src="https://github.com/user-attachments/assets/1bbcdeb0-38a4-47b9-b43b-89b75b1b859a" />


After:

<img width="318" height="352" alt="image" src="https://github.com/user-attachments/assets/f5608ae9-0400-4ce1-a7fa-4126a549d157" />

requires

 - [x] https://github.com/nextcloud/groupfolders/pull/4729