### PR TITLE
perf(folder): avoid on-disk temp table when sorting folders by group count

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -159,10 +159,20 @@ class FolderManager {
 		$query->setFirstResult($offset);
 		$query->setMaxResults($limit);
 		if ($orderBy === 'groups') {
-			$query
-				->leftJoin('f', 'group_folders_groups', 'g', $query->expr()->eq('f.folder_id', 'g.folder_id'))
-				->groupBy('f.folder_id')
-				->orderBy($query->func()->count('g.applicable_id'), $order);
+			// Order by the number of groups/circles applicable to each folder.
+			//
+			// We deliberately avoid a "JOIN group_folders_groups + GROUP BY f.folder_id"
+			// here. Grouping forces the database to materialize an internal temporary
+			// table, and because the selected `options` column is a LONGTEXT that
+			// temporary table cannot use the in-memory MEMORY engine, so MariaDB/MySQL
+			// always spills it to an on-disk (Aria) temp table regardless of
+			// `tmp_table_size`. A correlated sub-query yields the same ordering without
+			// grouping the wide result set, so no temporary table is created.
+			$countSubQuery = $this->connection->getQueryBuilder();
+			$countSubQuery->select($countSubQuery->func()->count('g.applicable_id'))
+				->from('group_folders_groups', 'g')
+				->where($countSubQuery->expr()->eq('g.folder_id', 'f.folder_id'));
+			$query->orderBy($query->createFunction('(' . $countSubQuery->getSQL() . ')'), $order);
 		} else {
 			$query->orderBy($orderBy, $order);
 		}

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -13,6 +13,7 @@ use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCP\Constants;
@@ -660,5 +661,38 @@ class FolderManagerTest extends TestCase {
 		$this->assertFalse($this->manager->canManageACL($folderId, $user));
 		$this->manager->deleteUser('bob');
 		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+	}
+
+	public function testGetAllFoldersWithSizeOrderedByGroups(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+
+		// Create folders with a different number of applicable groups each.
+		$oneGroup = $this->manager->createFolder('one-group');
+		$threeGroups = $this->manager->createFolder('three-groups');
+		$twoGroups = $this->manager->createFolder('two-groups');
+
+		$this->manager->addApplicableGroup($oneGroup, 'g1');
+
+		$this->manager->addApplicableGroup($twoGroups, 'g1');
+		$this->manager->addApplicableGroup($twoGroups, 'g2');
+
+		$this->manager->addApplicableGroup($threeGroups, 'g1');
+		$this->manager->addApplicableGroup($threeGroups, 'g2');
+		$this->manager->addApplicableGroup($threeGroups, 'g3');
+
+		$ascending = array_map(
+			fn (FolderWithMappingsAndCache $folder): string => $folder->mountPoint,
+			array_values($this->manager->getAllFoldersWithSize(0, null, 'groups', 'ASC')),
+		);
+		$this->assertEquals(['one-group', 'two-groups', 'three-groups'], $ascending);
+
+		$descending = array_map(
+			fn (FolderWithMappingsAndCache $folder): string => $folder->mountPoint,
+			array_values($this->manager->getAllFoldersWithSize(0, null, 'groups', 'DESC')),
+		);
+		$this->assertEquals(['three-groups', 'two-groups', 'one-group'], $descending);
 	}
 }


### PR DESCRIPTION
## Summary

Found while working on https://github.com/nextcloud/server/pull/60932

The admin list, when sorted by the **Groups** column, calls `FolderManager::getAllFoldersWithSize($offset, $limit, 'groups', $order)`. That code path ordered folders by their applicable-group count with a `LEFT JOIN group_folders_groups + GROUP BY f.folder_id`:

```php
$query
    ->leftJoin('f', 'group_folders_groups', 'g', $query->expr()->eq('f.folder_id', 'g.folder_id'))
    ->groupBy('f.folder_id')
    ->orderBy($query->func()->count('g.applicable_id'), $order);
```

The `GROUP BY` forces the database to materialize an internal temporary table. Because `selectWithFileCache()` selects the `options` column, a `LONGTEXT`, that temporary table cannot use the in-memory `MEMORY` engine (it cannot hold TEXT/BLOB), so MariaDB/MySQL **always** spill it to an on-disk (Aria) temporary table, regardless of `tmp_table_size`, on every request that uses this sort.

### Validation (MariaDB 10.11, 3 group folders, 60k `oc_filecache` rows)

`EXPLAIN`, driving table `f`:

| | Extra |
|---|---|
| before | `Using where; Using temporary; Using filesort` |
| after | `Using where; Using filesort` |

`SHOW STATUS` around the query (`tmp_table_size = max_heap_table_size = 64M`):

| | `Created_tmp_disk_tables` |
|---|---|
| before | **1** |
| after | **0** |

Result-equivalence: the returned folder order is identical for both `ASC` and `DESC`, verified by building the query through `IQueryBuilder` against the real database.

## Tests

Adds `FolderManagerTest::testGetAllFoldersWithSizeOrderedByGroups`, which creates folders with 1/2/3 applicable groups and asserts the `'groups'` sort returns them ordered by group count (both ascending and descending).
