### PR TITLE
return results for files without rules in RuleManager

### DIFF
--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -26,10 +26,10 @@ class RuleManager {
 	}
 
 	/**
-	 * @param array{mapping_type?: 'user'|'group'|'dummy'|'circle', mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string} $data
+	 * @param array{mapping_type?: 'user'|'group'|'dummy'|'circle'|null, mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string} $data
 	 */
 	private function createRule(array $data): ?Rule {
-		if (!isset($data['mapping_type'])) {
+		if (empty($data['mapping_type'])) {
 			return null;
 		}
 		$mapping = $this->userMappingManager->mappingFromId($data['mapping_type'], $data['mapping_id']);
@@ -64,12 +64,11 @@ class RuleManager {
 		/** @var list<array{mapping_type: 'user'|'group'|'circle', mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string}> $rows */
 		$rows = $query->executeQuery()->fetchAll();
 
-		$result = [];
+		$result = array_fill_keys($fileIds, []);
 		foreach ($rows as $row) {
 			$rule = $this->createRule($row);
 			if ($rule) {
 				$fileId = (int)$row['fileid'];
-				$result[$fileId] ??= [];
 				$result[$fileId][] = $rule;
 			}
 		}
@@ -173,12 +172,10 @@ class RuleManager {
 
 		$result = [];
 		foreach ($rows as $row) {
-			if ($row['mapping_type'] !== null) {
-				$rule = $this->createRule($row);
-				if ($rule) {
-					$result[$row['path']] ??= [];
-					$result[$row['path']][] = $rule;
-				}
+			$result[$row['path']] ??= [];
+			$rule = $this->createRule($row);
+			if ($rule) {
+				$result[$row['path']][] = $rule;
 			}
 		}
 
@@ -212,9 +209,9 @@ class RuleManager {
 	 */
 	private function rulesByPath(array $rows, array $result = []): array {
 		foreach ($rows as $row) {
+			$result[$row['path']] ??= [];
 			$rule = $this->createRule($row);
 			if ($rule) {
-				$result[$row['path']] ??= [];
 				$result[$row['path']][] = $rule;
 			}
 		}
@@ -231,11 +228,11 @@ class RuleManager {
 	private function rulesByFileId(array $rows): array {
 		$result = [];
 		foreach ($rows as $row) {
+			$storageId = (int)$row['storage'];
+			$result[$storageId] ??= [];
+			$result[$storageId][$row['path']] ??= [];
 			$rule = $this->createRule($row);
 			if ($rule) {
-				$storageId = (int)$row['storage'];
-				$result[$storageId] ??= [];
-				$result[$storageId][$row['path']] ??= [];
 				$result[$storageId][$row['path']][] = $rule;
 			}
 		}

--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -148,34 +148,77 @@ class RuleManager {
 			return [];
 		}
 
-		$query = $this->connection->getQueryBuilder();
-		$query->select(['f.fileid', 'a.mapping_type', 'a.mapping_id', 'a.mask', 'a.permissions', 'f.path'])
-			->from('filecache', 'f')
-			->leftJoin('f', 'group_folders_acl', 'a', $query->expr()->eq('f.fileid', 'a.fileid'))
-			->andWhere($query->expr()->eq('f.parent', $query->createNamedParameter($parentId, IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
-			->andWhere(
-				$query->expr()->orX(
-					$query->expr()->andX(
-						$query->expr()->isNull('a.mapping_type'),
-						$query->expr()->isNull('a.mapping_id')
-					),
-					...array_map(fn (IUserMapping $userMapping): ICompositeExpression => $query->expr()->andX(
-						$query->expr()->eq('a.mapping_type', $query->createNamedParameter($userMapping->getType())),
-						$query->expr()->eq('a.mapping_id', $query->createNamedParameter($userMapping->getId()))
-					), $userMappings)
-				)
-			);
+		if ($this->connection->getShardDefinition('filecache')) {
+			$query = $this->connection->getQueryBuilder();
+			// workaround https://github.com/nextcloud/server/pull/60970
+			// the manual join we do here is the similar to the on the partition query builder would do in the background
+			$rows = $query->select('fileid', 'path')
+				->from('filecache')
+				->where($query->expr()->eq('parent', $query->createNamedParameter($parentId, IQueryBuilder::PARAM_INT)))
+				->andWhere($query->expr()->eq('storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+				->executeQuery()->fetchAll();
+			$children = [];
+			/** @var array{fileid: int|string, path: string} $row */
+			foreach ($rows as $row) {
+				$children[(int)$row['fileid']] = $row['path'];
+			}
+			$childIds = array_keys($children);
 
-		/** @var list<array{mapping_type: null|'user'|'group'|'circle', mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string, path: string}> $rows */
-		$rows = $query->executeQuery()->fetchAll();
+			$query = $this->connection->getQueryBuilder();
+			$query->select(['fileid', 'mapping_type', 'mapping_id', 'mask', 'permissions'])
+				->from('group_folders_acl')
+				->where($query->expr()->in('fileid', $query->createNamedParameter($childIds, IQueryBuilder::PARAM_INT_ARRAY)))
+				->andWhere(
+					$query->expr()->orX(
+						...array_map(fn (IUserMapping $userMapping): ICompositeExpression => $query->expr()->andX(
+							$query->expr()->eq('mapping_type', $query->createNamedParameter($userMapping->getType())),
+							$query->expr()->eq('mapping_id', $query->createNamedParameter($userMapping->getId()))
+						), $userMappings)
+					)
+				);
 
-		$result = [];
-		foreach ($rows as $row) {
-			$result[$row['path']] ??= [];
-			$rule = $this->createRule($row);
-			if ($rule) {
-				$result[$row['path']][] = $rule;
+			/** @var list<array{mapping_type: null|'user'|'group'|'circle', mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string}> $rows */
+			$rows = $query->executeQuery()->fetchAll();
+
+			$result = array_fill_keys($children, []);
+			foreach ($rows as $row) {
+				$path = $children[(int)$row['fileid']];
+				$result[$path] ??= [];
+				$rule = $this->createRule($row);
+				if ($rule) {
+					$result[$path][] = $rule;
+				}
+			}
+		} else {
+			$query = $this->connection->getQueryBuilder();
+			$query->select(['f.fileid', 'a.mapping_type', 'a.mapping_id', 'a.mask', 'a.permissions', 'f.path'])
+				->from('filecache', 'f')
+				->leftJoin('f', 'group_folders_acl', 'a', $query->expr()->eq('f.fileid', 'a.fileid'))
+				->andWhere($query->expr()->eq('f.parent', $query->createNamedParameter($parentId, IQueryBuilder::PARAM_INT)))
+				->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+				->andWhere(
+					$query->expr()->orX(
+						$query->expr()->andX(
+							$query->expr()->isNull('a.mapping_type'),
+							$query->expr()->isNull('a.mapping_id')
+						),
+						...array_map(fn (IUserMapping $userMapping): ICompositeExpression => $query->expr()->andX(
+							$query->expr()->eq('a.mapping_type', $query->createNamedParameter($userMapping->getType())),
+							$query->expr()->eq('a.mapping_id', $query->createNamedParameter($userMapping->getId()))
+						), $userMappings)
+					)
+				);
+
+			/** @var list<array{mapping_type: null|'user'|'group'|'circle', mapping_id: string, fileid: int|string, mask: int|string, permissions: int|string, path: string}> $rows */
+			$rows = $query->executeQuery()->fetchAll();
+
+			$result = [];
+			foreach ($rows as $row) {
+				$result[$row['path']] ??= [];
+				$rule = $this->createRule($row);
+				if ($rule) {
+					$result[$row['path']][] = $rule;
+				}
 			}
 		}
 

--- a/tests/ACL/RuleManagerTest.php
+++ b/tests/ACL/RuleManagerTest.php
@@ -115,8 +115,9 @@ class RuleManagerTest extends TestCase {
 		$this->ruleManager->saveRule($rule2);
 		$this->ruleManager->saveRule($rule3);
 
-		$result = $this->ruleManager->getRulesForFilesById($this->user, [10, 11]);
-		$this->assertEquals([10 => [$rule1, $rule2], 11 => [$rule3]], $result);
+		$result = $this->ruleManager->getRulesForFilesById($this->user, [10, 11, 12]);
+		ksort($result);
+		$this->assertEquals([10 => [$rule1, $rule2], 11 => [$rule3], 12 => []], $result);
 
 		// cleanup
 		$this->ruleManager->deleteRule($rule1);
@@ -128,6 +129,7 @@ class RuleManagerTest extends TestCase {
 		$storage = new Temporary([]);
 		$storage->mkdir('foo');
 		$storage->mkdir('foo/bar');
+		$storage->mkdir('foo/asd');
 		$storage->getScanner()->scan('');
 		$cache = $storage->getCache();
 		$id1 = $cache->getId('foo');
@@ -148,8 +150,9 @@ class RuleManagerTest extends TestCase {
 		$this->ruleManager->saveRule($rule1);
 		$this->ruleManager->saveRule($rule2);
 
-		$result = $this->ruleManager->getRulesForFilesByPath($this->user, $storageId, ['foo', 'foo/bar', 'foo/bar/sub']);
-		$this->assertEquals(['foo' => [$rule1], 'foo/bar' => [$rule2], 'foo/bar/sub' => []], $result);
+		$result = $this->ruleManager->getRulesForFilesByPath($this->user, $storageId, ['foo', 'foo/bar', 'foo/bar/sub', 'foo/asd']);
+		ksort($result);
+		$this->assertEquals(['foo' => [$rule1], 'foo/bar' => [$rule2], 'foo/bar/sub' => [], 'foo/asd' => []], $result);
 
 		$result = $this->ruleManager->getAllRulesForPrefix($storageId, 'foo');
 		$this->assertEquals(['foo' => [$rule1], 'foo/bar' => [$rule2]], $result);
@@ -205,6 +208,7 @@ class RuleManagerTest extends TestCase {
 		$storage->mkdir('foo');
 		$storage->mkdir('foo/bar');
 		$storage->mkdir('foo/asd');
+		$storage->mkdir('foo/foo');
 		$storage->getScanner()->scan('');
 		$cache = $storage->getCache();
 		$parentId = $cache->getId('foo');
@@ -224,7 +228,8 @@ class RuleManagerTest extends TestCase {
 		$this->ruleManager->saveRule($rule2);
 
 		$result = $this->ruleManager->getRulesForFilesByParent($this->user, $storageId, $parentId);
-		$this->assertEquals(['foo/bar' => [$rule1], 'foo/asd' => [$rule2]], $result);
+		ksort($result);
+		$this->assertEquals(['foo/bar' => [$rule1], 'foo/asd' => [$rule2], 'foo/foo' => []], $result);
 
 		// cleanup
 		$this->ruleManager->deleteRule($rule1);


### PR DESCRIPTION
Empty results are important to ensure that files without rules also get cached.

This broke with https://github.com/nextcloud/groupfolders/pull/3942