### PR TITLE
perf(acl): share one ACLManager per user per request

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -30,6 +30,19 @@ class ACLManager {
 	}
 
 	/**
+	 * Build the rule cache key.
+	 *
+	 * The cache is shared for the whole request (one ACLManager per user), so it
+	 * can hold paths from more than one storage. Paths are only unique within a
+	 * storage (folders using a separate storage restart at the storage root,
+	 * e.g. "files/", "trash/", "versions/"), so the storage id must be part of
+	 * the key to avoid cross-storage collisions.
+	 */
+	private function ruleCacheKey(int $storageId, string $path): string {
+		return $storageId . '::' . $path;
+	}
+
+	/**
 	 * Get the list of rules applicable for a set of paths
 	 *
 	 * @param string[] $paths
@@ -41,7 +54,10 @@ class ACLManager {
 		// might discard former cached entries, so we can't assume they'll stay
 		// cached, so we read everything out initially to be able to return it
 		/** @var array<string, Rule[]> $rules */
-		$rules = array_combine($paths, array_map($this->ruleCache->get(...), $paths));
+		$rules = array_combine($paths, array_map(
+			fn (string $path): ?array => $this->ruleCache->get($this->ruleCacheKey($storageId, $path)),
+			$paths,
+		));
 
 		$nonCachedPaths = array_filter($paths, fn (string $path): bool => !isset($rules[$path]));
 
@@ -49,7 +65,7 @@ class ACLManager {
 			$newRules = $this->ruleManager->getRulesForFilesByPath($this->user, $storageId, $nonCachedPaths);
 			foreach ($newRules as $path => $rulesForPath) {
 				if ($cache) {
-					$this->ruleCache->set($path, $rulesForPath);
+					$this->ruleCache->set($this->ruleCacheKey($storageId, $path), $rulesForPath);
 				}
 
 				$rules[$path] = $rulesForPath;
@@ -75,7 +91,7 @@ class ACLManager {
 		foreach ($newRules as $storageId => $paths) {
 			foreach ($paths as $path => $rulesForPath) {
 				if ($cache) {
-					$this->ruleCache->set($path, $rulesForPath);
+					$this->ruleCache->set($this->ruleCacheKey($storageId, $path), $rulesForPath);
 				}
 
 				$rules[$storageId] ??= [];
@@ -251,7 +267,7 @@ class ACLManager {
 	public function preloadRulesForFolder(int $storageId, int $parentId): void {
 		$rules = $this->ruleManager->getRulesForFilesByParent($this->user, $storageId, $parentId);
 		foreach ($rules as $path => $rulesForPath) {
-			$this->ruleCache->set($path, $rulesForPath);
+			$this->ruleCache->set($this->ruleCacheKey($storageId, $path), $rulesForPath);
 		}
 	}
 

--- a/lib/ACL/ACLManagerFactory.php
+++ b/lib/ACL/ACLManagerFactory.php
@@ -9,23 +9,48 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\ACL;
 
 use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
+use OCP\Cache\CappedMemoryCache;
 use OCP\IAppConfig;
 use OCP\IUser;
 
 class ACLManagerFactory {
+	/**
+	 * Memoize one ACLManager (and therefore one rule cache) per user for the
+	 * lifetime of the request. The factory is a request-scoped service, so
+	 * sharing the instance lets cache warming (e.g. preloadRulesForFolder) and
+	 * the subsequent per-item permission checks hit the same cache instead of
+	 * each call resolving the rules again. ACL and group changes take effect on
+	 * the next request.
+	 *
+	 * Capped so a request resolving many users (e.g. an occ command or background
+	 * job) cannot grow the map without bound.
+	 *
+	 * @var CappedMemoryCache<ACLManager>
+	 */
+	private readonly CappedMemoryCache $managers;
+
 	public function __construct(
 		private readonly RuleManager $ruleManager,
 		private readonly IAppConfig $config,
 		private readonly IUserMappingManager $userMappingManager,
 	) {
+		$this->managers = new CappedMemoryCache();
 	}
 
 	public function getACLManager(IUser $user): ACLManager {
-		return new ACLManager(
-			$this->ruleManager,
-			$this->userMappingManager,
-			$user,
-			$this->config->getValueString('groupfolders', 'acl-inherit-per-user', 'false') === 'true',
-		);
+		$uid = $user->getUID();
+
+		$aclManager = $this->managers->get($uid);
+		if ($aclManager === null) {
+			$aclManager = new ACLManager(
+				$this->ruleManager,
+				$this->userMappingManager,
+				$user,
+				$this->config->getValueString('groupfolders', 'acl-inherit-per-user', 'false') === 'true',
+			);
+			$this->managers->set($uid, $aclManager);
+		}
+
+		return $aclManager;
 	}
 }

--- a/tests/ACL/ACLManagerFactoryTest.php
+++ b/tests/ACL/ACLManagerFactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\groupfolders\tests\ACL;
+
+use OCA\GroupFolders\ACL\ACLManagerFactory;
+use OCA\GroupFolders\ACL\RuleManager;
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
+use OCP\IAppConfig;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class ACLManagerFactoryTest extends TestCase {
+	private RuleManager&MockObject $ruleManager;
+	private IAppConfig&MockObject $config;
+	private IUserMappingManager&MockObject $userMappingManager;
+	private ACLManagerFactory $factory;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->ruleManager = $this->createMock(RuleManager::class);
+		$this->config = $this->createMock(IAppConfig::class);
+		$this->userMappingManager = $this->createMock(IUserMappingManager::class);
+		$this->factory = new ACLManagerFactory($this->ruleManager, $this->config, $this->userMappingManager);
+	}
+
+	private function createUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+
+		return $user;
+	}
+
+	public function testReturnsSameInstanceForSameUser(): void {
+		$user = $this->createUser('alice');
+
+		$this->assertSame(
+			$this->factory->getACLManager($user),
+			$this->factory->getACLManager($user),
+			'the same user must share one ACLManager (and one rule cache) per request',
+		);
+	}
+
+	public function testReturnsSameInstanceForDifferentUserObjectsWithSameUid(): void {
+		$this->assertSame(
+			$this->factory->getACLManager($this->createUser('alice')),
+			$this->factory->getACLManager($this->createUser('alice')),
+			'the manager is keyed by UID, not by the user object identity',
+		);
+	}
+
+	public function testReturnsDifferentInstancesForDifferentUsers(): void {
+		$this->assertNotSame(
+			$this->factory->getACLManager($this->createUser('alice')),
+			$this->factory->getACLManager($this->createUser('bob')),
+		);
+	}
+}

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -145,6 +145,90 @@ class ACLManagerTest extends TestCase {
 		$this->assertNotContains($childPath, $this->requestedPaths);
 	}
 
+	public function testRuleCacheIsScopedPerStorage(): void {
+		// Folders using a separate storage restart their paths at the storage root
+		// ("files/", "trash/", "versions/"), so two folders can have a file at the
+		// same path under different storage ids. As one ACLManager (and its cache)
+		// is now shared for the whole request, the cache must neither let one
+		// storage's rules leak into another nor stop caching within a storage.
+		$ruleManager = $this->createMock(RuleManager::class);
+		$aclManager = new ACLManager($ruleManager, $this->userMappingManager, $this->user);
+
+		$path = 'files/file';
+		$denyShare = new Rule($this->dummyMapping, 10, Constants::PERMISSION_SHARE, 0);
+		$denyUpdate = new Rule($this->dummyMapping, 10, Constants::PERMISSION_UPDATE, 0);
+
+		$queriedStorages = [];
+		$ruleManager->method('getRulesForFilesByPath')
+			->willReturnCallback(function (IUser $user, int $storageId, array $paths) use ($path, $denyShare, $denyUpdate, &$queriedStorages): array {
+				/** @var string[] $paths */
+				$queriedStorages[] = $storageId;
+				$rules = array_fill_keys($paths, []);
+				if (in_array($path, $paths, true)) {
+					$rules[$path] = [$storageId === 1 ? $denyShare : $denyUpdate];
+				}
+
+				return $rules;
+			});
+
+		// resolving on storage 1 caches its rules for "files/file"
+		$this->assertEquals(
+			Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
+			$aclManager->getACLPermissionsForPath(0, 1, $path),
+		);
+		// the same path on storage 2 must use storage 2's rules, not the cached storage-1 entry
+		$this->assertEquals(
+			Constants::PERMISSION_ALL - Constants::PERMISSION_UPDATE,
+			$aclManager->getACLPermissionsForPath(0, 2, $path),
+		);
+		// a second lookup on storage 1 is still served from the cache ...
+		$this->assertEquals(
+			Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
+			$aclManager->getACLPermissionsForPath(0, 1, $path),
+		);
+		// ... i.e. scoping the key by storage did not turn same-storage hits into misses
+		$this->assertSame(1, count(array_filter($queriedStorages, fn (int $storageId): bool => $storageId === 1)));
+	}
+
+	public function testPreloadRuleCacheIsScopedPerStorage(): void {
+		// preloadRulesForFolder warms the cache for one storage; a same-named path
+		// on another storage must not be resolved from that preloaded entry.
+		$path = '__groupfolders/1/file';
+		$denyShare = new Rule($this->dummyMapping, 10, Constants::PERMISSION_SHARE, 0);
+
+		$this->ruleManager->expects($this->once())
+			->method('getRulesForFilesByParent')
+			->willReturn([$path => [$denyShare]]);
+
+		$this->rules = [];
+		$this->requestedPaths = [];
+		$this->aclManager->preloadRulesForFolder(1, 1); // warm storage 1
+
+		// storage 2 must not pick up storage 1's preloaded rule ...
+		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath(0, 2, $path));
+		// ... it must actually query for its own rules
+		$this->assertContains($path, $this->requestedPaths);
+	}
+
+	public function testGetRulesByFileIdsCacheIsScopedPerStorage(): void {
+		// getRulesByFileIds caches the resolved rules per storage; a same-named path
+		// on another storage must not be resolved from that cached entry.
+		$path = 'files/file';
+		$denyShare = new Rule($this->dummyMapping, 10, Constants::PERMISSION_SHARE, 0);
+
+		$this->ruleManager->method('getRulesForFilesByIds')
+			->willReturn([1 => [$path => [$denyShare]]]);
+
+		$this->rules = [];
+		$this->requestedPaths = [];
+		$this->aclManager->getRulesByFileIds([10]); // warm storage 1
+
+		// storage 2 must not pick up storage 1's cached rule ...
+		$this->assertEquals(Constants::PERMISSION_ALL, $this->aclManager->getACLPermissionsForPath(0, 2, $path));
+		// ... it must actually query for its own rules
+		$this->assertContains($path, $this->requestedPaths);
+	}
+
 	public function testGetACLPermissionsForPathPerUserMerge(): void {
 		$aclManager = $this->getAclManager(true);
 		$this->rules = [


### PR DESCRIPTION
Fix https://github.com/nextcloud/groupfolders/issues/4740

`ACLManagerFactory::getACLManager()` created a fresh ACLManager (and a fresh empty rule cache) on every call, so `preloadRulesForFolder()` warmed a cache that was immediately discarded and the per-item permission checks ran on different instances that never saw it.

Memoize the manager by UID. Since the factory is request-scoped, all callers now share one rule cache per user, so cache warming and the subsequent lookups actually hit the same cache.

Because the cache is now shared across all of a user's folders, scope its keys by storage id. Paths are only unique within a storage (folders using a separate storage start over at "`files/...`"), so a path-only key could
otherwise return one storage's rules for a same-named path in another.

Tests:

- `ACLManagerFactoryTest`: same UID returns the same instance; different UIDs return different instances.
- `ACLManagerTest::testRuleCacheIsScopedPerStorage`: the same relative path under two storage ids resolves with each storage's own rules (no cross-storage cache collision).