### PR TITLE
filter ACL forbidden paths from search query

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -9,9 +9,14 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\ACL;
 
 use OC\Files\Cache\Wrapper\CacheWrapper;
+use OC\Files\Search\SearchBinaryOperator;
+use OC\Files\Search\SearchComparison;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Search\ISearchBinaryOperator;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOperator;
 use OCP\Files\Search\ISearchQuery;
 
 class ACLCacheWrapper extends CacheWrapper {
@@ -75,7 +80,7 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	#[\Override]
 	public function search($pattern): array {
-		$results = $this->getCache()->search($pattern);
+		$results = parent::search($pattern);
 		$this->preloadEntries($results);
 
 		return array_filter(array_map($this->formatCacheEntry(...), $results));
@@ -83,7 +88,7 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	#[\Override]
 	public function searchByMime($mimetype): array {
-		$results = $this->getCache()->searchByMime($mimetype);
+		$results = parent::searchByMime($mimetype);
 		$this->preloadEntries($results);
 
 		return array_filter(array_map($this->formatCacheEntry(...), $results));
@@ -91,7 +96,7 @@ class ACLCacheWrapper extends CacheWrapper {
 
 	#[\Override]
 	public function searchQuery(ISearchQuery $query): array {
-		$results = $this->getCache()->searchQuery($query);
+		$results = parent::searchQuery($query);
 		$this->preloadEntries($results);
 
 		return array_filter(array_map($this->formatCacheEntry(...), $results));
@@ -105,5 +110,33 @@ class ACLCacheWrapper extends CacheWrapper {
 		$paths = array_map(fn (ICacheEntry $entry): string => $entry->getPath(), $entries);
 
 		return $this->aclManager->getRelevantRulesForPath($this->getNumericStorageId(), $paths, false);
+	}
+
+	/**
+	 * Construct a search operator that filters out any paths that the current user doesn't have read permissions for
+	 */
+	private function getSearchFilter(): ISearchOperator {
+		$forbiddenPaths = $this->aclManager->getForbiddenPaths($this->getNumericStorageId(), '');
+
+		$filters = array_map(fn (string $path) => new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_NOT, [
+			new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', SearchComparison::escapeLikeParameter($path) . '/%')
+		]), $forbiddenPaths);
+		$filters[] = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_NOT, [
+			new SearchComparison(ISearchComparison::COMPARE_IN, 'path', $forbiddenPaths)
+		]);
+		return new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, $filters);
+	}
+
+	#[\Override]
+	public function getQueryFilterForStorage(): ISearchOperator {
+		$storageFilter = parent::getQueryFilterForStorage();
+
+		return new SearchBinaryOperator(
+			ISearchBinaryOperator::OPERATOR_AND,
+			[
+				$storageFilter,
+				$this->getSearchFilter(),
+			]
+		);
 	}
 }

--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -293,4 +293,23 @@ class ACLManager {
 
 		return Constants::PERMISSION_ALL;
 	}
+
+	/**
+	 * Calculate all paths that the current user doesn't have access to.
+	 *
+	 * @return list<string>
+	 */
+	public function getForbiddenPaths(int $storageId, string $prefix): array {
+		$rules = $this->ruleManager->getRulesForPrefix($this->user, $storageId, $prefix);
+		$forbidden = [];
+
+		foreach ($rules as $path => $pathRules) {
+			$mergedRule = Rule::mergeRules($pathRules);
+			if ($mergedRule->applyPermissions(Constants::PERMISSION_READ) === 0) {
+				$forbidden[] = $path;
+			}
+		}
+
+		return $forbidden;
+	}
 }

--- a/lib/ACL/RuleManager.php
+++ b/lib/ACL/RuleManager.php
@@ -280,15 +280,18 @@ class RuleManager {
 		$query->select(['f.fileid', 'mapping_type', 'mapping_id', 'mask', 'a.permissions', 'f.path'])
 			->from('group_folders_acl', 'a')
 			->innerJoin('a', 'filecache', 'f', $query->expr()->eq('f.fileid', 'a.fileid'))
-			->where($query->expr()->orX(
-				$query->expr()->like('f.path', $query->createNamedParameter($this->connection->escapeLikeParameter($prefix) . '/%')),
-				$query->expr()->eq('f.path_hash', $query->createNamedParameter(md5($prefix)))
-			))
-			->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
+			->where($query->expr()->eq('f.storage', $query->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->orX(...array_map(fn (IUserMapping $userMapping): ICompositeExpression => $query->expr()->andX(
 				$query->expr()->eq('mapping_type', $query->createNamedParameter($userMapping->getType())),
 				$query->expr()->eq('mapping_id', $query->createNamedParameter($userMapping->getId()))
 			), $userMappings)));
+
+		if ($prefix !== '') {
+			$query = $query->andWhere($query->expr()->orX(
+				$query->expr()->like('f.path', $query->createNamedParameter($this->connection->escapeLikeParameter($prefix) . '/%')),
+				$query->expr()->eq('f.path_hash', $query->createNamedParameter(md5($prefix)))
+			));
+		}
 
 		$rows = $query->executeQuery()->fetchAll();
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,6 +44,10 @@ parameters:
 		- tests/stubs/oc_files_objectstore_objectstorescanner.php
 		- tests/stubs/oc_files_objectstore_objectstorestorage.php
 		- tests/stubs/oc_files_objectstore_primaryobjectstoreconfig.php
+		- tests/stubs/oc_files_search_searchbinaryoperator.php
+		- tests/stubs/oc_files_search_searchcomparison.php
+		- tests/stubs/oc_files_search_searchorder.php
+		- tests/stubs/oc_files_search_searchquery.php
 		- tests/stubs/oc_files_setupmanager.php
 		- tests/stubs/oc_files_storage_common.php
 		- tests/stubs/oc_files_storage_local.php

--- a/tests/ACL/ACLCacheWrapperTest.php
+++ b/tests/ACL/ACLCacheWrapperTest.php
@@ -9,10 +9,22 @@ declare(strict_types=1);
 namespace OCA\groupfolders\tests\ACL;
 
 use OC\Files\Cache\CacheEntry;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
+use OC\Files\Search\SearchQuery;
+use OC\Files\Storage\Temporary;
 use OCA\GroupFolders\ACL\ACLCacheWrapper;
 use OCA\GroupFolders\ACL\ACLManager;
+use OCA\GroupFolders\ACL\Rule;
+use OCA\GroupFolders\ACL\RuleManager;
+use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOrder;
+use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -20,19 +32,48 @@ use Test\TestCase;
  * @group DB
  */
 class ACLCacheWrapperTest extends TestCase {
-	private ACLManager&MockObject $aclManager;
+	private ACLManager $aclManager;
 	private ICache&MockObject $source;
 	private ACLCacheWrapper $cache;
 	/** @var array<string, int> */
 	private array $aclPermissions = [];
 
+	private function makeRule(int $permission): Rule {
+		return new Rule($this->createMock(IUserMapping::class), 0, Constants::PERMISSION_ALL, $permission);
+	}
+
+	/**
+	 * @param string[] $paths
+	 * @return array<string, Rule[]>
+	 */
+	private function getRulesForPaths(IUser $user, int $storageId, array $paths): array {
+		return array_combine($paths, array_map(
+			fn (string $path) => isset($this->aclPermissions[$path]) ? [$this->makeRule($this->aclPermissions[$path])] : [],
+			$paths
+		));
+	}
+
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->aclManager = $this->createMock(ACLManager::class);
-		$this->aclManager->method('getACLPermissionsForPath')
-			->willReturnCallback(fn (int $folderId, int $storageId, string $path) => $this->aclPermissions[$path] ?? Constants::PERMISSION_ALL);
+		$user = $this->createMock(IUser::class);
+		$ruleManager = $this->createMock(RuleManager::class);
+		$ruleManager->method('getRulesForFilesByPath')
+			->willReturnCallback($this->getRulesForPaths(...));
+		$ruleManager->method('getRulesForPrefix')
+			->willReturnCallback(fn (IUser $user, int $storageId, string $prefix) => array_map(
+				fn (int $permission) => [$this->makeRule($permission)],
+				array_filter(
+					$this->aclPermissions,
+					fn (string $path) => str_starts_with($path, $prefix),
+					ARRAY_FILTER_USE_KEY,
+				))
+			);
+		$mappingManager = $this->createMock(IUserMappingManager::class);
+
+		$this->aclManager = new ACLManager($ruleManager, $mappingManager, $user);
+
 		$this->source = $this->createMock(ICache::class);
 		$this->source->method('getNumericStorageId')
 			->willReturn(1);
@@ -75,5 +116,35 @@ class ACLCacheWrapperTest extends TestCase {
 		];
 
 		$this->assertEquals($expected, $result);
+	}
+
+	public function testSearchNonRead(): void {
+		$sourceStorage = new Temporary([]);
+		$sourceStorage->mkdir('foo');
+		$sourceStorage->touch('foo/test1.txt', 100);
+		$sourceStorage->touch('foo/test2.txt', 101);
+		$sourceStorage->touch('foo/test3.txt', 102);
+		$sourceStorage->mkdir('bar');
+		$sourceStorage->touch('bar/test1.txt', 200);
+		$sourceStorage->touch('bar/test2.txt', 201);
+		$sourceStorage->touch('bar/test3.txt', 202);
+		$sourceStorage->getScanner()->scan('');
+		$this->aclPermissions['bar'] = 0;
+
+		$cache = new ACLCacheWrapper($sourceStorage->getCache(), $this->aclManager, 0, false);
+
+		$query = new SearchQuery(
+			new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%test%'),
+			2,
+			0,
+			[new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime')]
+		);
+		$result = $cache->searchQuery($query);
+		$paths = array_map(fn (ICacheEntry $entry) => $entry->getPath(), $result);
+
+		$this->assertEquals([
+			'foo/test3.txt',
+			'foo/test2.txt'
+		], $paths);
 	}
 }

--- a/tests/stubs/oc_app.php
+++ b/tests/stubs/oc_app.php
@@ -8,20 +8,16 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 use OC\App\AppManager;
-use OC\App\DependencyAnalyzer;
 use OC\AppFramework\App;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Installer;
 use OC\NeedsUpdateException;
-use OC\Repair;
-use OC\Repair\Events\RepairErrorEvent;
 use OC\SystemConfig;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\Authentication\IAlternativeLoginProvider;
 use OCP\BackgroundJob\IJobList;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -34,7 +30,6 @@ use OCP\Server;
 use OCP\Support\Subscription\IRegistry;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
-use function OCP\Log\logger;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
@@ -119,6 +114,7 @@ class OC_App {
 	 * @param bool $all whether to return apps for all users, not only the
 	 *                  currently logged in one
 	 * @return list<string>
+	 * @deprecated 32.0.0 - use {@see \OCP\App\IAppManager::getEnabledAppsForUser} or {@see \OC\OCP\AppIAppManager::getEnabledApps} instead
 	 */
 	public static function getEnabledApps(bool $forceRefresh = false, bool $all = false): array
     {
@@ -256,6 +252,7 @@ class OC_App {
 	 * @param string $appId
 	 * @param string[] $steps
 	 * @throws NeedsUpdateException
+	 * @deprecated 34.0.0 Use {@see \OC\App\AppManager::executeRepairSteps}
 	 */
 	public static function executeRepairSteps(string $appId, array $steps)
     {
@@ -270,6 +267,7 @@ class OC_App {
 
 	/**
 	 * @throws \Exception
+	 * @deprecated 34.0.0 Use {@see \OC\App\AppManager::checkAppDependencies} instead
 	 */
 	public static function checkAppDependencies(IConfig $config, IL10N $l, array $info, bool $ignoreMax): void
     {

--- a/tests/stubs/oc_appframework_ocs_baseresponse.php
+++ b/tests/stubs/oc_appframework_ocs_baseresponse.php
@@ -4,6 +4,7 @@
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\AppFramework\OCS;
 
 use OCP\AppFramework\Http;

--- a/tests/stubs/oc_appframework_ocs_v1response.php
+++ b/tests/stubs/oc_appframework_ocs_v1response.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\AppFramework\OCS;
 
 use OCP\AppFramework\Http;

--- a/tests/stubs/oc_appframework_utility_simplecontainer.php
+++ b/tests/stubs/oc_appframework_utility_simplecontainer.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\AppFramework\Utility;
 
 use ArrayAccess;
@@ -26,6 +27,7 @@ use function class_exists;
  * SimpleContainer is a simple implementation of a container on basis of Pimple
  */
 class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
+	/** @psalm-suppress ImpureStaticProperty A static property is the only way to pass the information from config to autoload */
 	public static bool $useLazyObjects = false;
 
 	public function __construct()

--- a/tests/stubs/oc_core_command_base.php
+++ b/tests/stubs/oc_core_command_base.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Core\Command;
 
 use OC\Core\Command\User\ListCommand;
@@ -25,41 +26,41 @@ class Base extends Command implements CompletionAwareInterface {
 
 	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
 
-	protected function configure()
- {
- }
+	#[\Override]
+    protected function configure()
+    {
+    }
 
 	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, iterable $items, string $prefix = '  - '): void
- {
- }
+    {
+    }
 
 	protected function writeTableInOutputFormat(InputInterface $input, OutputInterface $output, array $items): void
- {
- }
+    {
+    }
 
 	protected function writeStreamingTableInOutputFormat(InputInterface $input, OutputInterface $output, \Iterator $items, int $tableGroupSize): void
- {
- }
+    {
+    }
 
 	protected function writeStreamingJsonArray(InputInterface $input, OutputInterface $output, \Iterator $items): void
- {
- }
+    {
+    }
 
 	public function chunkIterator(\Iterator $iterator, int $count): \Iterator
- {
- }
-
+    {
+    }
 
 	/**
 	 * @param mixed $item
 	 */
 	protected function writeMixedInOutputFormat(InputInterface $input, OutputInterface $output, $item)
- {
- }
+    {
+    }
 
 	protected function valueToString($value, bool $returnNull = true): ?string
- {
- }
+    {
+    }
 
 	/**
 	 * Throw InterruptedException when interrupted by user
@@ -67,8 +68,8 @@ class Base extends Command implements CompletionAwareInterface {
 	 * @throws InterruptedException
 	 */
 	protected function abortIfInterrupted()
- {
- }
+    {
+    }
 
 	/**
 	 * Changes the status of the command to "interrupted" if ctrl-c has been pressed
@@ -76,28 +77,31 @@ class Base extends Command implements CompletionAwareInterface {
 	 * Gives a chance to the command to properly terminate what it's doing
 	 */
 	public function cancelOperation(): void
- {
- }
+    {
+    }
 
-	public function run(InputInterface $input, OutputInterface $output): int
- {
- }
+	#[\Override]
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+    }
 
 	/**
 	 * @param string $optionName
 	 * @param CompletionContext $context
 	 * @return string[]
 	 */
-	public function completeOptionValues($optionName, CompletionContext $context)
- {
- }
+	#[\Override]
+    public function completeOptionValues($optionName, CompletionContext $context)
+    {
+    }
 
 	/**
 	 * @param string $argumentName
 	 * @param CompletionContext $context
 	 * @return string[]
 	 */
-	public function completeArgumentValues($argumentName, CompletionContext $context)
- {
- }
+	#[\Override]
+    public function completeArgumentValues($argumentName, CompletionContext $context)
+    {
+    }
 }

--- a/tests/stubs/oc_db_querybuilder_querybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_querybuilder.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\DB\QueryBuilder;
 
 use Doctrine\DBAL\Query\QueryException;
@@ -137,7 +138,6 @@ class QueryBuilder extends TypedQueryBuilder {
     public function executeStatement(?IDBConnection $connection = null): int
     {
     }
-
 
 	/**
 	 * Gets the complete SQL string formed by the current specifications of this QueryBuilder.

--- a/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
+++ b/tests/stubs/oc_db_querybuilder_typedquerybuilder.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\DB\QueryBuilder;
 
 use OCP\DB\QueryBuilder\ITypedQueryBuilder;

--- a/tests/stubs/oc_encryption_exceptions_decryptionfailedexception.php
+++ b/tests/stubs/oc_encryption_exceptions_decryptionfailedexception.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Encryption\Exceptions;
 
 use OCP\Encryption\Exceptions\GenericEncryptionException;

--- a/tests/stubs/oc_files_cache_cache.php
+++ b/tests/stubs/oc_files_cache_cache.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Cache;
 
 use OC\DatabaseException;
@@ -24,8 +25,6 @@ use OCP\Files\Cache\CacheEntriesRemovedEvent;
 use OCP\Files\Cache\CacheEntryInsertedEvent;
 use OCP\Files\Cache\CacheEntryRemovedEvent;
 use OCP\Files\Cache\CacheEntryUpdatedEvent;
-use OCP\Files\Cache\CacheInsertEvent;
-use OCP\Files\Cache\CacheUpdateEvent;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Config\IUserMountCache;
@@ -348,7 +347,6 @@ class Cache implements ICache {
 	public function calculateFolderSize($path, $entry = null)
     {
     }
-
 
 	/**
 	 * inner function because we can't add new params to the public function without breaking any child classes

--- a/tests/stubs/oc_files_cache_cacheentry.php
+++ b/tests/stubs/oc_files_cache_cacheentry.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Cache;
 
 use OCP\Files\Cache\ICacheEntry;
@@ -52,24 +53,20 @@ class CacheEntry implements ICacheEntry {
     {
     }
 
-
 	#[\Override]
     public function getPath()
     {
     }
-
 
 	#[\Override]
     public function getName()
     {
     }
 
-
 	#[\Override]
     public function getMimeType(): string
     {
     }
-
 
 	#[\Override]
     public function getMimePart()

--- a/tests/stubs/oc_files_cache_scanner.php
+++ b/tests/stubs/oc_files_cache_scanner.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Cache;
 
 use Doctrine\DBAL\Exception;

--- a/tests/stubs/oc_files_cache_wrapper_cachejail.php
+++ b/tests/stubs/oc_files_cache_wrapper_cachejail.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Cache;

--- a/tests/stubs/oc_files_cache_wrapper_cachewrapper.php
+++ b/tests/stubs/oc_files_cache_wrapper_cachewrapper.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Cache;

--- a/tests/stubs/oc_files_fileinfo.php
+++ b/tests/stubs/oc_files_fileinfo.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files;
 
 use OC\Files\Cache\CacheEntry;

--- a/tests/stubs/oc_files_filesystem.php
+++ b/tests/stubs/oc_files_filesystem.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files;
 
 use OC\Files\Mount\MountPoint;
@@ -26,6 +27,9 @@ use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class Filesystem {
+	/**
+	 * @psalm-suppress ImpureStaticProperty
+	 */
 	public static bool $loaded = false;
 
 	/**

--- a/tests/stubs/oc_files_mount_mountpoint.php
+++ b/tests/stubs/oc_files_mount_mountpoint.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Mount;
 
 use OC\Files\Filesystem;

--- a/tests/stubs/oc_files_node_lazyfolder.php
+++ b/tests/stubs/oc_files_node_lazyfolder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;

--- a/tests/stubs/oc_files_node_node.php
+++ b/tests/stubs/oc_files_node_node.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;

--- a/tests/stubs/oc_files_objectstore_objectstorescanner.php
+++ b/tests/stubs/oc_files_objectstore_objectstorescanner.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\ObjectStore;
 
 use OC\Files\Cache\Scanner;

--- a/tests/stubs/oc_files_objectstore_objectstorestorage.php
+++ b/tests/stubs/oc_files_objectstore_objectstorestorage.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\ObjectStore;
 
 use Aws\S3\Exception\S3Exception;

--- a/tests/stubs/oc_files_search_searchbinaryoperator.php
+++ b/tests/stubs/oc_files_search_searchbinaryoperator.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Files\Search;
+
+use OCP\Files\Search\ISearchBinaryOperator;
+use OCP\Files\Search\ISearchOperator;
+
+class SearchBinaryOperator implements ISearchBinaryOperator {
+	/**
+	 * SearchBinaryOperator constructor.
+	 *
+	 * @param string $type
+	 * @param ISearchOperator[] $arguments
+	 */
+	public function __construct(
+		private $type,
+		private array $arguments,
+	) {
+	}
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getType()
+    {
+    }
+
+	/**
+	 * @return ISearchOperator[]
+	 */
+	#[\Override]
+    public function getArguments()
+    {
+    }
+
+	/**
+	 * @param ISearchOperator[] $arguments
+	 * @return void
+	 */
+	public function setArguments(array $arguments): void
+    {
+    }
+
+	#[\Override]
+    public function getQueryHint(string $name, $default)
+    {
+    }
+
+	#[\Override]
+    public function setQueryHint(string $name, $value): void
+    {
+    }
+
+	public function __toString(): string
+    {
+    }
+}

--- a/tests/stubs/oc_files_search_searchcomparison.php
+++ b/tests/stubs/oc_files_search_searchcomparison.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Files\Search;
+
+use OCP\Files\Search\ISearchComparison;
+
+/**
+ * @psalm-import-type ParamValue from ISearchComparison
+ */
+class SearchComparison implements ISearchComparison {
+	public function __construct(
+		private string $type,
+		private string $field,
+		/** @var ParamValue $value */
+		private \DateTime|int|string|bool|array $value,
+		private string $extra = '',
+	) {
+	}
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getType(): string
+    {
+    }
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getField(): string
+    {
+    }
+
+	#[\Override]
+    public function getValue(): string|int|bool|\DateTime|array
+    {
+    }
+
+	/**
+	 * @return string
+	 * @since 28.0.0
+	 */
+	#[\Override]
+    public function getExtra(): string
+    {
+    }
+
+	#[\Override]
+    public function getQueryHint(string $name, $default)
+    {
+    }
+
+	#[\Override]
+    public function setQueryHint(string $name, $value): void
+    {
+    }
+
+	public static function escapeLikeParameter(string $param): string
+    {
+    }
+
+	public function __toString(): string
+    {
+    }
+}

--- a/tests/stubs/oc_files_search_searchorder.php
+++ b/tests/stubs/oc_files_search_searchorder.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Files\Search;
+
+use OCP\Files\FileInfo;
+use OCP\Files\Search\ISearchOrder;
+
+class SearchOrder implements ISearchOrder {
+	public function __construct(
+		private string $direction,
+		private string $field,
+		private string $extra = '',
+	) {
+	}
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getDirection(): string
+    {
+    }
+
+	/**
+	 * @return string
+	 */
+	#[\Override]
+    public function getField(): string
+    {
+    }
+
+	/**
+	 * @return string
+	 * @since 28.0.0
+	 */
+	#[\Override]
+    public function getExtra(): string
+    {
+    }
+
+	#[\Override]
+    public function sortFileInfo(FileInfo $a, FileInfo $b): int
+    {
+    }
+}

--- a/tests/stubs/oc_files_search_searchquery.php
+++ b/tests/stubs/oc_files_search_searchquery.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Files\Search;
+
+use OCP\Files\Search\ISearchOperator;
+use OCP\Files\Search\ISearchOrder;
+use OCP\Files\Search\ISearchQuery;
+use OCP\IUser;
+
+class SearchQuery implements ISearchQuery {
+	/**
+	 * @param ISearchOrder[] $order
+	 */
+	public function __construct(
+		private ISearchOperator $searchOperation,
+		private int $limit,
+		private int $offset,
+		private array $order,
+		private ?IUser $user = null,
+		private bool $limitToHome = false,
+	) {
+	}
+
+	#[\Override]
+    public function getSearchOperation(): ISearchOperator
+    {
+    }
+
+	#[\Override]
+    public function getLimit(): int
+    {
+    }
+
+	#[\Override]
+    public function getOffset(): int
+    {
+    }
+
+	/**
+	 * @return ISearchOrder[]
+	 */
+	#[\Override]
+    public function getOrder(): array
+    {
+    }
+
+	#[\Override]
+    public function getUser(): ?IUser
+    {
+    }
+
+	#[\Override]
+    public function limitToHome(): bool
+    {
+    }
+}

--- a/tests/stubs/oc_files_storage_common.php
+++ b/tests/stubs/oc_files_storage_common.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage;
 
 use OC\Files\Cache\Cache;

--- a/tests/stubs/oc_files_storage_local.php
+++ b/tests/stubs/oc_files_storage_local.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage;
 
 use OC\Files\Filesystem;

--- a/tests/stubs/oc_files_storage_storage.php
+++ b/tests/stubs/oc_files_storage_storage.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage;
 
 use OCP\Files\Cache\ICache;
@@ -24,40 +25,26 @@ use OCP\Files\Storage\IStorage;
  */
 interface Storage extends IStorage, ILockingStorage {
 	#[\Override]
-    public function getCache(string $path = '', ?IStorage $storage = null): ICache
-    {
-    }
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache;
 
 	#[\Override]
-    public function getScanner(string $path = '', ?IStorage $storage = null): IScanner
-    {
-    }
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner;
 
 	#[\Override]
-    public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher
-    {
-    }
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher;
 
 	#[\Override]
-    public function getPropagator(?IStorage $storage = null): IPropagator
-    {
-    }
+	public function getPropagator(?IStorage $storage = null): IPropagator;
 
 	#[\Override]
-    public function getUpdater(?IStorage $storage = null): IUpdater
-    {
-    }
+	public function getUpdater(?IStorage $storage = null): IUpdater;
 
-	public function getStorageCache(): \OC\Files\Cache\Storage
-    {
-    }
+	public function getStorageCache(): \OC\Files\Cache\Storage;
 
 	/**
 	 * @return ?array<string, mixed>
 	 */
-	public function getMetaData(string $path): ?array
-    {
-    }
+	public function getMetaData(string $path): ?array;
 
 	/**
 	 * Get the contents of a directory with metadata
@@ -74,7 +61,5 @@ interface Storage extends IStorage, ILockingStorage {
 	 *
 	 * @return \Traversable<array<string, mixed>>
 	 */
-	public function getDirectoryContent(string $directory): \Traversable
-    {
-    }
+	public function getDirectoryContent(string $directory): \Traversable;
 }

--- a/tests/stubs/oc_files_storage_temporary.php
+++ b/tests/stubs/oc_files_storage_temporary.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage;
 
 use OCP\Files;

--- a/tests/stubs/oc_files_storage_wrapper_encryption.php
+++ b/tests/stubs/oc_files_storage_wrapper_encryption.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
@@ -94,7 +95,6 @@ class Encryption extends Wrapper {
     public function fopen(string $path, string $mode)
     {
     }
-
 
 	/**
 	 * perform some plausibility checks if the unencrypted size is correct.

--- a/tests/stubs/oc_files_storage_wrapper_jail.php
+++ b/tests/stubs/oc_files_storage_wrapper_jail.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Cache\Wrapper\CacheJail;
@@ -54,7 +55,6 @@ class Jail extends Wrapper {
 	public function getUnjailedStorage(): IStorage
     {
     }
-
 
 	public function getJailedPath(string $path): ?string
     {

--- a/tests/stubs/oc_files_storage_wrapper_permissionsmask.php
+++ b/tests/stubs/oc_files_storage_wrapper_permissionsmask.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Cache\Wrapper\CachePermissionsMask;

--- a/tests/stubs/oc_files_storage_wrapper_quota.php
+++ b/tests/stubs/oc_files_storage_wrapper_quota.php
@@ -5,12 +5,15 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Filesystem;
 use OC\SystemConfig;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
+use OCP\Files\GenericFileException;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\Storage\IStorage;
 
 class Quota extends Wrapper {
@@ -83,6 +86,11 @@ class Quota extends Wrapper {
     }
 
 	public function enableQuota(bool $enabled): void
+    {
+    }
+
+	#[\Override]
+    public function writeStream(string $path, $stream, ?int $size = null): int
     {
     }
 }

--- a/tests/stubs/oc_files_storage_wrapper_wrapper.php
+++ b/tests/stubs/oc_files_storage_wrapper_wrapper.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Storage\FailedStorage;
@@ -329,6 +330,13 @@ class Wrapper implements Storage, ILockingStorage, IWriteStreamStorage {
 
 	#[\Override]
     public function writeStream(string $path, $stream, ?int $size = null): int
+    {
+    }
+
+	/**
+	 * @param resource $stream
+	 */
+	protected function writeStreamFallback(string $path, $stream): int
     {
     }
 

--- a/tests/stubs/oc_files_view.php
+++ b/tests/stubs/oc_files_view.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Files;
 
 use Icewind\Streams\CallbackWrapper;
@@ -450,7 +451,6 @@ class View {
 	public function fromTmpFile($tmpFile, $path)
     {
     }
-
 
 	/**
 	 * @param string $path

--- a/tests/stubs/oc_group_database.php
+++ b/tests/stubs/oc_group_database.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Group;
 
 use OC\User\LazyUser;

--- a/tests/stubs/oc_group_manager.php
+++ b/tests/stubs/oc_group_manager.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Group;
 
 use OC\Hooks\PublicEmitter;
@@ -83,7 +84,6 @@ class Manager extends PublicEmitter implements IGroupManager {
     public function getBackends()
     {
     }
-
 
 	protected function clearCaches()
     {

--- a/tests/stubs/oc_hooks_basicemitter.php
+++ b/tests/stubs/oc_hooks_basicemitter.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Hooks;
 
 /**

--- a/tests/stubs/oc_hooks_emitter.php
+++ b/tests/stubs/oc_hooks_emitter.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Hooks;
 
 /**
@@ -25,9 +26,7 @@ interface Emitter {
 	 * @return void
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::addListener
 	 */
-	public function listen($scope, $method, callable $callback)
-    {
-    }
+	public function listen($scope, $method, callable $callback);
 
 	/**
 	 * @param string $scope optional
@@ -36,7 +35,5 @@ interface Emitter {
 	 * @return void
 	 * @deprecated 18.0.0 use \OCP\EventDispatcher\IEventDispatcher::removeListener
 	 */
-	public function removeListener($scope = null, $method = null, ?callable $callback = null)
-    {
-    }
+	public function removeListener($scope = null, $method = null, ?callable $callback = null);
 }

--- a/tests/stubs/oc_hooks_emittertrait.php
+++ b/tests/stubs/oc_hooks_emittertrait.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Hooks;
 
 /**

--- a/tests/stubs/oc_hooks_publicemitter.php
+++ b/tests/stubs/oc_hooks_publicemitter.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Hooks;
 
 /**

--- a/tests/stubs/oc_server.php
+++ b/tests/stubs/oc_server.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
@@ -12,7 +13,6 @@ use OC\Accounts\AccountManager;
 use OC\Activity\EventMerger;
 use OC\App\AppManager;
 use OC\App\AppStore\Bundles\BundleFetcher;
-use OC\AppFramework\Bootstrap\Coordinator;
 use OC\AppFramework\Http\Request;
 use OC\AppFramework\Http\RequestId;
 use OC\AppFramework\Services\AppConfig;
@@ -26,6 +26,7 @@ use OC\Authentication\Token\IProvider;
 use OC\Authentication\TwoFactorAuth\Registry;
 use OC\Avatar\AvatarManager;
 use OC\BackgroundJob\JobList;
+use OC\BackgroundJob\JobRuns;
 use OC\Blurhash\Listener\GenerateBlurhashMetadata;
 use OC\Collaboration\Collaborators\GroupPlugin;
 use OC\Collaboration\Collaborators\MailByMailPlugin;
@@ -102,15 +103,11 @@ use OC\OCM\OCMDiscoveryService;
 use OC\OCS\CoreCapabilities;
 use OC\OCS\DiscoveryService;
 use OC\Preview\Db\PreviewMapper;
-use OC\Preview\GeneratorHelper;
-use OC\Preview\IMagickSupport;
 use OC\Preview\MimeIconProvider;
 use OC\Preview\Watcher;
 use OC\Preview\WatcherConnector;
 use OC\Profile\ProfileManager;
 use OC\Profiler\Profiler;
-use OC\Remote\Api\ApiFactory;
-use OC\Remote\InstanceFactory;
 use OC\RichObjectStrings\RichTextFormatter;
 use OC\RichObjectStrings\Validator;
 use OC\Route\CachingRouter;
@@ -173,6 +170,7 @@ use OCP\Authentication\Token\IProvider as OCPIProvider;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\AutoloadNotAllowedException;
 use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\IJobRuns;
 use OCP\Collaboration\Collaborators\ISearch;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\Collaboration\Reference\IReferenceManager;
@@ -254,8 +252,6 @@ use OCP\OCS\IDiscoveryService;
 use OCP\Preview\IMimeIconProvider;
 use OCP\Profile\IProfileManager;
 use OCP\Profiler\IProfiler;
-use OCP\Remote\Api\IApiFactory;
-use OCP\Remote\IInstanceFactory;
 use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Route\IRouter;

--- a/tests/stubs/oc_servercontainer.php
+++ b/tests/stubs/oc_servercontainer.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC;
 
 use OC\AppFramework\App;
@@ -24,7 +25,7 @@ class ServerContainer extends SimpleContainer {
 	/** @var DIContainer[] */
 	protected $appContainers;
 
-	/** @var string[] */
+	/** @var array<string,true> */
 	protected $hasNoAppContainer;
 
 	/** @var string[] */
@@ -68,7 +69,7 @@ class ServerContainer extends SimpleContainer {
 	 * @return DIContainer
 	 * @throws QueryException
 	 */
-	protected function getAppContainer(string $namespace, string $sensitiveNamespace): DIContainer
+	protected function getAppContainer(string $sensitiveNamespace): DIContainer
     {
     }
 

--- a/tests/stubs/oc_settings_authorizedgroup.php
+++ b/tests/stubs/oc_settings_authorizedgroup.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Settings;
 
 use JsonSerializable;

--- a/tests/stubs/oc_settings_authorizedgroupmapper.php
+++ b/tests/stubs/oc_settings_authorizedgroupmapper.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Settings;
 
 use OCP\AppFramework\Db\DoesNotExistException;

--- a/tests/stubs/oc_user_user.php
+++ b/tests/stubs/oc_user_user.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\User;
 
 use InvalidArgumentException;
@@ -27,6 +28,7 @@ use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Server;
+use OCP\Support\Subscription\IAssertion;
 use OCP\User\Backend\IGetHomeBackend;
 use OCP\User\Backend\IPasswordHashBackend;
 use OCP\User\Backend\IPropertyPermissionBackend;
@@ -43,7 +45,6 @@ use OCP\User\GetQuotaEvent;
 use OCP\UserInterface;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
-
 use function json_decode;
 use function json_encode;
 
@@ -51,7 +52,7 @@ class User implements IUser {
 	private const CONFIG_KEY_MANAGERS = 'manager';
 	protected ?IAccountManager $accountManager = null;
 
-	public function __construct(private string $uid, private ?UserInterface $backend, private IEventDispatcher $dispatcher, private Emitter|Manager|null $emitter = null, ?IConfig $config = null, $urlGenerator = null)
+	public function __construct(private string $uid, private ?UserInterface $backend, private IEventDispatcher $dispatcher, private Emitter|Manager|null $emitter = null, ?IConfig $config = null, ?IURLGenerator $urlGenerator = null, ?IAssertion $assertion = null)
     {
     }
 

--- a/tests/stubs/stecman_component_symfony_console_bashcompletion_completion_completionawareinterface.php
+++ b/tests/stubs/stecman_component_symfony_console_bashcompletion_completion_completionawareinterface.php
@@ -14,9 +14,7 @@ interface CompletionAwareInterface
      * @param CompletionContext $context
      * @return array
      */
-    public function completeOptionValues($optionName, CompletionContext $context)
-    {
-    }
+    public function completeOptionValues($optionName, CompletionContext $context);
 
     /**
      * Return possible values for the named argument
@@ -25,7 +23,5 @@ interface CompletionAwareInterface
      * @param CompletionContext $context
      * @return array
      */
-    public function completeArgumentValues($argumentName, CompletionContext $context)
-    {
-    }
+    public function completeArgumentValues($argumentName, CompletionContext $context);
 }

--- a/tests/stubs/symfony_component_console_input_inputinterface.php
+++ b/tests/stubs/symfony_component_console_input_inputinterface.php
@@ -27,9 +27,7 @@ interface InputInterface
     /**
      * Returns the first argument from the raw parameters (not parsed).
      */
-    public function getFirstArgument(): ?string
-    {
-    }
+    public function getFirstArgument(): ?string;
 
     /**
      * Returns true if the raw parameters (not parsed) contain a value.
@@ -42,9 +40,7 @@ interface InputInterface
      * @param string|array $values     The values to look for in the raw parameters (can be an array)
      * @param bool         $onlyParams Only check real parameters, skip those following an end of options (--) signal
      */
-    public function hasParameterOption(string|array $values, bool $onlyParams = false): bool
-    {
-    }
+    public function hasParameterOption(string|array $values, bool $onlyParams = false): bool;
 
     /**
      * Returns the value of a raw option (not parsed).
@@ -60,9 +56,7 @@ interface InputInterface
      *
      * @return mixed
      */
-    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false)
-    {
-    }
+    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false);
 
     /**
      * Binds the current Input instance with the given arguments and options.
@@ -71,9 +65,7 @@ interface InputInterface
      *
      * @throws RuntimeException
      */
-    public function bind(InputDefinition $definition)
-    {
-    }
+    public function bind(InputDefinition $definition);
 
     /**
      * Validates the input.
@@ -82,18 +74,14 @@ interface InputInterface
      *
      * @throws RuntimeException When not enough arguments are given
      */
-    public function validate()
-    {
-    }
+    public function validate();
 
     /**
      * Returns all the given arguments merged with the default values.
      *
      * @return array<string|bool|int|float|array|null>
      */
-    public function getArguments(): array
-    {
-    }
+    public function getArguments(): array;
 
     /**
      * Returns the argument value for a given argument name.
@@ -102,9 +90,7 @@ interface InputInterface
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
-    public function getArgument(string $name)
-    {
-    }
+    public function getArgument(string $name);
 
     /**
      * Sets an argument value by name.
@@ -113,25 +99,19 @@ interface InputInterface
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
-    public function setArgument(string $name, mixed $value)
-    {
-    }
+    public function setArgument(string $name, mixed $value);
 
     /**
      * Returns true if an InputArgument object exists by name or position.
      */
-    public function hasArgument(string $name): bool
-    {
-    }
+    public function hasArgument(string $name): bool;
 
     /**
      * Returns all the given options merged with the default values.
      *
      * @return array<string|bool|int|float|array|null>
      */
-    public function getOptions(): array
-    {
-    }
+    public function getOptions(): array;
 
     /**
      * Returns the option value for a given option name.
@@ -140,9 +120,7 @@ interface InputInterface
      *
      * @throws InvalidArgumentException When option given doesn't exist
      */
-    public function getOption(string $name)
-    {
-    }
+    public function getOption(string $name);
 
     /**
      * Sets an option value by name.
@@ -151,30 +129,22 @@ interface InputInterface
      *
      * @throws InvalidArgumentException When option given doesn't exist
      */
-    public function setOption(string $name, mixed $value)
-    {
-    }
+    public function setOption(string $name, mixed $value);
 
     /**
      * Returns true if an InputOption object exists by name.
      */
-    public function hasOption(string $name): bool
-    {
-    }
+    public function hasOption(string $name): bool;
 
     /**
      * Is this input means interactive?
      */
-    public function isInteractive(): bool
-    {
-    }
+    public function isInteractive(): bool;
 
     /**
      * Sets the input interactivity.
      *
      * @return void
      */
-    public function setInteractive(bool $interactive)
-    {
-    }
+    public function setInteractive(bool $interactive);
 }

--- a/tests/stubs/symfony_component_console_output_outputinterface.php
+++ b/tests/stubs/symfony_component_console_output_outputinterface.php
@@ -39,9 +39,7 @@ interface OutputInterface
      *
      * @return void
      */
-    public function write(string|iterable $messages, bool $newline = false, int $options = 0)
-    {
-    }
+    public function write(string|iterable $messages, bool $newline = false, int $options = 0);
 
     /**
      * Writes a message to the output and adds a newline at the end.
@@ -51,9 +49,7 @@ interface OutputInterface
      *
      * @return void
      */
-    public function writeln(string|iterable $messages, int $options = 0)
-    {
-    }
+    public function writeln(string|iterable $messages, int $options = 0);
 
     /**
      * Sets the verbosity of the output.
@@ -62,74 +58,54 @@ interface OutputInterface
      *
      * @return void
      */
-    public function setVerbosity(int $level)
-    {
-    }
+    public function setVerbosity(int $level);
 
     /**
      * Gets the current verbosity of the output.
      *
      * @return self::VERBOSITY_*
      */
-    public function getVerbosity(): int
-    {
-    }
+    public function getVerbosity(): int;
 
     /**
      * Returns whether verbosity is quiet (-q).
      */
-    public function isQuiet(): bool
-    {
-    }
+    public function isQuiet(): bool;
 
     /**
      * Returns whether verbosity is verbose (-v).
      */
-    public function isVerbose(): bool
-    {
-    }
+    public function isVerbose(): bool;
 
     /**
      * Returns whether verbosity is very verbose (-vv).
      */
-    public function isVeryVerbose(): bool
-    {
-    }
+    public function isVeryVerbose(): bool;
 
     /**
      * Returns whether verbosity is debug (-vvv).
      */
-    public function isDebug(): bool
-    {
-    }
+    public function isDebug(): bool;
 
     /**
      * Sets the decorated flag.
      *
      * @return void
      */
-    public function setDecorated(bool $decorated)
-    {
-    }
+    public function setDecorated(bool $decorated);
 
     /**
      * Gets the decorated flag.
      */
-    public function isDecorated(): bool
-    {
-    }
+    public function isDecorated(): bool;
 
     /**
      * @return void
      */
-    public function setFormatter(OutputFormatterInterface $formatter)
-    {
-    }
+    public function setFormatter(OutputFormatterInterface $formatter);
 
     /**
      * Returns current output formatter instance.
      */
-    public function getFormatter(): OutputFormatterInterface
-    {
-    }
+    public function getFormatter(): OutputFormatterInterface;
 }


### PR DESCRIPTION
Currently, the logic for removing files the user doesn't have access to from search is done as a post-processing step.

While this filters out the correct entries, it means that the number of returned results is less than the limit asked for (or even 0). Which the search logic interprets as there being no more results.

By applying the filtering as part of the query, we return the number of results asked for.