### PR TITLE
fix: use clean rule when creating a rule from an inherited rule

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -252,6 +252,16 @@ async function changePermission(item: Rule, permission: number, state: number) {
 	const allow = state === STATES.SELF_ALLOW
 	const itemRestorePoint = item.clone()
 	item = item.clone()
+
+	// if we're creating a new rule from an inherited one,
+	// save the inherited state, and clean the current state.
+	if (item.inherited) {
+		item.inheritedPermissions = item.permissions
+		item.inheritedMask = item.mask
+		item.permissions = 0;
+		item.mask = 0;
+	}
+
 	if (inherit) {
 		item.mask = BinaryTools.clear(item.mask, bit)
 		// we can ignore permissions, since they are inherited


### PR DESCRIPTION
Currently, when setting one permission on a currently inherited rule, all set permissions would be copied over to the new rule. Instead of just the permission the user set

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
