### PR TITLE
perf(acl): cut per-folder/path DB queries during PROPFIND

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -59,6 +59,21 @@ use Psr\Log\LoggerInterface;
 class FolderManager {
 	public const SPACE_DEFAULT = -4;
 
+	/**
+	 * Per-request cache of `acl_default_no_permission`; the value only changes on
+	 * folder creation, so it is safe to reuse for the whole request.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $aclDefaultNoPermissionCache = [];
+
+	/**
+	 * Per-request cache of `canManageACL`, keyed by "folderId::uid::excludeAdmins".
+	 *
+	 * @var array<string, bool>
+	 */
+	private array $canManageACLCache = [];
+
 	public function __construct(
 		private readonly IDBConnection $connection,
 		private readonly IGroupManager $groupManager,
@@ -480,6 +495,15 @@ class FolderManager {
 	 * @throws Exception
 	 */
 	public function canManageACL(int $folderId, IUser $user, bool $excludeAdmins = false): bool {
+		$cacheKey = $folderId . '::' . $user->getUID() . '::' . ($excludeAdmins ? '1' : '0');
+		if (isset($this->canManageACLCache[$cacheKey])) {
+			return $this->canManageACLCache[$cacheKey];
+		}
+
+		return $this->canManageACLCache[$cacheKey] = $this->computeCanManageACL($folderId, $user, $excludeAdmins);
+	}
+
+	private function computeCanManageACL(int $folderId, IUser $user, bool $excludeAdmins): bool {
 		$userId = $user->getUId();
 		if (!$excludeAdmins && $this->groupManager->isAdmin($userId)) {
 			return true;
@@ -921,6 +945,8 @@ class FolderManager {
 
 		$query->executeStatement();
 
+		$this->invalidateFolderAclCache($folderId);
+
 		$action = $manageAcl ? 'given' : 'revoked';
 		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The %s "%s" was %s acl management rights to the groupfolder with id %d', [$type, $id, $action, $folderId]));
 	}
@@ -955,6 +981,8 @@ class FolderManager {
 			$query->executeStatement();
 
 			$this->connection->commit();
+
+			$this->invalidateFolderAclCache($folderId);
 
 			$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The groupfolder with id %d was removed', [$folderId]));
 
@@ -1016,6 +1044,9 @@ class FolderManager {
 			->where($query->expr()->eq('mapping_id', $query->createNamedParameter($groupId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('group')));
 		$query->executeStatement();
+
+		// group_folders_manage rows were removed, so canManageACL results may change
+		$this->canManageACLCache = [];
 	}
 
 	/**
@@ -1033,6 +1064,9 @@ class FolderManager {
 			->where($query->expr()->eq('mapping_id', $query->createNamedParameter($userId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('user')));
 		$query->executeStatement();
+
+		// group_folders_manage rows were removed, so canManageACL results may change
+		$this->canManageACLCache = [];
 	}
 
 	/**
@@ -1070,6 +1104,8 @@ class FolderManager {
 				->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId)));
 			$query->executeStatement();
 		}
+
+		$this->invalidateFolderAclCache($folderId);
 
 		$action = $acl ? 'enabled' : 'disabled';
 		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('Advanced permissions for the groupfolder with id %d was %s', [$folderId, $action]));
@@ -1209,6 +1245,10 @@ class FolderManager {
 	}
 
 	public function hasFolderACLDefaultNoPermission(int $folderId): bool {
+		if (isset($this->aclDefaultNoPermissionCache[$folderId])) {
+			return $this->aclDefaultNoPermissionCache[$folderId];
+		}
+
 		$qb = $this->connection->getQueryBuilder();
 
 		$query = $qb
@@ -1220,7 +1260,29 @@ class FolderManager {
 		$hasDefaultNoPermission = (bool)$result->fetchOne();
 		$result->closeCursor();
 
-		return $hasDefaultNoPermission;
+		return $this->aclDefaultNoPermissionCache[$folderId] = $hasDefaultNoPermission;
+	}
+
+	/**
+	 * Seed the cache from an already-loaded folder so bulk callers (the mount
+	 * provider) skip one `getBasePermission()` lookup per folder.
+	 */
+	public function primeAclDefaultNoPermission(FolderDefinition $folder): void {
+		$this->aclDefaultNoPermissionCache[$folder->id] = $folder->aclDefaultNoPermission;
+	}
+
+	/**
+	 * Drop request-scoped memoized ACL state for a folder.
+	 *
+	 * Call after any mutation that can change `acl_default_no_permission` or the
+	 * set of users/groups allowed to manage a folder's ACL, so later reads within
+	 * the same request observe the new value.
+	 */
+	private function invalidateFolderAclCache(int $folderId): void {
+		unset($this->aclDefaultNoPermissionCache[$folderId]);
+		// canManageACL keys embed the folder id together with user/excludeAdmins;
+		// clearing the whole (small, request-scoped) map is simplest and safe.
+		$this->canManageACLCache = [];
 	}
 
 	public function countAllFolders(): int {

--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -116,7 +116,8 @@ class FolderStorageManager {
 				'acl_manager' => $aclManager,
 				'in_share' => $inShare,
 				'folder_id' => $folderId,
-				'storage_id' => $storage->getCache()->getNumericStorageId(),
+				// already loaded with the folder; avoids a storages lookup per folder
+				'storage_id' => $folder->storageId,
 			]);
 		}
 
@@ -250,7 +251,8 @@ class FolderStorageManager {
 				'acl_manager' => $aclManager,
 				'in_share' => $inShare,
 				'folder_id' => $folderId,
-				'storage_id' => $rootStorage->getCache()->getNumericStorageId(),
+				// already loaded; the same id MountProvider uses for rule lookups (incl. legacy root-jail)
+				'storage_id' => $folder->storageId,
 			]);
 		}
 

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -54,6 +54,12 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 	public function getMountsForUser(IUser $user, IStorageFactory $loader): array {
 		$folders = $this->folderManager->getFoldersForUser($user);
 
+		// The folder definitions already carry `aclDefaultNoPermission`; prime the
+		// cache so the per-folder `getBasePermission()` below does not re-query it.
+		foreach ($folders as $folder) {
+			$this->folderManager->primeAclDefaultNoPermission($folder);
+		}
+
 		$mountPoints = array_map(fn (FolderDefinitionWithPermissions $folder): string => 'files/' . $folder->mountPoint, $folders);
 		$conflicts = $this->findConflictsForUser($user, $mountPoints);
 
@@ -307,6 +313,8 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 		$folders = $this->folderManager->getFoldersForUser($user, null, $relativePaths);
 
 		foreach ($folders as $folder) {
+			$this->folderManager->primeAclDefaultNoPermission($folder);
+
 			$mountPoint = '/' . $user->getUID() . '/files/' . $folder->mountPoint;
 
 			$mounts[$mountPoint] = $this->getMount(

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -16,6 +16,7 @@ use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeLoader;
@@ -516,5 +517,148 @@ class FolderManagerTest extends TestCase {
 			throw new \Exception('Folder not found');
 		}
 		$this->assertEquals(1024 ** 4, $folder->quota);
+	}
+
+	/**
+	 * Regression test for the PROPFIND/ACL per-path query.
+	 *
+	 * `hasFolderACLDefaultNoPermission()` is called once per path during ACL
+	 * permission calculation (`ACLManager::getBasePermission`). It must be served
+	 * from a request-scoped cache instead of querying `group_folders` every time.
+	 */
+	public function testHasFolderACLDefaultNoPermissionIsMemoizedUntilInvalidated(): void {
+		$folderId = $this->manager->createFolder('acl-default-test', [], true);
+
+		// First read populates the cache.
+		$this->assertTrue($this->manager->hasFolderACLDefaultNoPermission($folderId));
+
+		// Flip the stored value behind the manager's back.
+		$db = Server::get(IDBConnection::class);
+		$update = $db->getQueryBuilder();
+		$update->update('group_folders')
+			->set('acl_default_no_permission', $update->createNamedParameter(0, IQueryBuilder::PARAM_INT))
+			->where($update->expr()->eq('folder_id', $update->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		$update->executeStatement();
+
+		// Still served from cache: proves the per-call query was eliminated.
+		$this->assertTrue($this->manager->hasFolderACLDefaultNoPermission($folderId));
+
+		// A mutation through the manager invalidates the cache and forces a fresh read.
+		$this->manager->setManageACL($folderId, 'group', 'somegroup', true);
+		$this->assertFalse($this->manager->hasFolderACLDefaultNoPermission($folderId));
+	}
+
+	/**
+	 * Regression test for the repeated manager-mapping lookups.
+	 *
+	 * `canManageACL()` is consulted once per path for folders that grant no
+	 * permission by default. The result is stable within a request, so the
+	 * underlying lookups must only run once.
+	 */
+	public function testCanManageACLIsMemoized(): void {
+		$folderId = $this->manager->createFolder('manage-cache-test');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		// The DB-backed mapping check must run exactly once across both calls.
+		$this->userMappingManager->expects($this->once())
+			->method('userInMappings')
+			->willReturn(false);
+
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+	}
+
+	/**
+	 * The `canManageACL` cache must be dropped when the manager mappings change,
+	 * so a later check within the same request observes the new state.
+	 */
+	public function testCanManageACLCacheInvalidatedOnManageChange(): void {
+		$folderId = $this->manager->createFolder('manage-invalidate-test');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		// Recomputed once before and once after the invalidating mutation.
+		$this->userMappingManager->expects($this->exactly(2))
+			->method('userInMappings')
+			->willReturn(false);
+
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+		$this->manager->setManageACL($folderId, 'group', 'somegroup', true);
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+	}
+
+	/**
+	 * The ACL storage wrapper uses the folder's stored `storage_id` instead of
+	 * resolving the numeric id per folder; this guards that the stored value
+	 * stays equal to the live numeric storage id of the folder's files storage.
+	 */
+	public function testStoredStorageIdMatchesLiveNumericStorageId(): void {
+		$this->config->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+
+		$folderId = $this->manager->createFolder('storage-id-test');
+		$folder = $this->manager->getFolder($folderId);
+		if (!$folder) {
+			throw new \Exception('Folder not found');
+		}
+
+		$storage = $this->folderStorageManager->getBaseStorageForFolder(
+			$folderId,
+			$folder->useSeparateStorage(),
+			$folder,
+			null,
+			false,
+			'files',
+		);
+
+		$this->assertSame($folder->storageId, $storage->getCache()->getNumericStorageId());
+	}
+
+	/**
+	 * Deleting a group removes its manager mappings, so the `canManageACL` cache
+	 * must be dropped for a later check in the same request to stay correct.
+	 */
+	public function testCanManageACLCacheInvalidatedOnGroupDeletion(): void {
+		$folderId = $this->manager->createFolder('group-delete-test');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		// Recomputed once before and once after the group deletion.
+		$this->userMappingManager->expects($this->exactly(2))
+			->method('userInMappings')
+			->willReturn(false);
+
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+		$this->manager->deleteGroup('somegroup');
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+	}
+
+	/**
+	 * Deleting a user removes its manager mappings, so the `canManageACL` cache
+	 * must be dropped as well.
+	 */
+	public function testCanManageACLCacheInvalidatedOnUserDeletion(): void {
+		$folderId = $this->manager->createFolder('user-delete-test');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		// Recomputed once before and once after the user deletion.
+		$this->userMappingManager->expects($this->exactly(2))
+			->method('userInMappings')
+			->willReturn(false);
+
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
+		$this->manager->deleteUser('bob');
+		$this->assertFalse($this->manager->canManageACL($folderId, $user));
 	}
 }


### PR DESCRIPTION
PROPFIND on instances with many group folders is DB-heavy: ACL permission calculation re-queried static folder configuration on **every path**, and the ACL storage wrapper resolved each folder's numeric storage id separately, so
the query count scaled with the number of folders.

Fixes #4095.
Superseed https://github.com/nextcloud/groupfolders/pull/4676.

### Benchmarks

Nextcloud 35 + MariaDB 11.4, **3600 group folders / 172k files**. Query counts are deterministic.

| Path | main | this PR | speedup |
| --- | ---: | ---: | ---: |
| `getMountsForUser` runs on every PROPFIND at the home root | 7,214 q | **14 q** | 9.8× |
| List a 1,000-child folder | 1,004 q | **6 q** | 5.5× |
| List a 1,000-child folder (*no permission by default* + managed) | 3,004 q | **8 q** | 14.5× |

`FolderManagerTest` covers the memoization, cache invalidation (including on group and user deletion), and the storage-id invariant.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
