### PR TITLE
Add accessible header for the actions column

### DIFF
--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -426,7 +426,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 							<SortArrow name='acl' value={this.state.sort}
 								   direction={this.state.sortOrder}/>
 						</th>
-						<th/>
+						<th>
+							<span className="hidden-visually">{t('groupfolders', 'Actions')}</span>
+						</th>
 					</tr>
 				</thead>
 				<FlipMove typeName='tbody' enterAnimation="accordionVertical" leaveAnimation="accordionVertical">


### PR DESCRIPTION
## Summary

The actions column in the Team folders admin settings table rendered an empty `<th/>` header cell. This adds a visually hidden, translatable "Actions" label so the column has an accessible name without changing the visual layout.

## Why this matters

The header cell for the per-row edit and delete controls had no text or accessible name, so screen readers announced an unlabeled column and assistive-technology users were left without context for the action controls in each row (#4464). The label uses the existing `hidden-visually` class (already used in `SharingSidebarView.vue`) and the `t('groupfolders', ...)` helper, so it is localized and visually hidden rather than shown as visible text. The column layout is unchanged.

## Testing

- A screen reader now announces "Actions" for the previously empty header column.
- The table header row is visually unchanged; the label is visually hidden via `hidden-visually`.
- `eslint src/settings/App.tsx` introduces no new errors from this change (the pre-existing errors in the file are unrelated and present on `master`).

Fixes #4464
