### PR TITLE
fix: fix search results when no paths are forbidden

### DIFF
--- a/lib/ACL/ACLCacheWrapper.php
+++ b/lib/ACL/ACLCacheWrapper.php
@@ -117,6 +117,9 @@ class ACLCacheWrapper extends CacheWrapper {
 	 */
 	private function getSearchFilter(): ISearchOperator {
 		$forbiddenPaths = $this->aclManager->getForbiddenPaths($this->getNumericStorageId(), '');
+		if (count($forbiddenPaths) === 0) {
+			return new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, []);
+		}
 
 		$filters = array_map(fn (string $path) => new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_NOT, [
 			new SearchComparison(ISearchComparison::COMPARE_LIKE_CASE_SENSITIVE, 'path', SearchComparison::escapeLikeParameter($path) . '/%')

--- a/tests/ACL/ACLCacheWrapperTest.php
+++ b/tests/ACL/ACLCacheWrapperTest.php
@@ -129,7 +129,6 @@ class ACLCacheWrapperTest extends TestCase {
 		$sourceStorage->touch('bar/test2.txt', 201);
 		$sourceStorage->touch('bar/test3.txt', 202);
 		$sourceStorage->getScanner()->scan('');
-		$this->aclPermissions['bar'] = 0;
 
 		$cache = new ACLCacheWrapper($sourceStorage->getCache(), $this->aclManager, 0, false);
 
@@ -139,6 +138,16 @@ class ACLCacheWrapperTest extends TestCase {
 			0,
 			[new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime')]
 		);
+		$result = $cache->searchQuery($query);
+		$paths = array_map(fn (ICacheEntry $entry) => $entry->getPath(), $result);
+
+		$this->assertEquals([
+			'bar/test3.txt',
+			'bar/test2.txt'
+		], $paths);
+
+		$this->aclPermissions['bar'] = 0;
+
 		$result = $cache->searchQuery($query);
 		$paths = array_map(fn (ICacheEntry $entry) => $entry->getPath(), $result);
 


### PR DESCRIPTION
I'm not sure why `not in []` doesn't just become a noop.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
