### PR TITLE
fix(a11y): make team folder edit buttons keyboard-operable

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -44,9 +44,11 @@
 			}
 		}
 
-		.action-rename {
-			// Reset default button chrome so the focusable rename control
-			// keeps the inline text appearance of the former <a> element.
+		// Reset default button chrome so the focusable rename control keeps
+		// the inline text appearance of the former <a>. Scoped to the button
+		// so the sibling <a class="action-rename"> in the groups column keeps
+		// its own link styling.
+		button.action-rename {
 			display: inline;
 			padding: 0;
 			margin: 0;
@@ -56,7 +58,9 @@
 			color: inherit;
 			text-align: inherit;
 			cursor: pointer;
+		}
 
+		.action-rename {
 			&::after {
 				display: inline-block;
 				position: relative;

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -192,7 +192,8 @@
 					color: var(--color-text-lighter);
 				}
 				&.mountpoint {
-					a {
+					a,
+					button.action-rename {
 						color: var(--color-main-text);
 						font-weight: bold;
 					}

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -45,6 +45,18 @@
 		}
 
 		.action-rename {
+			// Reset default button chrome so the focusable rename control
+			// keeps the inline text appearance of the former <a> element.
+			display: inline;
+			padding: 0;
+			margin: 0;
+			border: none;
+			background: none;
+			font: inherit;
+			color: inherit;
+			text-align: inherit;
+			cursor: pointer;
+
 			&::after {
 				display: inline-block;
 				position: relative;
@@ -87,7 +99,8 @@
 			width: 32px;
 		}
 
-		a.icon {
+		a.icon,
+		button.icon {
 			margin-left: 5px;
 		}
 	}
@@ -119,6 +132,18 @@
 		&.icon-visible {
 			opacity: 0.5;
 		}
+	}
+
+	// Strip default button chrome from the icon-only action buttons so
+	// the focusable controls keep the glyph-only look of the former <a>.
+	button.icon {
+		width: 16px;
+		height: 16px;
+		padding: 0;
+		border: none;
+		background-color: transparent;
+		vertical-align: middle;
+		cursor: pointer;
 	}
 
 	.newgroup-name {

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -319,15 +319,17 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 									}}
 									initialValue={folder.mount_point}
 								/>
-								: <a
+								: <button
+									type="button"
 									className="action-rename"
+									aria-label={t('groupfolders', 'Rename')}
 									onClick={event => {
 										event.stopPropagation()
 										this.setState({ editingMountPoint: id })
 									}}
 								>
 									{folder.mount_point}
-								</a>
+								</button>
 							}
 						</td>
 						<td className="groups">
@@ -365,9 +367,11 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 							}
 						</td>
 						<td className="remove">
-							<a className="icon icon-delete icon-visible"
-						   onClick={this.deleteFolder.bind(this, folder)}
-						   title={t('groupfolders', 'Delete')}/>
+							<button type="button"
+								className="icon icon-delete icon-visible"
+								aria-label={t('groupfolders', 'Delete')}
+								onClick={this.deleteFolder.bind(this, folder)}
+								title={t('groupfolders', 'Delete')}/>
 						</td>
 					</tr>
 				})

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -322,7 +322,7 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 								: <button
 									type="button"
 									className="action-rename"
-									aria-label={t('groupfolders', 'Rename')}
+									aria-label={t('groupfolders', 'Rename "{mountPoint}"', { mountPoint: folder.mount_point })}
 									onClick={event => {
 										event.stopPropagation()
 										this.setState({ editingMountPoint: id })


### PR DESCRIPTION
## Summary

The team folders admin settings table rendered its row action controls as bare `<a>` elements with an `onClick` handler but no `href`:

- the rename trigger (the mount-point name), and
- the delete control (`<a className="icon icon-delete icon-visible">`).

Anchors without an `href` are not part of the tab order and do not respond to Enter/Space activation, so keyboard-only and screen-reader users could not rename or delete a team folder from the settings table.

This PR replaces those non-interactive anchors with native `<button type="button">` elements that carry the existing `onClick` handlers and a discernible `aria-label`. Buttons are natively focusable and fire on Enter/Space, restoring keyboard operability without a custom keydown handler. Minimal SCSS strips the default button chrome so the controls keep their prior icon/text appearance.

Notable accessibility detail: the rename button's `aria-label` includes the folder name (`Rename "{mountPoint}"`) so each row remains identifiable to screen-reader and voice-control users rather than every row being announced only as "Rename". The button-chrome reset is scoped to `button.action-rename` so the sibling `<a class="action-rename">` in the groups column keeps its existing link styling.

## Why this matters

Closes a WCAG keyboard-operability gap (2.1.1 Keyboard) in the team folders settings UI. The issue was filed by a maintainer and triaged by the Nextcloud team to the actionable `1. to develop` state (ref #4466). Scope is intentionally limited to the keyboard-interactivity fix for the row action controls.

## Testing

- Keyboard: Tab now reaches each row's rename and delete control, and Enter/Space activates the same handler the click path invokes (rename enters edit mode; delete prompts/removes the folder).
- Screen reader: each control exposes a non-empty accessible name ("Rename \"<folder>\"" / "Delete") rather than an empty, non-focusable anchor.
- Visual regression: the icon-only delete button and the inline rename control render with the same size/position/glyph as the prior anchors (no button background, border, or extra padding).
- Mouse: clicking the controls still renames/deletes exactly as before.
- `eslint src/settings/App.tsx` and `stylelint src/settings/App.scss` report no new findings on the changed lines (pre-existing warnings/errors unrelated to this change remain).

Fixes #4466
