### PR TITLE
fix(settings): Do not initiate ACL search right away

### DIFF
--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -542,7 +542,6 @@ function ManageAclSelect({ onChange, onSearch, folder }: ManageAclSelectProps) {
 		loadOptions={handleSearch}
 		isMulti
 		cacheOptions
-		defaultOptions
 		defaultValue={folder.manage}
 		isClearable={false}
 		onChange={(option, details) => {


### PR DESCRIPTION
Each Team folder row with ACL enabled was issuing a request to the server when the settings page was loaded.