### PR TITLE
fix: Fix adding a custom override to an inherited permission in UI

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -275,7 +275,7 @@ async function changePermission(item: Rule, permission: number, state: number) {
 	}
 
 	item.inherited = false
-	list.value.splice(index, 1, item)
+	list.value.splice(index, index >= 0 ? 1 : 0, item)
 	loading.value = true
 	try {
 		await setAcls(props.node.path, list.value.filter((rule) => !rule.inherited))


### PR DESCRIPTION
`list` contains the rules with custom overrides, but not the inherited rules without any custom override. Therefore, when the first custom override was added to an inherited rule the rule was not found in `list`, so `index` was `-1`, and `splice` wrongly removed the last item in the list and replaced it with the inherited rule.


## How to test

- As an admin, open the Accounts settings
- Create a group
- Create users _manager_, _user0_ and _user1_ and add them to the group
- Enable Team folders
- Create a team folder for the group
- Enable advanced permissions and set user _manager_ as the user that can manage them
- Log in as user _manager_
- Open the Files app
- Open the details for the team folder
- Add rules for _user0_ and _user1_
- Enter in the team folder
- Create a subfolder
- Open the details for the subfolder
- Add read permissions for _user0_
- Add read permissions for _user1_

### Result with this pull request

Both _user0_ and _user1_ have read permissions

### Result without this pull request

Only _user1_ has read permissions
