### PR TITLE
Fix getting state constants of inherited rules

### DIFF
--- a/src/components/SharingSidebarView.vue
+++ b/src/components/SharingSidebarView.vue
@@ -85,9 +85,10 @@ watch(() => props.node, async () => {
  */
 function getState(permission: number, item) {
 	// check if not inherited the permission
-	if ((permission & ~item.mask) === 0) {
+	if (!item.inherited && (permission & ~item.mask) === 0) {
 		return ((permission & item.permissions) > 0) ? STATES.SELF_ALLOW : STATES.SELF_DENY
-	} else if ((permission & ~item.inheritedMask) === 0) {
+	} else if ((!item.inherited && (permission & ~item.inheritedMask) === 0)
+				|| (item.inherited && (permission & ~item.mask) === 0)) {
 		return ((permission & item.inheritedPermissions) > 0) ? STATES.INHERIT_ALLOW : STATES.INHERIT_DENY
 	} else {
 		return STATES.INHERIT_DEFAULT


### PR DESCRIPTION
The permissions of inherited rules without custom overrides are included in the mask, so they were rendered as custom "allow" or "deny" states. Moreover, the inherited mask can be used only on rules with custom overrides, as [in inherited rules without custom overrides it is always 0](https://github.com/nextcloud/groupfolders/blob/c7260371fe695aa13c9243b62c5e5aba048cea06/src/services/acl.ts#L97-L105) and the normal mask should be checked instead.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
-- | --
<img width="480" height="221" alt="Groupfolders-Inherited-Rule-State-Before" src="https://github.com/user-attachments/assets/de70640c-b4b8-422f-8786-1130d2326884" /> | <img width="480" height="221" alt="Groupfolders-Inherited-Rule-State-After" src="https://github.com/user-attachments/assets/b9f97f5b-c486-4c60-952e-4ed89cbe81a3" />

## How to test

- As an admin, open the Accounts settings
- Create a group
- Create users _manager_ and _user0_ and add them to the group
- Enable Team folders
- Create a team folder for the group
- Enable advanced permissions and set user _manager_ as the user that can manage them
- Log in as user _manager_
- Open the Files app
- Open the details for the team folder
- Add a +read, -write rule for _user0_
- Enter in the team folder
- Create a subfolder
- Open the details for the subfolder
- Hover on the read and write permissions of the rule

### Result with this pull request

The tooltip shows _Allowed (Inherited permission)_ and _Denied (Inherited permission)_

### Result without this pull request

The tooltip shows _Allowed_ and _Denied_
