### PR TITLE
perf: Optimize call to userInMappings when no circle mapping is present

### DIFF
--- a/lib/ACL/UserMapping/UserMappingManager.php
+++ b/lib/ACL/UserMapping/UserMappingManager.php
@@ -121,10 +121,25 @@ class UserMappingManager implements IUserMappingManager {
 
 	#[\Override]
 	public function userInMappings(IUser $user, array $mappings): bool {
+		$userGroupIds = array_flip($this->groupManager->getUserGroupIds($user));
+
+		$hasCircleMapping = false;
 		foreach ($mappings as $mapping) {
 			if ($mapping->getType() === 'user' && $mapping->getId() === $user->getUID()) {
 				return true;
 			}
+
+			if ($mapping->getType() === 'group' && isset($userGroupIds[$mapping->getId()])) {
+				return true;
+			}
+
+			if ($mapping->getType() === 'circle') {
+				$hasCircleMapping = true;
+			}
+		}
+
+		if (!$hasCircleMapping) {
+			return false;
 		}
 
 		$mappingKeys = array_map(fn (IUserMapping $mapping): string => $mapping->getKey(), $mappings);


### PR DESCRIPTION
Then we just need to load the list of group ids the user is in and not additionally the group display name which is the expensive part.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
