### PR TITLE
fix(ci): replace buildjet/cache with actions/cache

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -81,7 +81,7 @@ jobs:
           TESTING=true npm run build --if-present
 
       - name: Save context
-        uses: buildjet/cache/save@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Restore context
-        uses: buildjet/cache/restore@3e70d19e31d6a8030aeddf6ed8dbe601f94d09f4 # v4.0.2
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           fail-on-cache-miss: true
           key: cypress-context-${{ github.run_id }}


### PR DESCRIPTION
Buildjet for GitHub Actions shut down on 2026-03-31.
https://buildjet.com/for-github-actions/blog/we-are-shutting-down

Their cache action is interoperable with actions/cache, so swap to the official action to avoid depending on unmaintained infrastructure.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
