### PR TITLE
feat(folder-manager): add methods to check if group or circle has associated team folders

### DIFF
--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -737,6 +737,52 @@ class FolderManager {
 	}
 
 	/**
+	 * @throws \InvalidArgumentException
+	 * @throws Exception
+	 */
+	public function hasFolderForGroup(string $groupId): bool {
+		if ($groupId === '') {
+			throw new \InvalidArgumentException('groupId cannot be empty');
+		}
+
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->count('*'))
+			->from('group_folders_groups')
+			->where($query->expr()->eq('group_id', $query->createNamedParameter($groupId)));
+
+		$result = $query->executeQuery();
+		/** @var int $count */
+		$count = $result->fetchOne();
+		$result->closeCursor();
+
+		return ($count) > 0;
+	}
+
+	/**
+	 * @throws \InvalidArgumentException
+	 * @throws Exception
+	 */
+	public function hasFolderForCircle(string $circleId): bool {
+		if ($circleId === '') {
+			throw new \InvalidArgumentException('circleId cannot be empty');
+		}
+
+		$query = $this->connection->getQueryBuilder();
+
+		$query->select($query->func()->count('*'))
+			->from('group_folders_groups')
+			->where($query->expr()->eq('circle_id', $query->createNamedParameter($circleId)));
+
+		$result = $query->executeQuery();
+		/** @var int $count */
+		$count = $result->fetchOne();
+		$result->closeCursor();
+
+		return ($count) > 0;
+	}
+
+	/**
 	 * @param list<string> $paths
 	 * @return list<FolderDefinitionWithPermissions>
 	 * @throws Exception


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Related to: https://github.com/nextcloud/circles/pull/2615

## Summary

Adds two methods to `lib/Folder/FolderManager` to check whether a group or circle has any team folder shared with it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)

## AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
