### PR TITLE
[stable33] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "groupfolders",
-      "version": "21.0.9",
+      "version": "21.0.10",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@mdi/svg": "^7.4.47",


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 19 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/cypress](#user-content-\\@nextcloud\\/cypress)
## Fixed vulnerabilities

### `@nextcloud/cypress` <a href="#user-content-\@nextcloud\/cypress" id="\@nextcloud\/cypress">#</a>
* Caused by vulnerable dependency:
  * [cypress](#user-content-cypress)
* Affected versions: 
* Package usage:
  * `node_modules/@nextcloud/cypress`