### PR TITLE
fix: Move trash items cross-storage when updating trashed children

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ As of Hub 10 / Nextcloud 31, admins must be members of a team to assign that tea
 Folder.
 ]]>
 	</description>
-	<version>23.0.0-dev.0</version>
+	<version>23.0.0-dev.1</version>
 	<licence>agpl</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>

--- a/lib/Listeners/NodeRenamedListener.php
+++ b/lib/Listeners/NodeRenamedListener.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\Listeners;
 
 use OCA\GroupFolders\Mount\GroupFolderStorage;
-use OCA\GroupFolders\Trash\TrashManager;
+use OCA\GroupFolders\Trash\TrashBackend;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeRenamedEvent;
@@ -21,7 +21,7 @@ use OCP\Files\Folder;
  */
 class NodeRenamedListener implements IEventListener {
 	public function __construct(
-		private readonly TrashManager $trashManager,
+		private readonly TrashBackend $trashBackend,
 	) {
 	}
 
@@ -58,6 +58,6 @@ class NodeRenamedListener implements IEventListener {
 
 		$sourceParentPath .= $source->getName();
 		$targetPath = $target->getInternalPath();
-		$this->trashManager->updateTrashedChildren($sourceParentStorage->getFolderId(), $targetStorage->getFolderId(), $sourceParentPath, $targetPath);
+		$this->trashBackend->updateTrashedChildren($sourceParentStorage, $targetStorage, $sourceParentPath, $targetPath);
 	}
 }

--- a/lib/Migration/Version2300000Date20260722115802.php
+++ b/lib/Migration/Version2300000Date20260722115802.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCA\GroupFolders\Trash\TrashBackend;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * One-off repair to find trash items whose `group_folders_trash` row was
+ * updated to point to a new Team folder but the actual entries weren't.
+ */
+class Version2300000Date20260722115802 extends SimpleMigrationStep {
+	public function __construct(
+		private readonly TrashBackend $trashBackend,
+	) {
+	}
+
+	#[\Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$fixed = $this->trashBackend->repairMisplacedTrashItems();
+		if ($fixed > 0) {
+			$output->info("Moved $fixed team folder trash item(s) to their correct storage");
+		}
+	}
+}

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -718,4 +718,63 @@ class TrashBackend implements ITrashBackend {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 		}
 	}
+
+	/**
+	 * Find trash items whose `group_folders_trash` row was updated to point to a
+	 * new Team folder but the actual entries weren't.
+	 *
+	 * @return int the number of trash items that were moved
+	 */
+	public function repairMisplacedTrashItems(): int {
+		$folders = $this->folderManager->getAllFolders();
+		if ($folders === []) {
+			return 0;
+		}
+
+		$trashFoldersById = [];
+		$nodesByFilename = [];
+		foreach ($folders as $folderId => $folder) {
+			try {
+				$trashFoldersById[$folderId] = $trashFolder = $this->setupTrashFolder($folder);
+			} catch (\Exception $e) {
+				$this->logger->error($e->getMessage(), ['exception' => $e]);
+				continue;
+			}
+
+			foreach ($trashFolder->getDirectoryListing() as $node) {
+				$nodesByFilename[$node->getName()][] = ['folderId' => $folderId, 'node' => $node];
+			}
+		}
+
+		$rows = $this->trashManager->listTrashForFolders(array_keys($folders));
+
+		$fixed = 0;
+		foreach ($rows as $row) {
+			$expectedTrashFolder = $trashFoldersById[$row['folder_id']] ?? null;
+			if ($expectedTrashFolder === null) {
+				continue;
+			}
+
+			$filename = $row['name'] . '.d' . $row['deleted_time'];
+			if ($expectedTrashFolder->nodeExists($filename)) {
+				continue;
+			}
+
+			foreach ($nodesByFilename[$filename] ?? [] as $candidate) {
+				if ($candidate['folderId'] === $row['folder_id']) {
+					continue;
+				}
+
+				try {
+					$candidate['node']->move($expectedTrashFolder->getPath() . '/' . $filename);
+					$fixed++;
+				} catch (\Exception $e) {
+					$this->logger->error($e->getMessage(), ['exception' => $e]);
+				}
+				break;
+			}
+		}
+
+		return $fixed;
+	}
 }

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -679,4 +679,43 @@ class TrashBackend implements ITrashBackend {
 
 		return [$count, $size];
 	}
+
+	public function updateTrashedChildren(IStorage $fromFolder, IStorage $toFolder, string $fromLocation, string $toLocation): void {
+		/** @var GroupFolderStorage $fromFolder */
+		/** @var GroupFolderStorage $toFolder */
+		$fromFolderId = $fromFolder->getFolderId();
+		$toFolderId = $toFolder->getFolderId();
+
+		// Move the trash items to their new storage
+		if ($fromFolder->getCache()->getNumericStorageId() !== $toFolder->getCache()->getNumericStorageId()) {
+			$this->moveTrashItems($fromFolderId, $toFolderId, $fromLocation);
+		}
+
+		// Update entries in group_folder_trash
+		$this->trashManager->updateTrashedChildren($fromFolderId, $toFolderId, $fromLocation, $toLocation);
+	}
+
+	private function moveTrashItems(int $fromFolderId, int $toFolderId, string $fromLocation): void {
+		try {
+			$toFolderDefinition = $this->folderManager->getFolder($toFolderId);
+			if ($toFolderDefinition === null) {
+				return;
+			}
+			$destinationFolder = $this->setupTrashFolder($toFolderDefinition);
+
+			$fromFolderDefinition = $this->folderManager->getFolder($fromFolderId);
+			if ($fromFolderDefinition === null) {
+				return;
+			}
+			$sourceFolder = $this->setupTrashFolder($fromFolderDefinition);
+
+			foreach ($this->trashManager->getTrashItemsFromSubfolder($fromFolderId, $fromLocation) as $item) {
+				$trashPath = $item['name'] . '.d' . $item['deleted_time'];
+				$trashNode = $sourceFolder->get($trashPath);
+				$trashNode->move($destinationFolder->getPath() . '/' . $trashPath);
+			}
+		} catch (\Exception $e) {
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+		}
+	}
 }

--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -732,46 +732,45 @@ class TrashBackend implements ITrashBackend {
 		}
 
 		$trashFoldersById = [];
-		$nodesByFilename = [];
 		foreach ($folders as $folderId => $folder) {
 			try {
-				$trashFoldersById[$folderId] = $trashFolder = $this->setupTrashFolder($folder);
+				$trashFoldersById[$folderId] = $this->setupTrashFolder($folder);
 			} catch (\Exception $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				continue;
-			}
-
-			foreach ($trashFolder->getDirectoryListing() as $node) {
-				$nodesByFilename[$node->getName()][] = ['folderId' => $folderId, 'node' => $node];
 			}
 		}
 
-		$rows = $this->trashManager->listTrashForFolders(array_keys($folders));
+		/** @var list<array{folderId: int, filename: string}> $missing */
+		$missing = [];
+		foreach ($trashFoldersById as $folderId => $trashFolder) {
+			foreach ($this->trashManager->listTrashForFolders([$folderId]) as $row) {
+				$filename = $row['name'] . '.d' . $row['deleted_time'];
+				if (!$trashFolder->nodeExists($filename)) {
+					$missing[] = ['folderId' => $folderId, 'filename' => $filename];
+				}
+			}
+		}
 
 		$fixed = 0;
-		foreach ($rows as $row) {
-			$expectedTrashFolder = $trashFoldersById[$row['folder_id']] ?? null;
-			if ($expectedTrashFolder === null) {
-				continue;
+		foreach ($trashFoldersById as $candidateFolderId => $candidateTrashFolder) {
+			if ($missing === []) {
+				break;
 			}
 
-			$filename = $row['name'] . '.d' . $row['deleted_time'];
-			if ($expectedTrashFolder->nodeExists($filename)) {
-				continue;
-			}
-
-			foreach ($nodesByFilename[$filename] ?? [] as $candidate) {
-				if ($candidate['folderId'] === $row['folder_id']) {
+			foreach ($missing as $index => $entry) {
+				if ($entry['folderId'] === $candidateFolderId || !$candidateTrashFolder->nodeExists($entry['filename'])) {
 					continue;
 				}
 
 				try {
-					$candidate['node']->move($expectedTrashFolder->getPath() . '/' . $filename);
+					$candidateTrashFolder->get($entry['filename'])
+						->move($trashFoldersById[$entry['folderId']]->getPath() . '/' . $entry['filename']);
 					$fixed++;
 				} catch (\Exception $e) {
 					$this->logger->error($e->getMessage(), ['exception' => $e]);
 				}
-				break;
+
+				unset($missing[$index]);
 			}
 		}
 

--- a/lib/Trash/TrashManager.php
+++ b/lib/Trash/TrashManager.php
@@ -127,4 +127,31 @@ class TrashManager {
 			->andWhere($query->expr()->eq('original_location', $query->createNamedParameter($fromLocation, IQueryBuilder::PARAM_STR)));
 		$query->executeStatement();
 	}
+
+	/**
+	 * @return \Generator<array{trash_id: int, name: string, deleted_time: int, original_location: string, folder_id: int, file_id: ?int, deleted_by: ?string}>
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getTrashItemsFromSubfolder(int $fromFolderId, string $fromLocation): \Generator {
+		$query = $this->connection->getQueryBuilder();
+		$query->select(['trash_id', 'name', 'deleted_time', 'original_location', 'folder_id', 'file_id', 'deleted_by'])
+			->from('group_folders_trash')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($fromFolderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->like('original_location', $query->createNamedParameter($fromLocation . '%', IQueryBuilder::PARAM_STR)));
+
+		$result = $query->executeQuery();
+
+		foreach ($result->iterateAssociative() as $row) {
+			/** @var array{trash_id: int|string, name: string, deleted_time: int|string, original_location: string, folder_id: int|string, file_id: null|int|string, deleted_by: ?string} $row */
+			yield [
+				'trash_id' => (int)$row['trash_id'],
+				'name' => $row['name'],
+				'deleted_time' => (int)$row['deleted_time'],
+				'original_location' => $row['original_location'],
+				'folder_id' => (int)$row['folder_id'],
+				'file_id' => $row['file_id'] !== null ? (int)$row['file_id'] : null,
+				'deleted_by' => $row['deleted_by'] ?? null,
+			];
+		}
+	}
 }

--- a/lib/Trash/TrashManager.php
+++ b/lib/Trash/TrashManager.php
@@ -137,7 +137,10 @@ class TrashManager {
 		$query->select(['trash_id', 'name', 'deleted_time', 'original_location', 'folder_id', 'file_id', 'deleted_by'])
 			->from('group_folders_trash')
 			->where($query->expr()->eq('folder_id', $query->createNamedParameter($fromFolderId, IQueryBuilder::PARAM_INT)))
-			->andWhere($query->expr()->like('original_location', $query->createNamedParameter($fromLocation . '%', IQueryBuilder::PARAM_STR)));
+			->andWhere($query->expr()->orX(
+				$query->expr()->eq('original_location', $query->createNamedParameter($fromLocation, IQueryBuilder::PARAM_STR)),
+				$query->expr()->like('original_location', $query->createNamedParameter($this->connection->escapeLikeParameter($fromLocation) . '/%')),
+			));
 
 		$result = $query->executeQuery();
 

--- a/tests/Listeners/NodeRenamedListenerTest.php
+++ b/tests/Listeners/NodeRenamedListenerTest.php
@@ -11,7 +11,7 @@ namespace OCA\GroupFolders\Tests\Listeners\NodeRenamedListener;
 
 use OCA\GroupFolders\Listeners\NodeRenamedListener;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
-use OCA\GroupFolders\Trash\TrashManager;
+use OCA\GroupFolders\Trash\TrashBackend;
 use OCP\EventDispatcher\Event;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\File;
@@ -20,7 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class NodeRenamedListenerTest extends TestCase {
-	private TrashManager&MockObject $trashManager;
+	private TrashBackend&MockObject $trashBackend;
 	private NodeRenamedListener $listener;
 	private GroupFolderStorage&MockObject $sourceParentStorage;
 	private Folder&MockObject $sourceParent;
@@ -34,9 +34,9 @@ class NodeRenamedListenerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->trashManager = $this->createMock(TrashManager::class);
+		$this->trashBackend = $this->createMock(TrashBackend::class);
 
-		$this->listener = new NodeRenamedListener($this->trashManager);
+		$this->listener = new NodeRenamedListener($this->trashBackend);
 
 		$this->sourceParentStorage = $this->createMock(GroupFolderStorage::class);
 		$this->sourceParentStorage
@@ -118,10 +118,10 @@ class NodeRenamedListenerTest extends TestCase {
 			->method('instanceOfStorage')
 			->willReturn(true);
 
-		$this->trashManager
+		$this->trashBackend
 			->expects($this->once())
 			->method('updateTrashedChildren')
-			->with(1, 2, 'abc/test.txt', 'def');
+			->with($this->sourceParentStorage, $this->targetStorage, 'abc/test.txt', 'def');
 
 		$this->listener->handle($this->event);
 	}
@@ -152,10 +152,10 @@ class NodeRenamedListenerTest extends TestCase {
 			->method('instanceOfStorage')
 			->willReturn(true);
 
-		$this->trashManager
+		$this->trashBackend
 			->expects($this->once())
 			->method('updateTrashedChildren')
-			->with(1, 2, 'test.txt', 'def');
+			->with($this->sourceParentStorage, $this->targetStorage, 'test.txt', 'def');
 
 		$this->listener->handle($this->event);
 	}
@@ -163,7 +163,7 @@ class NodeRenamedListenerTest extends TestCase {
 	public function testHandleTargetNotAFolder(): void {
 		$this->target = $this->createMock(File::class);
 
-		$this->trashManager
+		$this->trashBackend
 			->expects($this->never())
 			->method('updateTrashedChildren');
 
@@ -187,7 +187,7 @@ class NodeRenamedListenerTest extends TestCase {
 			->method('instanceOfStorage')
 			->willReturn(false);
 
-		$this->trashManager
+		$this->trashBackend
 			->expects($this->never())
 			->method('updateTrashedChildren');
 
@@ -206,7 +206,7 @@ class NodeRenamedListenerTest extends TestCase {
 			->method('instanceOfStorage')
 			->willReturn(false);
 
-		$this->trashManager
+		$this->trashBackend
 			->expects($this->never())
 			->method('updateTrashedChildren');
 

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -366,4 +366,50 @@ class TrashBackendTest extends TestCase {
 		$this->trashBackend->restoreItem($trashItem);
 		$this->assertTrue($folder->nodeExists('sub'));
 	}
+
+	public function testRepairMisplacedTrashItems(): void {
+		$this->loginAsUser('manager');
+
+		$folder2Id = $this->folderManager->createFolder('gf2');
+		$this->folderManager->addApplicableGroup($folder2Id, 'gf_manager');
+		$this->folderManager->setGroupPermissions($folder2Id, 'gf_manager', Constants::PERMISSION_ALL);
+
+		$file = $this->managerUserFolder->newFile("{$this->folderName}/foo.txt", 'content');
+		$this->trashBackend->moveToTrash($file->getStorage(), $file->getInternalPath());
+		$this->assertFalse($this->managerUserFolder->nodeExists("{$this->folderName}/foo.txt"));
+
+		// Simulate the pre-fix bug by calling TrashManager::updateTrashedChildren instead of
+		// TrashBackend::updateTrashedChildren
+		$this->trashManager->updateTrashedChildren($this->folderId, $folder2Id, 'foo.txt', 'foo.txt');
+
+		$rows = $this->trashManager->listTrashForFolders([$folder2Id]);
+		$this->assertCount(1, $rows);
+		$this->assertSame('foo.txt', $rows[0]['name']);
+
+		/** @var list<GroupTrashItem> $before */
+		$before = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $before);
+		$this->assertSame('', $before[0]->getInternalOriginalLocation());
+		$this->assertSame($this->folderName, $before[0]->getGroupFolderMountPoint());
+
+		$fixed = $this->trashBackend->repairMisplacedTrashItems();
+		$this->assertSame(1, $fixed);
+
+		/** @var list<GroupTrashItem> $after */
+		$after = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $after);
+		$this->assertSame('foo.txt', $after[0]->getInternalOriginalLocation());
+		$this->assertSame('gf2', $after[0]->getGroupFolderMountPoint());
+
+		// Running the repair again does nothing
+		$this->assertSame(0, $this->trashBackend->repairMisplacedTrashItems());
+
+		$folder2 = $this->folderManager->getFolder($folder2Id);
+		$this->assertNotNull($folder2);
+		$folder2WithPermissions = FolderDefinitionWithPermissions::fromFolder($folder2, $folder2->rootCacheEntry, Constants::PERMISSION_ALL);
+		$this->trashBackend->cleanTrashFolder($folder2WithPermissions);
+		$this->folderManager->removeFolder($folder2Id);
+
+		$this->logout();
+	}
 }


### PR DESCRIPTION
Otherwise the group_folders_trash entries will be updated with the new folder_id but not the filecache entries.

This is also relevant when using object stores and a bucket per groupfolder.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly generated using AI (the new unit test in tests/Trash/TrashBackendTest.php, rest was by an human)
