### PR TITLE
fix: quota dropdown options background

### DIFF
--- a/src/settings/EditSelect.scss
+++ b/src/settings/EditSelect.scss
@@ -27,6 +27,10 @@
 		left: 0;
 		margin: 0;
 		background-color: transparent;
+
+		option {
+			background-color: var(--color-main-background);
+		}
 	}
 
 	.quotabar-holder {


### PR DESCRIPTION
Resolve: #4461 

## Summary
Style the Team Folders quota options and keep the closed select background transparent so the used-quota bar remains visible.


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
