### PR TITLE
fix: add label for advanced permissions checkbox

### DIFF
--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -357,7 +357,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 							<input id={'acl-' + folder.id} type="checkbox" className="checkbox" checked={folder.acl} disabled={!App.supportACL()}
 								onChange={(event) => this.setAcl(folder, event.target.checked)}
 							/>
-							<label htmlFor={'acl-' + folder.id} title={t('groupfolders', 'Advanced permissions allows setting permissions on a per-file basis but comes with a performance overhead')}></label>
+							<label htmlFor={'acl-' + folder.id} title={t('groupfolders', 'Advanced permissions allows setting permissions on a per-file basis but comes with a performance overhead')}>
+								<span className="hidden-visually">{t('groupfolders', 'Advanced permissions for "{mountPoint}"', { mountPoint: folder.mount_point })}</span>
+							</label>
 							{folder.acl
 							&& <ManageAclSelect
 								folder={folder}


### PR DESCRIPTION
## Summary
- Fixes an accessibility issue where the Advanced permissions checkbox had an empty `<label>` that only exposed its name via the `title` attribute.
- Adds a visually hidden label text so assistive technologies receive a proper accessible name, while keeping the existing checkbox styling and tooltip.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
