### PR TITLE
fix: thin focus outline for advanced permissions

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -97,6 +97,11 @@
 			& > label {
 				padding-top: 10px;
 			}
+
+			// Core .checkbox focus ring is 1px; use the standard 2px indicator.
+			input.checkbox:focus-visible + label {
+				outline-width: 2px;
+			}
 		}
 
 		&.remove {


### PR DESCRIPTION
Resolves: #4471 

##Summary
Update the focused **Advanced Permissions** checkbox to use a `2px` outline.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
