### PR TITLE
fix: update table header sort accessibility

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -23,10 +23,29 @@
 
 	th {
 		border-bottom: 2px solid var(--color-border);
-		cursor: pointer;
+
+		button.sort-header {
+			display: flex;
+			align-items: center;
+			width: 100%;
+			padding: 0;
+			margin: 0;
+			border: none;
+			background: none;
+			font: inherit;
+			color: inherit;
+			text-align: inherit;
+			border-radius: var(--border-radius-element, var(--border-radius));
+			cursor: pointer;
+
+			&:focus-visible {
+				outline: 2px solid var(--color-main-text);
+				outline-offset: 2px;
+			}
+		}
 
 		.sort_arrow {
-			padding-left: 10px;
+			padding-inline-start: 10px;
 			color: var(--color-text-maxcontrast);
 		}
 	}

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -409,26 +409,42 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 			<table>
 				<thead>
 					<tr>
-						<th onClick={() => this.onSortClick('mount_point')}>
-							{t('groupfolders', 'Folder name')}
-							<SortArrow name='mount_point' value={this.state.sort}
-								   direction={this.state.sortOrder}/>
+						<th>
+							<button type="button"
+								className="sort-header"
+								onClick={() => this.onSortClick('mount_point')}>
+								{t('groupfolders', 'Folder name')}
+								<SortArrow name='mount_point' value={this.state.sort}
+									   direction={this.state.sortOrder}/>
+							</button>
 						</th>
-						<th onClick={() => this.onSortClick('groups')}
-							title={groupHeaderSort}>
-							{groupHeader}
-							<SortArrow name='groups' value={this.state.sort}
-								   direction={this.state.sortOrder}/>
+						<th>
+							<button type="button"
+								className="sort-header"
+								title={groupHeaderSort}
+								onClick={() => this.onSortClick('groups')}>
+								{groupHeader}
+								<SortArrow name='groups' value={this.state.sort}
+									   direction={this.state.sortOrder}/>
+							</button>
 						</th>
-						<th onClick={() => this.onSortClick('quota')}>
-							{t('groupfolders', 'Quota')}
-							<SortArrow name='quota' value={this.state.sort}
-								   direction={this.state.sortOrder}/>
+						<th>
+							<button type="button"
+								className="sort-header"
+								onClick={() => this.onSortClick('quota')}>
+								{t('groupfolders', 'Quota')}
+								<SortArrow name='quota' value={this.state.sort}
+									   direction={this.state.sortOrder}/>
+							</button>
 						</th>
-						<th onClick={() => this.onSortClick('acl')}>
-							{t('groupfolders', 'Advanced Permissions')}
-							<SortArrow name='acl' value={this.state.sort}
-								   direction={this.state.sortOrder}/>
+						<th>
+							<button type="button"
+								className="sort-header"
+								onClick={() => this.onSortClick('acl')}>
+								{t('groupfolders', 'Advanced Permissions')}
+								<SortArrow name='acl' value={this.state.sort}
+									   direction={this.state.sortOrder}/>
+							</button>
 						</th>
 						<th>
 							<span className="hidden-visually">{t('groupfolders', 'Actions')}</span>

--- a/src/settings/SortArrow.tsx
+++ b/src/settings/SortArrow.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import * as React from 'react'
+import { t } from '@nextcloud/l10n'
 
 export interface SortArrowProps {
     name: string;
@@ -12,11 +13,20 @@ export interface SortArrowProps {
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export function SortArrow({ name, value, direction }: SortArrowProps) {
-	if (name === value) {
-		return (<span className='sort_arrow'>
-			{direction < 0 ? '▼' : '▲'}
-		</span>)
-	} else {
-		return <span/>
+	if (name !== value) {
+		return null
 	}
+
+	const label = direction < 0
+		? t('groupfolders', 'sorted descending')
+		: t('groupfolders', 'sorted ascending')
+
+	return (
+		<>
+			<span className="sort_arrow" aria-hidden="true">
+				{direction < 0 ? '▼' : '▲'}
+			</span>
+			<span className="hidden-visually">{label}</span>
+		</>
+	)
 }


### PR DESCRIPTION
Resolves: #4463 

## Summary
- Make the table headers accessible via keyboard
- Add meaningful labels to sort icons.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
