### PR TITLE
fix(acl): handle numeric-only paths in rule cache

### DIFF
--- a/lib/ACL/ACLManager.php
+++ b/lib/ACL/ACLManager.php
@@ -37,9 +37,12 @@ class ACLManager {
 	 * storage (folders using a separate storage restart at the storage root,
 	 * e.g. "files/", "trash/", "versions/"), so the storage id must be part of
 	 * the key to avoid cross-storage collisions.
+	 *
+	 * Numeric-only paths are converted to integers when used as array keys by
+	 * PHP, so accept both possible array-key types and normalize them here.
 	 */
-	private function ruleCacheKey(int $storageId, string $path): string {
-		return $storageId . '::' . $path;
+	private function ruleCacheKey(int $storageId, int|string $path): string {
+		return $storageId . '::' . (string)$path;
 	}
 
 	/**

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -188,6 +188,25 @@ class ACLManagerTest extends TestCase {
 		$this->assertSame(1, count(array_filter($queriedStorages, fn (int $storageId): bool => $storageId === 1)));
 	}
 
+	public function testRuleCacheAcceptsNumericOnlyPath(): void {
+		$ruleManager = $this->createMock(RuleManager::class);
+		$aclManager = new ACLManager($ruleManager, $this->userMappingManager, $this->user);
+		$denyShare = new Rule($this->dummyMapping, 10, Constants::PERMISSION_SHARE, 0);
+
+		$ruleManager->method('getRulesForFilesByPath')
+			->willReturnCallback(function (IUser $user, int $storageId, array $paths) use ($denyShare): array {
+				$rules = array_fill_keys($paths, []);
+				$rules['2026'] = [$denyShare];
+
+				return $rules;
+			});
+
+		$this->assertEquals(
+			Constants::PERMISSION_ALL - Constants::PERMISSION_SHARE,
+			$aclManager->getACLPermissionsForPath(0, 1, '2026/file'),
+		);
+	}
+
 	public function testPreloadRuleCacheIsScopedPerStorage(): void {
 		// preloadRulesForFolder warms the cache for one storage; a same-named path
 		// on another storage must not be resolved from that preloaded entry.

--- a/tests/ACL/ACLManagerTest.php
+++ b/tests/ACL/ACLManagerTest.php
@@ -195,6 +195,7 @@ class ACLManagerTest extends TestCase {
 
 		$ruleManager->method('getRulesForFilesByPath')
 			->willReturnCallback(function (IUser $user, int $storageId, array $paths) use ($denyShare): array {
+				/** @var list<string> $paths */
 				$rules = array_fill_keys($paths, []);
 				$rules['2026'] = [$denyShare];
 


### PR DESCRIPTION
Issue:

> {"reqId":"TYM1CVd5rY1ZCUatDCeP","level":3,"time":"2026-08-06T06:00:27+02:00","remoteAddr":"10.11.31.41","user":"stephan.budach","app":"webdav","method":"PROPFIND","url":"/remote.php/dav/files/xyz/2026/Kampagnen","scriptName":"/remote.php","message":"OCA\\GroupFolders\\ACL\\ACLManager::ruleCacheKey(): Argument #2 ($path) must be of type string, int given, called in /var/www/nextcloud.ceph/nextcloud/apps/groupfolders/lib/ACL/ACLManager.php on line 68","userAgent":"Mozilla/5.0 (Macintosh) mirall/34.0.1

- PHP converts numeric-only string array keys to integers. Accept both possible key types when building ACL rule cache keys and normalize the path back to a string.
- Add a regression test covering an ACL below a numeric-only top-level folder.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
