### PR TITLE
perf: Optimize userInMappings with circle enabled

### DIFF
--- a/lib/ACL/UserMapping/IUserMappingManager.php
+++ b/lib/ACL/UserMapping/IUserMappingManager.php
@@ -12,10 +12,9 @@ use OCP\IUser;
 
 interface IUserMappingManager {
 	/**
-	 * @param bool $userAssignable whether to include mappings that are assignable by non admin users
 	 * @return IUserMapping[]
 	 */
-	public function getMappingsForUser(IUser $user, bool $userAssignable = true): array;
+	public function getMappingsForUser(IUser $user): array;
 
 	public function mappingFromId(string $type, string $id): ?IUserMapping;
 

--- a/lib/ACL/UserMapping/UserMappingManager.php
+++ b/lib/ACL/UserMapping/UserMappingManager.php
@@ -30,6 +30,9 @@ class UserMappingManager implements IUserMappingManager {
 	/** @var CappedMemoryCache<IUserMapping|false> */
 	private CappedMemoryCache $mappingByKey;
 
+	/** @var CappedMemoryCache<array<string, Circle>> */
+	private CappedMemoryCache $circlesByUser;
+
 	public function __construct(
 		private readonly IGroupManager $groupManager,
 		private readonly IUserManager $userManager,
@@ -37,6 +40,7 @@ class UserMappingManager implements IUserMappingManager {
 	) {
 		$this->mappingsByUser = new CappedMemoryCache();
 		$this->mappingByKey = new CappedMemoryCache();
+		$this->circlesByUser = new CappedMemoryCache();
 	}
 
 	#[\Override]
@@ -52,7 +56,7 @@ class UserMappingManager implements IUserMappingManager {
 
 		$mappings = array_merge([
 			new UserMapping('user', $user->getUID(), $user->getDisplayName()),
-		], $groupMappings, $circleMappings);
+		], $groupMappings, array_values($circleMappings));
 
 		$this->mappingsByUser->set($cacheKey, $mappings);
 		foreach ($mappings as $mapping) {
@@ -70,19 +74,15 @@ class UserMappingManager implements IUserMappingManager {
 			return $cached === false ? null : $cached;
 		}
 
-		switch ($type) {
-			case 'group':
-				$displayName = $this->groupManager->get($id)?->getDisplayName();
-				break;
-			case 'user':
-				$displayName = $this->userManager->get($id)?->getDisplayName();
-				break;
-			case 'circle':
-				$displayName = $this->getCircle($id)?->getDisplayName();
-				break;
-			default:
-				return null;
+		if ($type !== 'group' && $type !== 'circle' && $type !== 'user') {
+			return null;
 		}
+
+		$displayName = match ($type) {
+			'group' => $this->groupManager->get($id)?->getDisplayName(),
+			'user' => $this->userManager->get($id)?->getDisplayName(),
+			'circle' => $this->getCircle($id)?->getDisplayName(),
+		};
 
 		if ($displayName === null) {
 			$this->mappingByKey->set($cacheKey, false);
@@ -120,24 +120,35 @@ class UserMappingManager implements IUserMappingManager {
 	}
 
 	/**
-	 * returns list of circles a user is member of
-	 * @return list<Circle>
+	 * Returns list of circles a user is member of.
+	 *
+	 * @return array<string, Circle>
 	 */
 	private function getUserCircles(string $userId): array {
+		if (isset($this->circlesByUser[$userId])) {
+			return $this->circlesByUser[$userId];
+		}
 		$circlesManager = $this->getCirclesManager();
 		if ($circlesManager === null) {
+			$this->circlesByUser[$userId] = [];
 			return [];
 		}
 
 		$circlesManager->startSession($circlesManager->getLocalFederatedUser($userId));
 		try {
-			return $circlesManager->probeCircles();
+			$result = [];
+			foreach ($circlesManager->probeCircles() as $circle) {
+				$result[$circle->getSingleId()] = $circle;
+			}
+			$this->circlesByUser[$userId] = $result;
+			return $result;
 		} catch (\Exception $e) {
 			$this->logger->warning('', ['exception' => $e]);
 		} finally {
 			$circlesManager->stopSession();
 		}
 
+		$this->circlesByUser[$userId] = [];
 		return [];
 	}
 
@@ -151,41 +162,39 @@ class UserMappingManager implements IUserMappingManager {
 
 	#[\Override]
 	public function userInMappings(IUser $user, array $mappings): bool {
-		$userGroupIds = array_flip($this->groupManager->getUserGroupIds($user));
-
-		$hasCircleMapping = false;
+		$userGroupIds = null;
+		$circleMappings = [];
 		foreach ($mappings as $mapping) {
 			if ($mapping->getType() === 'user' && $mapping->getId() === $user->getUID()) {
 				return true;
 			}
 
-			if ($mapping->getType() === 'group' && isset($userGroupIds[$mapping->getId()])) {
-				return true;
+			if ($mapping->getType() === 'group') {
+				// Only fetch the user's groups once we know we actually need them.
+				$userGroupIds ??= array_flip($this->groupManager->getUserGroupIds($user));
+				if (isset($userGroupIds[$mapping->getId()])) {
+					return true;
+				}
 			}
 
 			if ($mapping->getType() === 'circle') {
-				$hasCircleMapping = true;
+				$circleMappings[] = $mapping->getId();
 			}
 		}
 
-		if (!$hasCircleMapping) {
+		if ($circleMappings === []) {
 			return false;
 		}
 
-		$mappingKeys = array_map(fn (IUserMapping $mapping): string => $mapping->getKey(), $mappings);
-
-		$userMappings = $this->getMappingsForUser($user);
-		foreach ($userMappings as $userMapping) {
-			if (in_array($userMapping->getKey(), $mappingKeys, true)) {
-				return true;
-			}
-		}
-		return false;
+		// This is expensive do it at the end if we didn't match any group or user mapping first
+		$circleIds = array_keys($this->getUserCircles($user->getUID()));
+		return array_any($circleMappings, fn (string $circleId): bool => in_array($circleId, $circleIds));
 	}
 
 	#[\Override]
 	public function resetCache(): void {
 		$this->mappingByKey = new CappedMemoryCache();
 		$this->mappingsByUser = new CappedMemoryCache();
+		$this->circlesByUser = new CappedMemoryCache();
 	}
 }

--- a/lib/ACL/UserMapping/UserMappingManager.php
+++ b/lib/ACL/UserMapping/UserMappingManager.php
@@ -40,8 +40,8 @@ class UserMappingManager implements IUserMappingManager {
 	}
 
 	#[\Override]
-	public function getMappingsForUser(IUser $user, bool $userAssignable = true): array {
-		$cacheKey = $user->getUID() . '|' . (int)$userAssignable;
+	public function getMappingsForUser(IUser $user): array {
+		$cacheKey = $user->getUID();
 		$cached = $this->mappingsByUser->get($cacheKey);
 		if ($cached !== null) {
 			return $cached;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -131,3 +131,4 @@ parameters:
 		- tests/stubs/symfony_component_console_question_question.php
 		- tests/stubs/test_testcase.php
 		- tests/stubs/test_traits_usertrait.php
+		- tests/stubs/php.php

--- a/tests/stubs/php.php
+++ b/tests/stubs/php.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+function array_any(array $array, callable $callback): bool {}


### PR DESCRIPTION
If we find an circle mapping and the current user doesn't map to any of
the group or user mapping, then load the circles for an user (and cache
them).

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
