### PR TITLE
feat: implement automatic creation of .system folder in auto-created team-folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Team folders always appear as special shared folders in users’ file lists, reg
 
 All access control, configuration, and permissions for Team folders are managed within the Nextcloud database and UI as before.
 
+
 ## Setting Advanced Permissions
 
 _Advanced Permissions_ allows entitled users to configure permissions inside Team folders on a per file and folder basis.

--- a/lib/TeamSpace/TeamSpaceProvider.php
+++ b/lib/TeamSpace/TeamSpaceProvider.php
@@ -59,12 +59,10 @@ class TeamSpaceProvider implements ITeamFolderProvider {
 	/**
 	 * @return list<TeamFolder>
 	 */
-	#[\Override]
 	public function getLinkableTeamFolders(string $teamId): array {
 		return $this->service->getLinkableTeamSpaces($teamId);
 	}
 
-	#[\Override]
 	public function linkTeamFolder(string $teamId, int $folderId): TeamFolder {
 		return $this->service->linkTeamSpace($teamId, $folderId);
 	}

--- a/lib/TeamSpace/TeamSpaceProvider.php
+++ b/lib/TeamSpace/TeamSpaceProvider.php
@@ -77,11 +77,16 @@ class TeamSpaceProvider implements ITeamFolderProvider {
 	 * @return list<TeamResource>
 	 */
 	public function getSharedWith(string $teamId): array {
+		$teamSpaceFolder = $this->service->getTeamSpaceForCircle($teamId);
+		$teamSpaceFolderId = $teamSpaceFolder !== null ? (string)$teamSpaceFolder->getId() : null;
+
 		return array_map(fn (TeamFolder $folder): TeamResource => new TeamResource(
 			$this,
 			(string)$folder->getId(),
 			$folder->getMountPoint(),
-			$this->urlGenerator->getAbsoluteURL('/apps/files/?dir=/' . rawurlencode($folder->getMountPoint())),
+			$teamSpaceFolderId !== null && (string)$folder->getId() === $teamSpaceFolderId
+				? $this->urlGenerator->getAbsoluteURL('/index.php/apps/circles/teams/team/' . rawurlencode($teamId))
+				: $this->urlGenerator->getAbsoluteURL('/apps/files/?dir=/' . rawurlencode($folder->getMountPoint())),
 			iconSvg: $this->getIconSvg(),
 		), $this->service->getGroupFoldersForCircle($teamId));
 	}

--- a/lib/TeamSpace/TeamSpaceProvider.php
+++ b/lib/TeamSpace/TeamSpaceProvider.php
@@ -56,6 +56,19 @@ class TeamSpaceProvider implements ITeamFolderProvider {
 		return $folder;
 	}
 
+	/**
+	 * @return list<TeamFolder>
+	 */
+	#[\Override]
+	public function getLinkableTeamFolders(string $teamId): array {
+		return $this->service->getLinkableTeamSpaces($teamId);
+	}
+
+	#[\Override]
+	public function linkTeamFolder(string $teamId, int $folderId): TeamFolder {
+		return $this->service->linkTeamSpace($teamId, $folderId);
+	}
+
 	#[\Override]
 	public function unlinkTeamFolder(string $teamId): ?TeamFolder {
 		$folder = $this->getTeamFolder($teamId);
@@ -77,11 +90,16 @@ class TeamSpaceProvider implements ITeamFolderProvider {
 	 * @return list<TeamResource>
 	 */
 	public function getSharedWith(string $teamId): array {
+		$teamSpaceFolder = $this->service->getTeamSpaceForCircle($teamId);
+		$teamSpaceFolderId = $teamSpaceFolder !== null ? (string)$teamSpaceFolder->getId() : null;
+
 		return array_map(fn (TeamFolder $folder): TeamResource => new TeamResource(
 			$this,
 			(string)$folder->getId(),
 			$folder->getMountPoint(),
-			$this->urlGenerator->getAbsoluteURL('/apps/files/?dir=/' . rawurlencode($folder->getMountPoint())),
+			$teamSpaceFolderId !== null && (string)$folder->getId() === $teamSpaceFolderId
+				? $this->urlGenerator->getAbsoluteURL('/index.php/apps/circles/teams/team/' . rawurlencode($teamId))
+				: $this->urlGenerator->getAbsoluteURL('/apps/files/?dir=/' . rawurlencode($folder->getMountPoint())),
 			iconSvg: $this->getIconSvg(),
 		), $this->service->getGroupFoldersForCircle($teamId));
 	}

--- a/lib/TeamSpace/TeamSpaceService.php
+++ b/lib/TeamSpace/TeamSpaceService.php
@@ -11,6 +11,8 @@ namespace OCA\GroupFolders\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\FolderStorageManager;
+use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
 use OCP\Teams\TeamFolder;
 use Psr\Log\LoggerInterface;
@@ -31,8 +33,11 @@ use Psr\Log\LoggerInterface;
  * needed.
  */
 class TeamSpaceService {
+	private const string APP_DIRECTORY_NAME = '.system';
+
 	public function __construct(
 		private readonly FolderManager $folderManager,
+		private readonly FolderStorageManager $folderStorageManager,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -51,6 +56,8 @@ class TeamSpaceService {
 		$folderId = $this->folderManager->createFolder($mountPoint);
 
 		try {
+			$this->createAppDirectory($folderId);
+
 			if ($quota > 0) {
 				$this->folderManager->setFolderQuota($folderId, $quota);
 			}
@@ -96,6 +103,34 @@ class TeamSpaceService {
 		}
 
 		return $folderId;
+	}
+
+	/**
+	 * Create the folder reserved for app data in a team space.
+	 *
+	 * @throws \RuntimeException when the folder cannot be created.
+	 */
+	private function createAppDirectory(int $folderId): void {
+		$teamSpace = $this->folderManager->getFolder($folderId);
+		if ($teamSpace === null) {
+			throw new \RuntimeException('Created team space could not be found');
+		}
+
+		$storage = $this->folderStorageManager->getBaseStorageForFolder(
+			$folderId,
+			$teamSpace->useSeparateStorage(),
+			$teamSpace,
+		);
+
+		if ($storage->is_dir(self::APP_DIRECTORY_NAME)) {
+			return;
+		}
+
+		if (!$storage->mkdir(self::APP_DIRECTORY_NAME) && !$storage->is_dir(self::APP_DIRECTORY_NAME)) {
+			throw new \RuntimeException('Could not create ' . self::APP_DIRECTORY_NAME . ' folder for team space');
+		}
+
+		$storage->getScanner()->scan(self::APP_DIRECTORY_NAME);
 	}
 
 	/**
@@ -196,6 +231,8 @@ class TeamSpaceService {
 		if ($folder === null) {
 			return null;
 		}
+
+		$this->createAppDirectory($folderId);
 
 		return new TeamFolder($folder->id, $folder->mountPoint);
 	}

--- a/lib/TeamSpace/TeamSpaceService.php
+++ b/lib/TeamSpace/TeamSpaceService.php
@@ -11,6 +11,8 @@ namespace OCA\GroupFolders\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\FolderStorageManager;
+use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
 use OCP\Teams\TeamFolder;
 use Psr\Log\LoggerInterface;
@@ -31,8 +33,11 @@ use Psr\Log\LoggerInterface;
  * needed.
  */
 class TeamSpaceService {
+	private const string APP_DIRECTORY_NAME = '.system';
+
 	public function __construct(
 		private readonly FolderManager $folderManager,
+		private readonly FolderStorageManager $folderStorageManager,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -51,6 +56,8 @@ class TeamSpaceService {
 		$folderId = $this->folderManager->createFolder($mountPoint);
 
 		try {
+			$this->createAppDirectory($folderId);
+
 			if ($quota > 0) {
 				$this->folderManager->setFolderQuota($folderId, $quota);
 			}
@@ -96,6 +103,34 @@ class TeamSpaceService {
 		}
 
 		return $folderId;
+	}
+
+	/**
+	 * Create the folder reserved for app data in a team space.
+	 *
+	 * @throws \RuntimeException when the folder cannot be created.
+	 */
+	private function createAppDirectory(int $folderId): void {
+		$teamSpace = $this->folderManager->getFolder($folderId);
+		if ($teamSpace === null) {
+			throw new \RuntimeException('Created team space could not be found');
+		}
+
+		$storage = $this->folderStorageManager->getBaseStorageForFolder(
+			$folderId,
+			$teamSpace->useSeparateStorage(),
+			$teamSpace,
+		);
+
+		if ((bool)$storage->is_dir(self::APP_DIRECTORY_NAME)) {
+			return;
+		}
+
+		if (!$storage->mkdir(self::APP_DIRECTORY_NAME)) {
+			throw new \RuntimeException('Could not create ' . self::APP_DIRECTORY_NAME . ' folder for team space');
+		}
+
+		$storage->getScanner()->scan(self::APP_DIRECTORY_NAME);
 	}
 
 	/**
@@ -197,6 +232,8 @@ class TeamSpaceService {
 			return null;
 		}
 
+		$this->createAppDirectory($folderId);
+
 		return new TeamFolder($folder->id, $folder->mountPoint);
 	}
 
@@ -213,6 +250,41 @@ class TeamSpaceService {
 			static fn (FolderDefinition $folder): TeamFolder => new TeamFolder($folder->id, $folder->mountPoint),
 			$this->folderManager->getFoldersForCircle($circleId),
 		);
+	}
+
+	/**
+	 * Return regular group folders that are directly available to the team and
+	 * can become its exclusive team folder.
+	 *
+	 * @return list<TeamFolder>
+	 */
+	public function getLinkableTeamSpaces(string $circleId): array {
+		return array_map(
+			static fn (FolderDefinition $folder): TeamFolder => new TeamFolder($folder->id, $folder->mountPoint),
+			array_values(array_filter(
+				$this->folderManager->getFoldersForCircle($circleId),
+				static fn (FolderDefinition $folder): bool => !$folder->isTeamSpace(),
+			)),
+		);
+	}
+
+	/**
+	 * Make a regular group folder directly available to the team its exclusive
+	 * team space.
+	 */
+	public function linkTeamSpace(string $circleId, int $folderId): TeamFolder {
+		foreach ($this->folderManager->getFoldersForCircle($circleId) as $folder) {
+			if ($folder->id !== $folderId || $folder->isTeamSpace()) {
+				continue;
+			}
+
+			$this->folderManager->setTeamCircleId($folderId, $circleId);
+			$this->createAppDirectory($folderId);
+
+			return new TeamFolder($folder->id, $folder->mountPoint);
+		}
+
+		throw new \InvalidArgumentException('Folder is not linkable to this team');
 	}
 
 	/**

--- a/tests/TeamSpace/TeamSpaceProviderTest.php
+++ b/tests/TeamSpace/TeamSpaceProviderTest.php
@@ -37,6 +37,10 @@ class TeamSpaceProviderTest extends TestCase {
 
 	public function testGetSharedWithReturnsAllFoldersAssignedToTeam(): void {
 		$this->service->expects($this->once())
+			->method('getTeamSpaceForCircle')
+			->with('team-1')
+			->willReturn(new TeamFolder(42, 'Engineering'));
+		$this->service->expects($this->once())
 			->method('getGroupFoldersForCircle')
 			->with('team-1')
 			->willReturn([
@@ -52,7 +56,7 @@ class TeamSpaceProviderTest extends TestCase {
 		$this->assertCount(2, $resources);
 		$this->assertSame('42', $resources[0]->getId());
 		$this->assertSame('Engineering', $resources[0]->getLabel());
-		$this->assertSame('https://cloud.example/apps/files/?dir=/Engineering', $resources[0]->getUrl());
+		$this->assertSame('https://cloud.example/index.php/apps/circles/teams/team/team-1', $resources[0]->getUrl());
 		$this->assertSame('43', $resources[1]->getId());
 		$this->assertSame('Shared projects', $resources[1]->getLabel());
 		$this->assertSame('https://cloud.example/apps/files/?dir=/Shared%20projects', $resources[1]->getUrl());
@@ -69,5 +73,25 @@ class TeamSpaceProviderTest extends TestCase {
 
 		$this->assertTrue($this->provider->isSharedWithTeam('team-1', '43'));
 		$this->assertFalse($this->provider->isSharedWithTeam('team-1', '44'));
+	}
+
+	public function testGetLinkableTeamFoldersDelegatesToService(): void {
+		$folders = [new TeamFolder(43, 'Shared projects')];
+		$this->service->expects($this->once())
+			->method('getLinkableTeamSpaces')
+			->with('team-1')
+			->willReturn($folders);
+
+		$this->assertSame($folders, $this->provider->getLinkableTeamFolders('team-1'));
+	}
+
+	public function testLinkTeamFolderDelegatesToService(): void {
+		$folder = new TeamFolder(43, 'Shared projects');
+		$this->service->expects($this->once())
+			->method('linkTeamSpace')
+			->with('team-1', 43)
+			->willReturn($folder);
+
+		$this->assertSame($folder, $this->provider->linkTeamFolder('team-1', 43));
 	}
 }

--- a/tests/TeamSpace/TeamSpaceProviderTest.php
+++ b/tests/TeamSpace/TeamSpaceProviderTest.php
@@ -37,6 +37,10 @@ class TeamSpaceProviderTest extends TestCase {
 
 	public function testGetSharedWithReturnsAllFoldersAssignedToTeam(): void {
 		$this->service->expects($this->once())
+			->method('getTeamSpaceForCircle')
+			->with('team-1')
+			->willReturn(new TeamFolder(42, 'Engineering'));
+		$this->service->expects($this->once())
 			->method('getGroupFoldersForCircle')
 			->with('team-1')
 			->willReturn([
@@ -52,7 +56,7 @@ class TeamSpaceProviderTest extends TestCase {
 		$this->assertCount(2, $resources);
 		$this->assertSame('42', $resources[0]->getId());
 		$this->assertSame('Engineering', $resources[0]->getLabel());
-		$this->assertSame('https://cloud.example/apps/files/?dir=/Engineering', $resources[0]->getUrl());
+		$this->assertSame('https://cloud.example/index.php/apps/circles/teams/team/team-1', $resources[0]->getUrl());
 		$this->assertSame('43', $resources[1]->getId());
 		$this->assertSame('Shared projects', $resources[1]->getLabel());
 		$this->assertSame('https://cloud.example/apps/files/?dir=/Shared%20projects', $resources[1]->getUrl());

--- a/tests/TeamSpace/TeamSpaceServiceTest.php
+++ b/tests/TeamSpace/TeamSpaceServiceTest.php
@@ -10,8 +10,12 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\Tests\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
-use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\TeamSpace\TeamSpaceService;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -19,36 +23,104 @@ use Test\TestCase;
 
 class TeamSpaceServiceTest extends TestCase {
 	private FolderManager&MockObject $folderManager;
+	private FolderStorageManager&MockObject $folderStorageManager;
 	private TeamSpaceService $service;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->folderManager = $this->createMock(FolderManager::class);
+		$this->folderStorageManager = $this->createMock(FolderStorageManager::class);
 		$this->service = new TeamSpaceService(
 			$this->folderManager,
+			$this->folderStorageManager,
 			$this->createMock(LoggerInterface::class),
 		);
 	}
 
 	public function testCreateTeamSpaceStoresOnlyTeamSpaceLink(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(false);
+		$storage->expects($this->once())->method('mkdir')->with('.system')->willReturn(true);
+		$storage->expects($this->once())->method('getScanner')->willReturn($scanner);
+		$scannedPaths = [];
+		$scanner->expects($this->once())->method('scan')->willReturnCallback(
+			static function (string $path) use (&$scannedPaths): void {
+				$scannedPaths[] = $path;
+			},
+		);
 		$this->folderManager->expects($this->once())->method('setFolderQuota')->with(42, 1024);
 		$this->folderManager->expects($this->once())->method('addApplicableGroup')->with(42, 'team-1');
 		$this->folderManager->expects($this->once())->method('setManageACL')->with(42, 'circle', 'team-1', true);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->createTeamSpace('team-1', 'Engineering', 1024));
+		$this->assertSame(['.system'], $scannedPaths);
+	}
+
+	public function testCreateTeamSpaceDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->service->createTeamSpace('team-1', 'Engineering');
+	}
+
+	public function testCreateTeamSpaceRollsBackWhenAppDirectoryCannotBeCreated(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(false);
+		$this->folderManager->expects($this->once())->method('clearTeamCircleId')->with(42);
+		$this->folderManager->expects($this->once())->method('removeFolder')->with(42);
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->createTeamSpace('team-1', 'Engineering');
 	}
 
 	public function testUpgradeUsesPublicTeamValue(): void {
 		$team = new Team('team-1', 'Engineering', null);
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
 		$this->folderManager->method('mountPointExists')->willReturn(false);
 		$this->folderManager->expects($this->once())->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(true);
+		$storage->method('getScanner')->willReturn($scanner);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->upgradeTeamSpace($team));
+	}
+
+	public function testGetTeamSpaceForCircleDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->assertSame(42, $this->service->getTeamSpaceForCircle('team-1')?->getId());
 	}
 
 	public function testUnlinkKeepsFolderAndClearsTeamLink(): void {
@@ -83,5 +155,21 @@ class TeamSpaceServiceTest extends TestCase {
 
 	public function testSanitizeMountPointStripsControlCharsAndSeparators(): void {
 		$this->assertSame('Engineering', $this->service->sanitizeMountPoint("Engi\nnee/rin\\g"));
+	}
+
+	private function createTeamSpaceFolder(): FolderWithMappingsAndCache {
+		return new FolderWithMappingsAndCache(
+			42,
+			'Engineering',
+			0,
+			false,
+			false,
+			1,
+			99,
+			[],
+			[],
+			[],
+			$this->createMock(ICacheEntry::class),
+		);
 	}
 }

--- a/tests/TeamSpace/TeamSpaceServiceTest.php
+++ b/tests/TeamSpace/TeamSpaceServiceTest.php
@@ -11,7 +11,12 @@ namespace OCA\GroupFolders\Tests\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\TeamSpace\TeamSpaceService;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -19,36 +24,104 @@ use Test\TestCase;
 
 class TeamSpaceServiceTest extends TestCase {
 	private FolderManager&MockObject $folderManager;
+	private FolderStorageManager&MockObject $folderStorageManager;
 	private TeamSpaceService $service;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->folderManager = $this->createMock(FolderManager::class);
+		$this->folderStorageManager = $this->createMock(FolderStorageManager::class);
 		$this->service = new TeamSpaceService(
 			$this->folderManager,
+			$this->folderStorageManager,
 			$this->createMock(LoggerInterface::class),
 		);
 	}
 
 	public function testCreateTeamSpaceStoresOnlyTeamSpaceLink(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->exactly(2))->method('is_dir')->with('.system')->willReturn(false, true);
+		$storage->expects($this->once())->method('mkdir')->with('.system')->willReturn(true);
+		$storage->expects($this->once())->method('getScanner')->willReturn($scanner);
+		$scannedPaths = [];
+		$scanner->expects($this->once())->method('scan')->willReturnCallback(
+			static function (string $path) use (&$scannedPaths): void {
+				$scannedPaths[] = $path;
+			},
+		);
 		$this->folderManager->expects($this->once())->method('setFolderQuota')->with(42, 1024);
 		$this->folderManager->expects($this->once())->method('addApplicableGroup')->with(42, 'team-1');
 		$this->folderManager->expects($this->once())->method('setManageACL')->with(42, 'circle', 'team-1', true);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->createTeamSpace('team-1', 'Engineering', 1024));
+		$this->assertSame(['.system'], $scannedPaths);
+	}
+
+	public function testCreateTeamSpaceDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->service->createTeamSpace('team-1', 'Engineering');
+	}
+
+	public function testCreateTeamSpaceRollsBackWhenAppDirectoryCannotBeCreated(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(false);
+		$this->folderManager->expects($this->once())->method('clearTeamCircleId')->with(42);
+		$this->folderManager->expects($this->once())->method('removeFolder')->with(42);
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->createTeamSpace('team-1', 'Engineering');
 	}
 
 	public function testUpgradeUsesPublicTeamValue(): void {
 		$team = new Team('team-1', 'Engineering', null);
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
 		$this->folderManager->method('mountPointExists')->willReturn(false);
 		$this->folderManager->expects($this->once())->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(true);
+		$storage->method('getScanner')->willReturn($scanner);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->upgradeTeamSpace($team));
+	}
+
+	public function testGetTeamSpaceForCircleDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->assertSame(42, $this->service->getTeamSpaceForCircle('team-1')?->getId());
 	}
 
 	public function testUnlinkKeepsFolderAndClearsTeamLink(): void {
@@ -83,5 +156,21 @@ class TeamSpaceServiceTest extends TestCase {
 
 	public function testSanitizeMountPointStripsControlCharsAndSeparators(): void {
 		$this->assertSame('Engineering', $this->service->sanitizeMountPoint("Engi\nnee/rin\\g"));
+	}
+
+	private function createTeamSpaceFolder(): FolderWithMappingsAndCache {
+		return new FolderWithMappingsAndCache(
+			42,
+			'Engineering',
+			0,
+			false,
+			false,
+			1,
+			99,
+			[],
+			[],
+			[],
+			$this->createMock(ICacheEntry::class),
+		);
 	}
 }


### PR DESCRIPTION

feat: create an `.system` folder in the team-folder after creating a team. This hidden folder will hold team-owned app-data in the future.

Relates to https://github.com/nextcloud/circles/issues/2637

## 🤖 AI (if applicable)

- [x] The content of this PR was
