### PR TITLE
[stable33] fix: getTrashMount(): Argument #1 ($folder) must be of type

### DIFF
--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -159,7 +159,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 	}
 
 	public function getTrashMount(
-		FolderDefinitionWithPermissions $folder,
+		FolderDefinition $folder,
 		string $mountPoint,
 		IStorageFactory $loader,
 		?IUser $user,
@@ -220,7 +220,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 	 * @param 'files'|'trash'|'versions' $type
 	 */
 	public function getGroupFolderStorage(
-		FolderDefinitionWithPermissions $folder,
+		FolderDefinition $folder,
 		?IUser $user,
 		?ICacheEntry $rootCacheEntry,
 		string $type = 'files',


### PR DESCRIPTION
This was fixed on master and stable34 but not in stable33



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
