### PR TITLE
fix: update group edit button accessibility and label

### DIFF
--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -79,6 +79,12 @@
 			cursor: pointer;
 		}
 
+		.action-rename:focus-visible {
+			&::after {
+				opacity: 1;
+			}
+		}
+
 		.action-rename {
 			&::after {
 				display: inline-block;

--- a/src/settings/FolderGroups.scss
+++ b/src/settings/FolderGroups.scss
@@ -18,6 +18,7 @@
 			background: transparent var(--icon-close-dark) no-repeat;
 			min-width: 16px;
 			min-height: 16px;
+			padding: 0;
 		}
 
 		// Fit group selection

--- a/src/settings/FolderGroups.tsx
+++ b/src/settings/FolderGroups.tsx
@@ -76,7 +76,11 @@ export function FolderGroups({ groups, allGroups = [], allCircles = [], onAddGro
 						   checked={hasPermissions(permissions, (OC.PERMISSION_DELETE))}/>
 				</td>
 				<td>
-					<a onClick={removeGroup.bind(this, groupId)} className="close-btn"></a>
+					<button
+						onClick={removeGroup.bind(this, groupId)}
+						aria-label={t('groupfolders', 'Unassign: {group}', { group: displayNames[index] })}
+						className="close-btn" >
+					</button>
 				</td>
 			</tr>
 		})
@@ -106,15 +110,18 @@ export function FolderGroups({ groups, allGroups = [], allCircles = [], onAddGro
 		</table>
 	} else {
 		if (Object.keys(groups).length === 0) {
-			return <span>
-				<em>{t('groupfolders', 'None')}</em>
-				<a className="icon icon-rename" onClick={showEdit}/>
-			</span>
+			return <button className="action-rename"
+				aria-label={t('groupfolders', 'Assign groups')}
+				onClick={showEdit}>
+				{t('groupfolders', 'None')}
+			</button>
 		}
 
-		return <a className="action-rename" onClick={showEdit}>
+		return <button className="action-rename"
+			aria-label={t('groupfolders', 'Edit assigned groups: {groups}', { groups: displayNames.join(', ') })}
+			onClick={showEdit}>
 			{displayNames.join(', ')}
-		</a>
+		</button>
 	}
 }
 

--- a/src/settings/FolderGroups.tsx
+++ b/src/settings/FolderGroups.tsx
@@ -78,7 +78,7 @@ export function FolderGroups({ groups, allGroups = [], allCircles = [], onAddGro
 				<td>
 					<button
 						onClick={removeGroup.bind(this, groupId)}
-						aria-label={t('groupfolders', 'Unassign: {group}', { group: displayNames[index] })}
+						aria-label={t('groupfolders', 'Unassign')}
 						className="close-btn" >
 					</button>
 				</td>


### PR DESCRIPTION
## Summary
- Resolves #4467 

- Make edit button visible when focused not only when hover.
- Add label for group edit button

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
