### PR TITLE
Feature/generate automatic .system folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Team folders always appear as special shared folders in users’ file lists, reg
 
 All access control, configuration, and permissions for Team folders are managed within the Nextcloud database and UI as before.
 
+
 ## Setting Advanced Permissions
 
 _Advanced Permissions_ allows entitled users to configure permissions inside Team folders on a per file and folder basis.

--- a/lib/TeamSpace/TeamSpaceProvider.php
+++ b/lib/TeamSpace/TeamSpaceProvider.php
@@ -77,13 +77,22 @@ class TeamSpaceProvider implements ITeamFolderProvider {
 	 * @return list<TeamResource>
 	 */
 	public function getSharedWith(string $teamId): array {
-		return array_map(fn (TeamFolder $folder): TeamResource => new TeamResource(
-			$this,
-			(string)$folder->getId(),
-			$folder->getMountPoint(),
-			$this->urlGenerator->getAbsoluteURL('/apps/files/?dir=/' . rawurlencode($folder->getMountPoint())),
-			iconSvg: $this->getIconSvg(),
-		), $this->service->getGroupFoldersForCircle($teamId));
+		$teamSpaceFolder = $this->service->getTeamSpaceForCircle($teamId);
+		$teamSpaceFolderId = $teamSpaceFolder !== null ? (string)$teamSpaceFolder->getId() : null;
+
+		return array_map(function (TeamFolder $folder) use ($teamId, $teamSpaceFolderId): TeamResource {
+			$url = $teamSpaceFolderId !== null && (string)$folder->getId() === $teamSpaceFolderId
+				? $this->urlGenerator->linkToRouteAbsolute('circles.page.indexpath', ['path' => 'team/' . $teamId])
+				: $this->urlGenerator->linkToRouteAbsolute('files.view.index', ['dir' => '/' . $folder->getMountPoint()]);
+
+			return new TeamResource(
+				$this,
+				(string)$folder->getId(),
+				$folder->getMountPoint(),
+				$url,
+				iconSvg: $this->getIconSvg(),
+			);
+		}, $this->service->getGroupFoldersForCircle($teamId));
 	}
 
 	#[\Override]

--- a/lib/TeamSpace/TeamSpaceService.php
+++ b/lib/TeamSpace/TeamSpaceService.php
@@ -11,6 +11,7 @@ namespace OCA\GroupFolders\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCP\Teams\Team;
 use OCP\Teams\TeamFolder;
 use Psr\Log\LoggerInterface;
@@ -31,8 +32,11 @@ use Psr\Log\LoggerInterface;
  * needed.
  */
 class TeamSpaceService {
+	private const string APP_DIRECTORY_NAME = '.system';
+
 	public function __construct(
 		private readonly FolderManager $folderManager,
+		private readonly FolderStorageManager $folderStorageManager,
 		private readonly LoggerInterface $logger,
 	) {
 	}
@@ -51,6 +55,8 @@ class TeamSpaceService {
 		$folderId = $this->folderManager->createFolder($mountPoint);
 
 		try {
+			$this->createAppDirectory($folderId);
+
 			if ($quota > 0) {
 				$this->folderManager->setFolderQuota($folderId, $quota);
 			}
@@ -96,6 +102,34 @@ class TeamSpaceService {
 		}
 
 		return $folderId;
+	}
+
+	/**
+	 * Create the folder reserved for app data in a team space.
+	 *
+	 * @throws \RuntimeException when the folder cannot be created.
+	 */
+	private function createAppDirectory(int $folderId): void {
+		$teamSpace = $this->folderManager->getFolder($folderId);
+		if ($teamSpace === null) {
+			throw new \RuntimeException('Created team space could not be found');
+		}
+
+		$storage = $this->folderStorageManager->getBaseStorageForFolder(
+			$folderId,
+			$teamSpace->useSeparateStorage(),
+			$teamSpace,
+		);
+
+		if ((bool)$storage->is_dir(self::APP_DIRECTORY_NAME)) {
+			return;
+		}
+
+		if (!$storage->mkdir(self::APP_DIRECTORY_NAME)) {
+			throw new \RuntimeException('Could not create ' . self::APP_DIRECTORY_NAME . ' folder for team space');
+		}
+
+		$storage->getScanner()->scan(self::APP_DIRECTORY_NAME);
 	}
 
 	/**
@@ -196,6 +230,8 @@ class TeamSpaceService {
 		if ($folder === null) {
 			return null;
 		}
+
+		$this->createAppDirectory($folderId);
 
 		return new TeamFolder($folder->id, $folder->mountPoint);
 	}

--- a/tests/TeamSpace/TeamSpaceProviderTest.php
+++ b/tests/TeamSpace/TeamSpaceProviderTest.php
@@ -37,6 +37,10 @@ class TeamSpaceProviderTest extends TestCase {
 
 	public function testGetSharedWithReturnsAllFoldersAssignedToTeam(): void {
 		$this->service->expects($this->once())
+			->method('getTeamSpaceForCircle')
+			->with('team-1')
+			->willReturn(new TeamFolder(42, 'Engineering'));
+		$this->service->expects($this->once())
 			->method('getGroupFoldersForCircle')
 			->with('team-1')
 			->willReturn([
@@ -44,15 +48,18 @@ class TeamSpaceProviderTest extends TestCase {
 				new TeamFolder(43, 'Shared projects'),
 			]);
 		$this->urlGenerator->expects($this->exactly(2))
-			->method('getAbsoluteURL')
-			->willReturnCallback(static fn (string $url): string => 'https://cloud.example' . $url);
+			->method('linkToRouteAbsolute')
+			->willReturnMap([
+				['circles.page.indexpath', ['path' => 'team/team-1'], 'https://cloud.example/index.php/apps/circles/teams/team/team-1'],
+				['files.view.index', ['dir' => '/Shared projects'], 'https://cloud.example/apps/files/?dir=/Shared%20projects'],
+			]);
 
 		$resources = $this->provider->getSharedWith('team-1');
 
 		$this->assertCount(2, $resources);
 		$this->assertSame('42', $resources[0]->getId());
 		$this->assertSame('Engineering', $resources[0]->getLabel());
-		$this->assertSame('https://cloud.example/apps/files/?dir=/Engineering', $resources[0]->getUrl());
+		$this->assertSame('https://cloud.example/index.php/apps/circles/teams/team/team-1', $resources[0]->getUrl());
 		$this->assertSame('43', $resources[1]->getId());
 		$this->assertSame('Shared projects', $resources[1]->getLabel());
 		$this->assertSame('https://cloud.example/apps/files/?dir=/Shared%20projects', $resources[1]->getUrl());

--- a/tests/TeamSpace/TeamSpaceServiceTest.php
+++ b/tests/TeamSpace/TeamSpaceServiceTest.php
@@ -11,7 +11,12 @@ namespace OCA\GroupFolders\Tests\TeamSpace;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
+use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\TeamSpace\TeamSpaceService;
+use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -19,36 +24,104 @@ use Test\TestCase;
 
 class TeamSpaceServiceTest extends TestCase {
 	private FolderManager&MockObject $folderManager;
+	private FolderStorageManager&MockObject $folderStorageManager;
 	private TeamSpaceService $service;
 
 	#[\Override]
 	protected function setUp(): void {
 		parent::setUp();
 		$this->folderManager = $this->createMock(FolderManager::class);
+		$this->folderStorageManager = $this->createMock(FolderStorageManager::class);
 		$this->service = new TeamSpaceService(
 			$this->folderManager,
+			$this->folderStorageManager,
 			$this->createMock(LoggerInterface::class),
 		);
 	}
 
 	public function testCreateTeamSpaceStoresOnlyTeamSpaceLink(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(false);
+		$storage->expects($this->once())->method('mkdir')->with('.system')->willReturn(true);
+		$storage->expects($this->once())->method('getScanner')->willReturn($scanner);
+		$scannedPaths = [];
+		$scanner->expects($this->once())->method('scan')->willReturnCallback(
+			static function (string $path) use (&$scannedPaths): void {
+				$scannedPaths[] = $path;
+			},
+		);
 		$this->folderManager->expects($this->once())->method('setFolderQuota')->with(42, 1024);
 		$this->folderManager->expects($this->once())->method('addApplicableGroup')->with(42, 'team-1');
 		$this->folderManager->expects($this->once())->method('setManageACL')->with(42, 'circle', 'team-1', true);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->createTeamSpace('team-1', 'Engineering', 1024));
+		$this->assertSame(['.system'], $scannedPaths);
+	}
+
+	public function testCreateTeamSpaceDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->service->createTeamSpace('team-1', 'Engineering');
+	}
+
+	public function testCreateTeamSpaceRollsBackWhenAppDirectoryCannotBeCreated(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(false);
+		$this->folderManager->expects($this->once())->method('clearTeamCircleId')->with(42);
+		$this->folderManager->expects($this->once())->method('removeFolder')->with(42);
+
+		$this->expectException(\RuntimeException::class);
+		$this->service->createTeamSpace('team-1', 'Engineering');
 	}
 
 	public function testUpgradeUsesPublicTeamValue(): void {
 		$team = new Team('team-1', 'Engineering', null);
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$scanner = $this->createMock(IScanner::class);
 		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(null);
 		$this->folderManager->method('mountPointExists')->willReturn(false);
 		$this->folderManager->expects($this->once())->method('createFolder')->with('Engineering')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->method('is_dir')->with('.system')->willReturn(false);
+		$storage->method('mkdir')->with('.system')->willReturn(true);
+		$storage->method('getScanner')->willReturn($scanner);
 		$this->folderManager->expects($this->once())->method('setTeamCircleId')->with(42, 'team-1');
 
 		$this->assertSame(42, $this->service->upgradeTeamSpace($team));
+	}
+
+	public function testGetTeamSpaceForCircleDoesNotRecreateExistingAppDirectory(): void {
+		$teamSpace = $this->createTeamSpaceFolder();
+		$storage = $this->createMock(IStorage::class);
+		$this->folderManager->method('getFolderIdByTeamCircleId')->with('team-1')->willReturn(42);
+		$this->folderManager->method('getFolder')->with(42)->willReturn($teamSpace);
+		$this->folderStorageManager->expects($this->once())->method('getBaseStorageForFolder')->with(42, false, $teamSpace)->willReturn($storage);
+		$storage->expects($this->once())->method('is_dir')->with('.system')->willReturn(true);
+		$storage->expects($this->never())->method('mkdir');
+		$storage->expects($this->never())->method('getScanner');
+
+		$this->assertSame(42, $this->service->getTeamSpaceForCircle('team-1')?->getId());
 	}
 
 	public function testUnlinkKeepsFolderAndClearsTeamLink(): void {
@@ -83,5 +156,21 @@ class TeamSpaceServiceTest extends TestCase {
 
 	public function testSanitizeMountPointStripsControlCharsAndSeparators(): void {
 		$this->assertSame('Engineering', $this->service->sanitizeMountPoint("Engi\nnee/rin\\g"));
+	}
+
+	private function createTeamSpaceFolder(): FolderWithMappingsAndCache {
+		return new FolderWithMappingsAndCache(
+			42,
+			'Engineering',
+			0,
+			false,
+			false,
+			1,
+			99,
+			[],
+			[],
+			[],
+			$this->createMock(ICacheEntry::class),
+		);
 	}
 }


### PR DESCRIPTION

feat: create an .system folder in the team-folder after creating a team. This hidden folder will hold team-owned app-data in the future.

Relates to
* https://github.com/nextcloud/groupfolders/issues/5060
* https://github.com/nextcloud/circles/issues/2637

my first PR [5011 ] (https://github.com/nextcloud/groupfolders/pull/5011)has alwaxs cypress checks fails. So I create a new one

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
