### PR TITLE
fix: Clean up trash items whose file is already gone from storage

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -223,6 +223,18 @@ class TrashBackend implements ITrashBackend {
 	}
 
 	/**
+	 * An item that is already gone from storage is not a failure to delete: its cache
+	 * entry and trash record still have to be cleaned up, otherwise an interrupted
+	 * delete leaves the item stuck in the trashbin forever.
+	 */
+	private function unlinkTrashNode(Node $node): bool {
+		$storage = $node->getStorage();
+		$internalPath = $node->getInternalPath();
+
+		return $storage->unlink($internalPath) !== false || !$storage->file_exists($internalPath);
+	}
+
+	/**
 	 * @throws \LogicException
 	 * @throws \Exception
 	 */
@@ -247,7 +259,7 @@ class TrashBackend implements ITrashBackend {
 			throw new NotPermittedException();
 		}
 
-		if ($node->getStorage()->unlink($node->getInternalPath()) === false) {
+		if (!$this->unlinkTrashNode($node)) {
 			throw new \Exception('Failed to remove item from trashbin');
 		}
 
@@ -656,7 +668,7 @@ class TrashBackend implements ITrashBackend {
 
 				if ($expiration->isExpired($groupTrashItem['deleted_time'], $folder->quota > 0 && $folder->quota < ($size + $sizeInTrash))) {
 					$this->logger->debug('expiring ' . $node->getPath());
-					if ($node->getStorage()->unlink($node->getInternalPath()) === false) {
+					if (!$this->unlinkTrashNode($node)) {
 						$this->logger->error('Failed to remove item from trashbin: ' . $node->getPath());
 						continue;
 					}

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -24,8 +24,10 @@ use OCA\GroupFolders\Trash\TrashBackend;
 use OCA\GroupFolders\Trash\TrashManager;
 use OCP\Constants;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
@@ -414,6 +416,34 @@ class TrashBackendTest extends TestCase {
 		$this->logout();
 	}
 
+	/**
+	 * Leave the item in the state an interrupted delete produces: the file is gone from
+	 * storage while its cache entry is still there. Object stores drop the cache entry as
+	 * part of unlink(), so it gets restored to reach the same state on every backend.
+	 */
+	private function removeTrashFileKeepingCacheEntry(Node $node): void {
+		$storage = $node->getStorage();
+		$internalPath = $node->getInternalPath();
+		$cache = $storage->getCache();
+
+		$entry = $cache->get($internalPath);
+		$this->assertInstanceOf(ICacheEntry::class, $entry);
+		$this->assertTrue($storage->unlink($internalPath));
+
+		if (!$cache->inCache($internalPath)) {
+			$cache->put($internalPath, [
+				'size' => $entry->getSize(),
+				'mtime' => $entry->getMTime(),
+				'storage_mtime' => $entry->getStorageMTime(),
+				'mimetype' => $entry->getMimeType(),
+				'etag' => $entry->getEtag(),
+				'permissions' => $entry->getPermissions(),
+			]);
+		}
+
+		$this->assertTrue($cache->inCache($internalPath));
+	}
+
 	public function testExpireWithMissingTrashFile(): void {
 		$this->loginAsUser('manager');
 
@@ -424,10 +454,7 @@ class TrashBackendTest extends TestCase {
 		$items = $this->trashBackend->listTrashRoot($this->managerUser);
 		$this->assertCount(1, $items);
 
-		// Simulate an expiry run that was interrupted after the unlink but before the
-		// cache entry and the trash record were cleaned up
-		$node = $items[0]->getTrashNode();
-		$this->assertTrue($node->getStorage()->unlink($node->getInternalPath()));
+		$this->removeTrashFileKeepingCacheEntry($items[0]->getTrashNode());
 
 		$expiration = $this->createMock(Expiration::class);
 		$expiration->method('isExpired')->willReturn(true);
@@ -449,8 +476,7 @@ class TrashBackendTest extends TestCase {
 		$items = $this->trashBackend->listTrashRoot($this->managerUser);
 		$this->assertCount(1, $items);
 
-		$node = $items[0]->getTrashNode();
-		$this->assertTrue($node->getStorage()->unlink($node->getInternalPath()));
+		$this->removeTrashFileKeepingCacheEntry($items[0]->getTrashNode());
 
 		$this->trashBackend->removeItem($items[0]);
 

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -11,6 +11,7 @@ namespace OCA\GroupFolders\Tests\Trash;
 
 use OC\Files\SetupManager;
 use OC\Group\Database;
+use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\ACL\RuleManager;
@@ -409,6 +410,52 @@ class TrashBackendTest extends TestCase {
 		$folder2WithPermissions = FolderDefinitionWithPermissions::fromFolder($folder2, $folder2->rootCacheEntry, Constants::PERMISSION_ALL);
 		$this->trashBackend->cleanTrashFolder($folder2WithPermissions);
 		$this->folderManager->removeFolder($folder2Id);
+
+		$this->logout();
+	}
+
+	public function testExpireWithMissingTrashFile(): void {
+		$this->loginAsUser('manager');
+
+		$file = $this->managerUserFolder->newFile("{$this->folderName}/gone.txt", 'content');
+		$this->trashBackend->moveToTrash($file->getStorage(), $file->getInternalPath());
+
+		/** @var list<GroupTrashItem> $items */
+		$items = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $items);
+
+		// Simulate an expiry run that was interrupted after the unlink but before the
+		// cache entry and the trash record were cleaned up
+		$node = $items[0]->getTrashNode();
+		$this->assertTrue($node->getStorage()->unlink($node->getInternalPath()));
+
+		$expiration = $this->createMock(Expiration::class);
+		$expiration->method('isExpired')->willReturn(true);
+		$this->trashBackend->expire($expiration);
+
+		$this->assertCount(0, $this->trashManager->listTrashForFolders([$this->folderId]));
+		$this->assertCount(0, $this->trashBackend->listTrashRoot($this->managerUser));
+
+		$this->logout();
+	}
+
+	public function testRemoveItemWithMissingTrashFile(): void {
+		$this->loginAsUser('manager');
+
+		$file = $this->managerUserFolder->newFile("{$this->folderName}/gone.txt", 'content');
+		$this->trashBackend->moveToTrash($file->getStorage(), $file->getInternalPath());
+
+		/** @var list<GroupTrashItem> $items */
+		$items = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $items);
+
+		$node = $items[0]->getTrashNode();
+		$this->assertTrue($node->getStorage()->unlink($node->getInternalPath()));
+
+		$this->trashBackend->removeItem($items[0]);
+
+		$this->assertCount(0, $this->trashManager->listTrashForFolders([$this->folderId]));
+		$this->assertCount(0, $this->trashBackend->listTrashRoot($this->managerUser));
 
 		$this->logout();
 	}


### PR DESCRIPTION
Deleting a trash item whose file is already gone from storage currently counts as a failure, so the item can never be cleaned up.

Both delete paths in `TrashBackend` end with the same three steps: unlink the file, remove the filecache entry, remove the `oc_group_folders_trash` row. When `unlink()` returns false we skip the last two. The catch is that `Local::unlink()` returns `false` for a path that is neither a file nor a directory, so "the file is already gone" and "the delete failed" are the exact same return value, and we treat both as fatal.

Once an item is in that state nothing recovers it:

- `expire()` logs `Failed to remove item from trashbin` on every cron run, forever,
- `removeItem()` throws, so permanently deleting the item from the web UI or over DAV fails too,
- the item stays visible in Deleted files, because the listing is built from the filecache and not from the trash table.

`ObjectStoreStorage::unlink()` behaves the same way when there is no cache entry.

Fixes [#5031](https://github.com/nextcloud/groupfolders/issues/5031)
Fixes [#2067](https://github.com/nextcloud/groupfolders/issues/2067)
Fixes [#4367](https://github.com/nextcloud/groupfolders/issues/4367)

Same symptom is reported in [#2263](https://github.com/nextcloud/groupfolders/issues/2263) and [#771](https://github.com/nextcloud/groupfolders/issues/771). [#771](https://github.com/nextcloud/groupfolders/issues/771) is already closed, and [#2263](https://github.com/nextcloud/groupfolders/issues/2263) mixes this in with a separate ACL problem.