### PR TITLE
chore(CI): Derive the Circles checkout ref from the branch under test

### DIFF
--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-sqlite-s3.yml
+++ b/.github/workflows/phpunit-sqlite-s3.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app


### PR DESCRIPTION
The Circles ref is hardcoded while the server checkout next to it already uses `matrix.server-versions`. On master both resolve to `master`, so nothing changes here.

It has to be rewritten by hand on every stable branch and keeps getting missed in `phpunit-sqlite-s3` and `phpunit-mysql-sharding`. On stable33 and stable34 those two jobs fail today, because Circles master uses `OCP\DB\Schema\ColumnType` which those Nextcloud versions do not have.
