### PR TITLE
[stable35] chore(CI): Derive the Circles checkout ref from the branch under test

### DIFF
--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app

--- a/.github/workflows/phpunit-sqlite-s3.yml
+++ b/.github/workflows/phpunit-sqlite-s3.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/circles
-          ref: master
+          ref: ${{ matrix.server-versions }}
           path: apps/circles
 
       - name: Checkout app


### PR DESCRIPTION
Backport of #5050.

No job fails on this branch yet, this closes the same gap in `phpunit-sqlite-s3` and `phpunit-mysql-sharding`.
