### PR TITLE
fix: Don't apply the ACL wrapper to trash storage on separate storages

### DIFF
--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -109,7 +109,8 @@ class FolderStorageManager {
 			$storage = $this->getBaseStorageForFolderSeparateStorageLocal($folderId, $init);
 		}
 
-		if ($folder?->acl && $user) {
+		// apply acl before jail, trash doesn't get the ACL wrapper as it does its own ACL filtering
+		if ($folder?->acl && $user && $type !== 'trash') {
 			$aclManager = $this->aclManagerFactory->getACLManager($user);
 			$storage = new ACLStorageWrapper([
 				'storage' => $storage,

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -226,6 +226,30 @@ class TrashBackendTest extends TestCase {
 		$this->logout();
 	}
 
+	public function testRemoveTrashedFolderWithRestrictedChild(): void {
+		$this->loginAsUser('manager');
+
+		$folder = $this->managerUserFolder->newFolder("{$this->folderName}/folder");
+		$child = $folder->newFile('file.txt', 'content');
+
+		$this->trashBackend->moveToTrash($folder->getStorage(), $folder->getInternalPath());
+		$this->assertFalse($this->managerUserFolder->nodeExists("{$this->folderName}/folder"));
+
+		// the rule follows the child's file id into the trash, where the storage must not
+		// enforce it: the trash backend does its own ACL filtering
+		$this->ruleManager->saveRule(new Rule(new UserMapping('user', 'manager'), $child->getId(), Constants::PERMISSION_DELETE, 0));
+
+		$items = $this->trashBackend->listTrashRoot($this->managerUser);
+		$this->assertCount(1, $items);
+
+		$this->trashBackend->removeItem($items[0]);
+
+		$this->assertCount(0, $this->trashBackend->listTrashRoot($this->managerUser));
+		$this->assertCount(0, $this->trashManager->listTrashForFolders([$this->folderId]));
+
+		$this->logout();
+	}
+
 	public function testWrongOriginalLocation(): void {
 		$shareManager = Server::get(Share\IManager::class);
 


### PR DESCRIPTION
`getBaseStorageForFolderRootJail()` skips the ACL wrapper for the trash storage because the trash backend does its own ACL filtering. The separate storage path never got the same guard, and `createFolder()` always uses separate storages now.

`ACLStorageWrapper` sits below the jail, so its `unlink()` runs `canDeleteTree()` over the trash paths. A deny delete rule follows a file's id into the trash, so permanently deleting the folder that file was in fails with `Failed to remove item from trashbin`, even though the trash backend already allowed the delete.
