### PR TITLE
fix: Stop trash expiry once a folder is back under its quota

### DIFF
--- a/lib/Trash/TrashBackend.php
+++ b/lib/Trash/TrashBackend.php
@@ -656,7 +656,7 @@ class TrashBackend implements ITrashBackend {
 				$sizeInTrash += $node->getSize();
 			}
 
-			$size = $folder->rootCacheEntry->getSize();
+			$folderSize = $folder->rootCacheEntry->getSize();
 
 			foreach ($trashItems as $groupTrashItem) {
 				$nodeName = $groupTrashItem['name'] . '.d' . $groupTrashItem['deleted_time'];
@@ -666,7 +666,7 @@ class TrashBackend implements ITrashBackend {
 
 				$node = $nodes[$nodeName];
 
-				if ($expiration->isExpired($groupTrashItem['deleted_time'], $folder->quota > 0 && $folder->quota < ($size + $sizeInTrash))) {
+				if ($expiration->isExpired($groupTrashItem['deleted_time'], $folder->quota > 0 && $folder->quota < ($folderSize + $sizeInTrash))) {
 					$this->logger->debug('expiring ' . $node->getPath());
 					if (!$this->unlinkTrashNode($node)) {
 						$this->logger->error('Failed to remove item from trashbin: ' . $node->getPath());
@@ -676,7 +676,7 @@ class TrashBackend implements ITrashBackend {
 					// only count up after checking if removal is possible
 					$count += 1;
 					$size += $node->getSize();
-					$size -= $node->getSize();
+					$sizeInTrash -= $node->getSize();
 					$node->getStorage()->getCache()->remove($node->getInternalPath());
 					$this->trashManager->removeItem($folderId, $groupTrashItem['name'], $groupTrashItem['deleted_time']);
 					if (!is_null($groupTrashItem['file_id']) && !is_null($this->versionsBackend)) {

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -485,4 +485,30 @@ class TrashBackendTest extends TestCase {
 
 		$this->logout();
 	}
+
+	public function testExpireStopsOnceBackUnderQuota(): void {
+		$this->loginAsUser('manager');
+
+		foreach (['a.txt', 'b.txt', 'c.txt'] as $name) {
+			$file = $this->managerUserFolder->newFile("{$this->folderName}/$name", str_repeat('x', 100));
+			$this->trashBackend->moveToTrash($file->getStorage(), $file->getInternalPath());
+		}
+
+		$this->assertCount(3, $this->trashManager->listTrashForFolders([$this->folderId]));
+
+		// over quota by less than one trash item, so expiring a single item is enough
+		$folderSize = $this->folderManager->getAllFoldersWithSize()[$this->folderId]->rootCacheEntry->getSize();
+		$this->folderManager->setFolderQuota($this->folderId, (int)$folderSize + 250);
+
+		$expiration = $this->createMock(Expiration::class);
+		$expiration->method('isExpired')->willReturnCallback(fn (int $timestamp, bool $quotaExceeded): bool => $quotaExceeded);
+
+		[$count, $size] = $this->trashBackend->expire($expiration);
+
+		$this->assertSame(1, $count);
+		$this->assertSame(100, $size);
+		$this->assertCount(2, $this->trashManager->listTrashForFolders([$this->folderId]));
+
+		$this->logout();
+	}
 }


### PR DESCRIPTION
`$size += $node->getSize()` followed by `$size -= $node->getSize()` cancels out, so the quota flag handed to `Expiration::isExpired()` never drops while the loop runs. A folder that is over quota gets its whole trashbin purged in one run instead of stopping once enough space is freed.

Decrement `$sizeInTrash` instead, which is the value the quota check sums, and keep the folder size in its own variable. That also leaves `$size` as the number of bytes freed, which is what the return value is documented to be.
