### PR TITLE
feat(stable34): add governed Team Folder subfolders and recovery

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@ As of Hub 10 / Nextcloud 31, admins must be members of a team to assign that tea
 Folder.
 ]]>
 	</description>
-	<version>22.0.6</version>
+	<version>22.0.7-dev.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author>Robin Appelman</author>
 	<namespace>GroupFolders</namespace>
@@ -47,6 +47,7 @@ Folder.
 	<background-jobs>
 		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupVersions</job>
 		<job>OCA\GroupFolders\BackgroundJob\ExpireGroupTrash</job>
+		<job>OCA\GroupFolders\BackgroundJob\ExpireDeletedFolders</job>
 	</background-jobs>
 
 	<repair-steps>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,11 +25,13 @@ use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupTrash;
 use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupVersions;
 use OCA\GroupFolders\Command\ExpireGroup\ExpireGroupVersionsTrash;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCA\GroupFolders\Listeners\CacheListener;
 use OCA\GroupFolders\Listeners\CircleDestroyedEventListener;
 use OCA\GroupFolders\Listeners\DeleteListener;
 use OCA\GroupFolders\Listeners\LoadAdditionalScriptsListener;
 use OCA\GroupFolders\Listeners\NodeRenamedListener;
+use OCA\GroupFolders\Listeners\SubfolderQuotaListener;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\Mount\MountProvider;
 use OCA\GroupFolders\Trash\TrashBackend;
@@ -46,6 +48,8 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\CacheEntryInsertedEvent;
 use OCP\Files\Cache\CacheEntryUpdatedEvent;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
@@ -87,6 +91,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeTemplateRenderedEvent::class, LoadAdditionalScriptsListener::class);
 		$context->registerEventListener(CircleDestroyedEvent::class, CircleDestroyedEventListener::class);
 		$context->registerEventListener(NodeRenamedEvent::class, NodeRenamedListener::class);
+		$context->registerEventListener(BeforeNodeRenamedEvent::class, SubfolderQuotaListener::class);
+		$context->registerEventListener(NodeRenamedEvent::class, SubfolderQuotaListener::class);
+		$context->registerEventListener(NodeDeletedEvent::class, SubfolderQuotaListener::class);
 		$context->registerEventListener(CacheEntryInsertedEvent::class, CacheListener::class, 99999);
 		$context->registerEventListener(CacheEntryUpdatedEvent::class, CacheListener::class, 99999);
 		$context->registerEventListener(GroupDeletedEvent::class, DeleteListener::class);
@@ -106,6 +113,7 @@ class Application extends App implements IBootstrap {
 				$c->get(IMountProviderCollection::class),
 				$c->get(IDBConnection::class),
 				$c->get(FolderStorageManager::class),
+				$c->get(SubfolderQuotaManager::class),
 				$allowRootShare,
 				$enableEncryption
 			);

--- a/lib/BackgroundJob/ExpireDeletedFolders.php
+++ b/lib/BackgroundJob/ExpireDeletedFolders.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\BackgroundJob;
+
+use OCA\GroupFolders\Folder\FolderManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Permanently removes Team folders whose recovery period has elapsed.
+ */
+class ExpireDeletedFolders extends TimedJob {
+	public function __construct(
+		private readonly ITimeFactory $timeFactory,
+		private readonly FolderManager $folderManager,
+		private readonly LoggerInterface $logger,
+	) {
+		parent::__construct($timeFactory);
+		$this->setInterval(24 * 60 * 60);
+		$this->setAllowParallelRuns(false);
+	}
+
+	#[\Override]
+	protected function run(mixed $argument): void {
+		$expiredBefore = $this->timeFactory->getTime() - FolderManager::DELETED_FOLDER_RETENTION_SECONDS;
+
+		foreach ($this->folderManager->getDeletedFoldersBefore($expiredBefore) as $deletedFolder) {
+			try {
+				$this->folderManager->purgeDeletedFolder($deletedFolder->folder->id);
+			} catch (\Throwable $exception) {
+				$this->logger->error('Could not permanently remove an expired Team folder from the recovery bin', [
+					'app' => 'groupfolders',
+					'folderId' => $deletedFolder->folder->id,
+					'exception' => $exception,
+				]);
+			}
+		}
+	}
+}

--- a/lib/Command/Delete.php
+++ b/lib/Command/Delete.php
@@ -19,9 +19,10 @@ class Delete extends FolderCommand {
 	protected function configure(): void {
 		$this
 			->setName('groupfolders:delete')
-			->setDescription('Delete Team folder')
-			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to rename')
-			->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip confirmation');
+			->setDescription('Move Team folder to the recovery bin')
+			->addArgument('folder_id', InputArgument::REQUIRED, 'Id of the folder to delete')
+			->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip confirmation')
+			->addOption('permanent', 'p', InputOption::VALUE_NONE, 'Permanently delete the Team folder and all files');
 		parent::configure();
 	}
 
@@ -33,10 +34,18 @@ class Delete extends FolderCommand {
 
 		/** @var QuestionHelper $helper */
 		$helper = $this->getHelper('question');
-		$question = new ConfirmationQuestion('Are you sure you want to delete the Team folder ' . $folder->mountPoint . ' and all files within, this cannot be undone (y/N).', false);
+		$permanent = (bool)$input->getOption('permanent');
+		$question = new ConfirmationQuestion(
+			$permanent
+				? 'Are you sure you want to permanently delete the Team folder ' . $folder->mountPoint . ' and all files within, this cannot be undone (y/N).'
+				: 'Move the Team folder ' . $folder->mountPoint . ' to the recovery bin? It can be restored for 30 days (y/N).',
+			false,
+		);
 		if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
-			$this->folderStorageManager->deleteStoragesForFolder($folder);
-			$this->folderManager->removeFolder($folder->id);
+			$this->folderManager->archiveFolder($folder->id, null);
+			if ($permanent) {
+				$this->folderManager->purgeDeletedFolder($folder->id);
+			}
 		}
 
 		return 0;

--- a/lib/Command/Quota.php
+++ b/lib/Command/Quota.php
@@ -38,7 +38,12 @@ class Quota extends FolderCommand {
 		$quotaString = strtolower($quotaString);
 		$quota = ($quotaString === 'unlimited') ? FileInfo::SPACE_UNLIMITED : \OCP\Util::computerFileSize($quotaString);
 		if ($quota) {
-			$this->folderManager->setFolderQuota($folder->id, (int)$quota);
+			try {
+				$this->folderManager->setFolderQuota($folder->id, (int)$quota);
+			} catch (\InvalidArgumentException $exception) {
+				$output->writeln('<error>' . $exception->getMessage() . '</error>');
+				return -1;
+			}
 			return 0;
 		}
 

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -12,6 +12,8 @@ use OC\AppFramework\OCS\V1Response;
 use OCA\GroupFolders\Attribute\RequireGroupFolderAdmin;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
+use OCA\GroupFolders\Folder\SubfolderQuota;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCA\GroupFolders\Service\DelegationService;
@@ -38,6 +40,7 @@ use OCP\IUserSession;
  * @phpstan-import-type GroupFoldersUser from ResponseDefinitions
  * @phpstan-import-type GroupFoldersFolder from ResponseDefinitions
  * @phpstan-import-type GroupFoldersAclManage from ResponseDefinitions
+ * @phpstan-import-type GroupFoldersSubfolderQuota from ResponseDefinitions
  * @phpstan-type GroupFoldersFolderXML = array{
  *     id: int,
  *     mount_point: string,
@@ -68,6 +71,7 @@ class FolderController extends OCSController {
 		private readonly DelegationService $delegationService,
 		private readonly IGroupManager $groupManager,
 		private readonly FolderStorageManager $folderStorageManager,
+		private readonly SubfolderQuotaManager $subfolderQuotaManager,
 	) {
 		parent::__construct($appName, $request);
 		$this->user = $userSession->getUser();
@@ -111,6 +115,13 @@ class FolderController extends OCSController {
 			'group_details' => $folder->groups,
 			'manage' => $folder->manage,
 		];
+	}
+
+	/**
+	 * @return GroupFoldersSubfolderQuota
+	 */
+	private function formatSubfolderQuota(SubfolderQuota $subfolderQuota): array {
+		return $subfolderQuota->toArray();
 	}
 
 	/**
@@ -446,6 +457,104 @@ class FolderController extends OCSController {
 		$folder = $this->checkedGetFolder($id);
 
 		return new DataResponse(['success' => true, 'folder' => $this->formatFolder($folder)]);
+	}
+
+	/**
+	 * List the direct subfolders of a Team folder and their optional quotas
+	 *
+	 * @param int $id ID of the Team folder
+	 * @return DataResponse<Http::STATUS_OK, list<GroupFoldersSubfolderQuota>, array{}>
+	 * @throws OCSNotFoundException Team folder not found
+	 *
+	 * 200: Direct subfolders returned successfully
+	 */
+	#[RequireGroupFolderAdmin]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}/subfolder-quotas', requirements: ['id' => '\d+'])]
+	public function getSubfolderQuotas(int $id): DataResponse {
+		$folder = $this->checkedGetFolder($id);
+
+		return new DataResponse(array_map(
+			$this->formatSubfolderQuota(...),
+			$this->subfolderQuotaManager->getSubfolderQuotas($folder),
+		));
+	}
+
+	/**
+	 * Create a direct subfolder and assign its quota
+	 *
+	 * @param int $id ID of the Team folder
+	 * @param string $name Name for the new direct subfolder
+	 * @param int $quota Quota in bytes, or -3 for unlimited
+	 * @return DataResponse<Http::STATUS_OK, GroupFoldersSubfolderQuota, array{}>
+	 * @throws OCSBadRequestException Invalid subfolder name or quota
+	 * @throws OCSNotFoundException Team folder not found
+	 *
+	 * 200: Subfolder created successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[RequireGroupFolderAdmin]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/subfolder-quotas', requirements: ['id' => '\d+'])]
+	public function createSubfolderQuota(int $id, string $name, int $quota): DataResponse {
+		$folder = $this->checkedGetFolder($id);
+
+		try {
+			$subfolderQuota = $this->subfolderQuotaManager->createSubfolder($folder, $name, $quota);
+		} catch (\InvalidArgumentException $exception) {
+			throw new OCSBadRequestException($exception->getMessage());
+		}
+
+		return new DataResponse($this->formatSubfolderQuota($subfolderQuota));
+	}
+
+	/**
+	 * Set a quota for a direct subfolder of a Team folder
+	 *
+	 * @param int $id ID of the Team folder
+	 * @param int $fileId File ID of the direct subfolder
+	 * @param int $quota Quota in bytes, or -3 to remove the independent limit
+	 * @return DataResponse<Http::STATUS_OK, GroupFoldersSubfolderQuota, array{}>
+	 * @throws OCSBadRequestException The target is not a direct subfolder or the quota is invalid
+	 * @throws OCSNotFoundException Team folder not found
+	 *
+	 * 200: Subfolder quota set successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[RequireGroupFolderAdmin]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/subfolder-quotas/{fileId}', requirements: ['id' => '\d+', 'fileId' => '\d+'])]
+	public function setSubfolderQuota(int $id, int $fileId, int $quota): DataResponse {
+		$folder = $this->checkedGetFolder($id);
+
+		try {
+			$subfolderQuota = $this->subfolderQuotaManager->setSubfolderQuota($folder, $fileId, $quota);
+		} catch (\InvalidArgumentException $exception) {
+			throw new OCSBadRequestException($exception->getMessage());
+		}
+
+		return new DataResponse($this->formatSubfolderQuota($subfolderQuota));
+	}
+
+	/**
+	 * Remove the independent quota from a direct subfolder
+	 *
+	 * @param int $id ID of the Team folder
+	 * @param int $fileId File ID of the direct subfolder
+	 * @return DataResponse<Http::STATUS_OK, array{success: true}, array{}>
+	 * @throws OCSNotFoundException Team folder not found
+	 *
+	 * 200: Subfolder quota removed successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[RequireGroupFolderAdmin]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'DELETE', url: '/folders/{id}/subfolder-quotas/{fileId}', requirements: ['id' => '\d+', 'fileId' => '\d+'])]
+	public function removeSubfolderQuota(int $id, int $fileId): DataResponse {
+		$this->checkedGetFolder($id);
+		$this->subfolderQuotaManager->removeSubfolderQuota($id, $fileId);
+
+		return new DataResponse(['success' => true]);
 	}
 
 	/**

--- a/lib/Controller/FolderController.php
+++ b/lib/Controller/FolderController.php
@@ -9,12 +9,15 @@ declare (strict_types=1);
 namespace OCA\GroupFolders\Controller;
 
 use OC\AppFramework\OCS\V1Response;
+use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
 use OCA\GroupFolders\Attribute\RequireGroupFolderAdmin;
+use OCA\GroupFolders\Folder\DeletedFolder;
+use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Folder\FolderWithMappingsAndCache;
+use OCA\GroupFolders\Folder\SubfolderManagerService;
 use OCA\GroupFolders\Folder\SubfolderQuota;
 use OCA\GroupFolders\Folder\SubfolderQuotaManager;
-use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\ResponseDefinitions;
 use OCA\GroupFolders\Service\DelegationService;
 use OCA\GroupFolders\Service\FoldersFilter;
@@ -40,7 +43,9 @@ use OCP\IUserSession;
  * @phpstan-import-type GroupFoldersUser from ResponseDefinitions
  * @phpstan-import-type GroupFoldersFolder from ResponseDefinitions
  * @phpstan-import-type GroupFoldersAclManage from ResponseDefinitions
+ * @phpstan-import-type GroupFoldersDeletedFolder from ResponseDefinitions
  * @phpstan-import-type GroupFoldersSubfolderQuota from ResponseDefinitions
+ * @phpstan-import-type GroupFoldersSubfolderManagement from ResponseDefinitions
  * @phpstan-type GroupFoldersFolderXML = array{
  *     id: int,
  *     mount_point: string,
@@ -70,8 +75,8 @@ class FolderController extends OCSController {
 		private readonly FoldersFilter $foldersFilter,
 		private readonly DelegationService $delegationService,
 		private readonly IGroupManager $groupManager,
-		private readonly FolderStorageManager $folderStorageManager,
 		private readonly SubfolderQuotaManager $subfolderQuotaManager,
+		private readonly SubfolderManagerService $subfolderManagerService,
 	) {
 		parent::__construct($appName, $request);
 		$this->user = $userSession->getUser();
@@ -122,6 +127,53 @@ class FolderController extends OCSController {
 	 */
 	private function formatSubfolderQuota(SubfolderQuota $subfolderQuota): array {
 		return $subfolderQuota->toArray();
+	}
+
+	/**
+	 * @return GroupFoldersDeletedFolder
+	 */
+	private function formatDeletedFolder(DeletedFolder $deletedFolder): array {
+		return [
+			'id' => $deletedFolder->folder->id,
+			'mount_point' => $deletedFolder->folder->mountPoint,
+			'quota' => $deletedFolder->folder->quota,
+			'size' => $deletedFolder->rootCacheEntry->getSize(),
+			'deleted_at' => $deletedFolder->deletedAt,
+			'deleted_by' => $deletedFolder->deletedBy,
+		];
+	}
+
+	/**
+	 * @return GroupFoldersAclManage
+	 */
+	private function formatSubfolderManager(IUserMapping $mapping): array {
+		$type = $mapping->getType();
+		if (!in_array($type, ['user', 'group', 'circle'], true)) {
+			throw new \LogicException('A subfolder manager must be a user, group, or Circle');
+		}
+
+		/** @var 'user'|'group'|'circle' $type */
+		return [
+			'displayname' => $mapping->getDisplayName(),
+			'id' => $mapping->getId(),
+			'type' => $type,
+		];
+	}
+
+	/**
+	 * @param list<IUserMapping> $managers
+	 * @return GroupFoldersSubfolderManagement
+	 */
+	private function formatSubfolderManagement(SubfolderQuota $subfolder, array $managers, bool $canManage, bool $canAssign): array {
+		return [
+			'file_id' => $subfolder->fileId,
+			'name' => $subfolder->name,
+			'size' => $subfolder->size,
+			'quota' => $subfolder->quota,
+			'managers' => array_map($this->formatSubfolderManager(...), $managers),
+			'can_manage' => $canManage,
+			'can_assign' => $canAssign,
+		];
 	}
 
 	/**
@@ -230,6 +282,47 @@ class FolderController extends OCSController {
 		return $folder;
 	}
 
+	/**
+	 * Recovery-bin data and permanent deletion are intentionally limited to
+	 * full Nextcloud administrators, not delegated Team folder administrators.
+	 *
+	 * @throws OCSForbiddenException
+	 */
+	private function requireGlobalAdmin(): void {
+		if ($this->user === null || !$this->groupManager->isAdmin($this->user->getUID())) {
+			throw new OCSForbiddenException('Only a global administrator can manage the Team folder recovery bin');
+		}
+	}
+
+	/**
+	 * @return array{folder: FolderDefinition, subfolder: SubfolderQuota, canManage: bool, canAssign: bool}
+	 * @throws OCSForbiddenException
+	 * @throws OCSNotFoundException
+	 */
+	private function getSubfolderManagementAccess(int $id, int $fileId): array {
+		$folder = $this->checkedGetFolder($id);
+		$subfolder = $this->subfolderQuotaManager->getDirectSubfolder($folder, $fileId);
+		if ($subfolder === null) {
+			throw new OCSNotFoundException('Direct subfolder not found');
+		}
+		if ($this->user === null) {
+			throw new OCSForbiddenException();
+		}
+
+		$canAssign = $folder->acl && $this->manager->canManageACL($id, $this->user);
+		$canManage = $canAssign || $this->subfolderManagerService->canManageSubfolder($folder, $fileId, $this->user);
+		if (!$canManage) {
+			throw new OCSForbiddenException('You are not allowed to manage this subfolder');
+		}
+
+		return [
+			'folder' => $folder,
+			'subfolder' => $subfolder,
+			'canManage' => $canManage,
+			'canAssign' => $canAssign,
+		];
+	}
+
 	private function checkMountPointExists(string $mountpoint): void {
 		$storageId = $this->getRootFolderStorageId();
 		if ($storageId === null) {
@@ -283,13 +376,13 @@ class FolderController extends OCSController {
 	}
 
 	/**
-	 * Remove a Groupfolder
+	 * Move a Groupfolder to the recovery bin
 	 *
 	 * @param int $id ID of the Groupfolder
 	 * @return DataResponse<Http::STATUS_OK, array{success: true}, array{}>
 	 * @throws OCSNotFoundException Groupfolder not found
 	 *
-	 * 200: Groupfolder removed successfully
+	 * 200: Groupfolder moved to the recovery bin successfully
 	 */
 	#[PasswordConfirmationRequired]
 	#[RequireGroupFolderAdmin]
@@ -298,8 +391,83 @@ class FolderController extends OCSController {
 	public function removeFolder(int $id): DataResponse {
 		$folder = $this->checkedGetFolder($id);
 
-		$this->folderStorageManager->deleteStoragesForFolder($folder);
-		$this->manager->removeFolder($id);
+		$this->manager->archiveFolder($folder->id, $this->user?->getUID());
+
+		return new DataResponse(['success' => true]);
+	}
+
+	/**
+	 * Get Team folders that are still recoverable.
+	 *
+	 * @return DataResponse<Http::STATUS_OK, list<GroupFoldersDeletedFolder>, array{}>
+	 * @throws OCSForbiddenException Not a global administrator
+	 *
+	 * 200: Deleted Team folders returned successfully
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/deleted')]
+	public function getDeletedFolders(): DataResponse {
+		$this->requireGlobalAdmin();
+
+		return new DataResponse(array_map($this->formatDeletedFolder(...), $this->manager->getDeletedFolders()));
+	}
+
+	/**
+	 * Restore a Team folder from the recovery bin.
+	 *
+	 * @param int $id ID of the deleted Team folder
+	 * @param ?string $mountpoint Replacement mount point when its original name is in use
+	 * @return DataResponse<Http::STATUS_OK, array{success: true, folder: GroupFoldersFolder}, array{}>
+	 * @throws OCSBadRequestException A replacement mount point is invalid or already in use
+	 * @throws OCSForbiddenException Not a global administrator
+	 * @throws OCSNotFoundException Deleted Team folder not found
+	 *
+	 * 200: Team folder restored successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/restore', requirements: ['id' => '\d+'])]
+	public function restoreDeletedFolder(int $id, ?string $mountpoint = null): DataResponse {
+		$this->requireGlobalAdmin();
+
+		if ($mountpoint !== null) {
+			$mountpoint = $this->manager->trimMountpoint($mountpoint);
+		}
+
+		try {
+			$this->manager->restoreDeletedFolder($id, $mountpoint);
+		} catch (\InvalidArgumentException $exception) {
+			if ($exception->getMessage() === 'Deleted Team folder not found') {
+				throw new OCSNotFoundException($exception->getMessage());
+			}
+			throw new OCSBadRequestException($exception->getMessage());
+		}
+
+		return new DataResponse([
+			'success' => true,
+			'folder' => $this->formatFolder($this->checkedGetFolder($id)),
+		]);
+	}
+
+	/**
+	 * Permanently remove a Team folder and all of its stored data.
+	 *
+	 * @param int $id ID of the deleted Team folder
+	 * @return DataResponse<Http::STATUS_OK, array{success: true}, array{}>
+	 * @throws OCSForbiddenException Not a global administrator
+	 * @throws OCSNotFoundException Deleted Team folder not found
+	 *
+	 * 200: Team folder permanently removed successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'DELETE', url: '/folders/{id}/permanent', requirements: ['id' => '\d+'])]
+	public function purgeDeletedFolder(int $id): DataResponse {
+		$this->requireGlobalAdmin();
+
+		if (!$this->manager->purgeDeletedFolder($id)) {
+			throw new OCSNotFoundException('Deleted Team folder not found');
+		}
 
 		return new DataResponse(['success' => true]);
 	}
@@ -452,7 +620,11 @@ class FolderController extends OCSController {
 	public function setQuota(int $id, int $quota): DataResponse {
 		$this->checkedGetFolder($id);
 
-		$this->manager->setFolderQuota($id, $quota);
+		try {
+			$this->manager->setFolderQuota($id, $quota);
+		} catch (\InvalidArgumentException $exception) {
+			throw new OCSBadRequestException($exception->getMessage());
+		}
 
 		$folder = $this->checkedGetFolder($id);
 
@@ -555,6 +727,72 @@ class FolderController extends OCSController {
 		$this->subfolderQuotaManager->removeSubfolderQuota($id, $fileId);
 
 		return new DataResponse(['success' => true]);
+	}
+
+	/**
+	 * Get the delegated administrators for one direct Team folder child.
+	 *
+	 * A Team folder administrator may assign managers. A delegated subfolder
+	 * administrator may view the configuration of the subfolder they manage.
+	 *
+	 * @param int $id ID of the Team folder
+	 * @param int $fileId File ID of the direct subfolder
+	 * @return DataResponse<Http::STATUS_OK, GroupFoldersSubfolderManagement, array{}>
+	 * @throws OCSForbiddenException Not allowed to manage this subfolder
+	 * @throws OCSNotFoundException Team folder or direct subfolder not found
+	 *
+	 * 200: Subfolder management returned successfully
+	 */
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/folders/{id}/subfolder-quotas/{fileId}/management', requirements: ['id' => '\d+', 'fileId' => '\d+'])]
+	public function getSubfolderManagement(int $id, int $fileId): DataResponse {
+		$access = $this->getSubfolderManagementAccess($id, $fileId);
+
+		return new DataResponse($this->formatSubfolderManagement(
+			$access['subfolder'],
+			$this->subfolderManagerService->getManagers($access['folder'], $fileId),
+			$access['canManage'],
+			$access['canAssign'],
+		));
+	}
+
+	/**
+	 * Add or remove a delegated administrator for one direct Team folder child.
+	 * Only a Team folder administrator can change this assignment.
+	 *
+	 * @param int $id ID of the Team folder
+	 * @param int $fileId File ID of the direct subfolder
+	 * @param string $mappingType Type of mapping: user, group, or circle
+	 * @param string $mappingId ID of the selected user, group, or team
+	 * @param bool $manager Whether to grant or revoke subfolder management
+	 * @return DataResponse<Http::STATUS_OK, GroupFoldersSubfolderManagement, array{}>
+	 * @throws OCSBadRequestException Invalid child or mapping
+	 * @throws OCSForbiddenException Not allowed to assign subfolder managers
+	 * @throws OCSNotFoundException Team folder or direct subfolder not found
+	 *
+	 * 200: Subfolder manager assignment updated successfully
+	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'POST', url: '/folders/{id}/subfolder-quotas/{fileId}/management', requirements: ['id' => '\d+', 'fileId' => '\d+'])]
+	public function setSubfolderManager(int $id, int $fileId, string $mappingType, string $mappingId, bool $manager): DataResponse {
+		$access = $this->getSubfolderManagementAccess($id, $fileId);
+		if (!$access['canAssign']) {
+			throw new OCSForbiddenException('Only a Team folder administrator can assign subfolder managers');
+		}
+
+		try {
+			$this->subfolderManagerService->setManager($access['folder'], $fileId, $mappingType, $mappingId, $manager);
+		} catch (\InvalidArgumentException $exception) {
+			throw new OCSBadRequestException($exception->getMessage());
+		}
+
+		return new DataResponse($this->formatSubfolderManagement(
+			$access['subfolder'],
+			$this->subfolderManagerService->getManagers($access['folder'], $fileId),
+			true,
+			true,
+		));
 	}
 
 	/**

--- a/lib/DAV/ACLPlugin.php
+++ b/lib/DAV/ACLPlugin.php
@@ -14,9 +14,11 @@ use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\ACL\RuleManager;
 use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\SubfolderManagerService;
 use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
 use OCP\IL10N;
 use OCP\IUser;
@@ -41,27 +43,38 @@ class ACLPlugin extends ServerPlugin {
 
 	private ?Server $server = null;
 	private ?IUser $user = null;
-	/** @var array<int, bool> */
+	/** @var array<string, bool> */
 	private array $canManageACL = [];
 
 	public function __construct(
 		private readonly RuleManager $ruleManager,
 		private readonly IUserSession $userSession,
 		private readonly FolderManager $folderManager,
+		private readonly SubfolderManagerService $subfolderManagerService,
 		private readonly IEventDispatcher $eventDispatcher,
 		private readonly ACLManagerFactory $aclManagerFactory,
 		private readonly IL10N $l10n,
 	) {
 	}
 
-	private function isAdmin(IUser $user, string $path): bool {
-		$folderId = $this->folderManager->getFolderByPath($path);
-
-		if (!isset($this->canManageACL[$folderId])) {
-			$this->canManageACL[$folderId] = $this->folderManager->canManageACL($folderId, $user);
+	private function isAdmin(IUser $user, FileInfo $fileInfo): bool {
+		$mount = $fileInfo->getMountPoint();
+		if (!$mount instanceof GroupMountPoint) {
+			return false;
 		}
 
-		return $this->canManageACL[$folderId];
+		$folder = $mount->getFolder();
+		if (!$folder->acl) {
+			return false;
+		}
+
+		$cacheKey = $folder->id . '::' . $user->getUID() . '::' . trim($fileInfo->getInternalPath(), '/');
+		if (!isset($this->canManageACL[$cacheKey])) {
+			$this->canManageACL[$cacheKey] = $this->folderManager->canManageACL($folder->id, $user)
+				|| $this->subfolderManagerService->canManagePath($folder, $fileInfo->getInternalPath(), $user);
+		}
+
+		return $this->canManageACL[$cacheKey];
 	}
 
 	#[\Override]
@@ -111,7 +124,7 @@ class ACLPlugin extends ServerPlugin {
 			}
 
 			$path = trim($mount->getSourcePath() . '/' . $fileInfo->getInternalPath(), '/');
-			if ($this->isAdmin($this->user, $fileInfo->getPath())) {
+			if ($this->isAdmin($this->user, $fileInfo)) {
 				$rules = $this->ruleManager->getAllRulesForPaths($mount->getNumericStorageId(), [$path]);
 			} else {
 				$rules = $this->ruleManager->getRulesForFilesByPath($this->user, $mount->getNumericStorageId(), [$path]);
@@ -133,7 +146,7 @@ class ACLPlugin extends ServerPlugin {
 
 			$parentInternalPaths = $this->getParents($fileInfo->getInternalPath());
 			$parentPaths = array_map(fn (string $internalPath): string => trim($mount->getSourcePath() . '/' . $internalPath, '/'), $parentInternalPaths);
-			if ($this->isAdmin($this->user, $fileInfo->getPath())) {
+			if ($this->isAdmin($this->user, $fileInfo)) {
 				$rulesByPath = $this->ruleManager->getAllRulesForPaths($mount->getNumericStorageId(), $parentPaths);
 			} else {
 				$rulesByPath = $this->ruleManager->getRulesForFilesByPath($this->user, $mount->getNumericStorageId(), $parentPaths);
@@ -191,7 +204,7 @@ class ACLPlugin extends ServerPlugin {
 				return false;
 			}
 
-			return $this->isAdmin($this->user, $fileInfo->getPath());
+			return $this->isAdmin($this->user, $fileInfo);
 		});
 
 		$propFind->handle(self::ACL_BASE_PERMISSION_PROPERTYNAME, function () use ($mount): int {
@@ -222,7 +235,7 @@ class ACLPlugin extends ServerPlugin {
 
 		$fileInfo = $node->getFileInfo();
 		$mount = $fileInfo->getMountPoint();
-		if (!$mount instanceof GroupMountPoint || !$this->isAdmin($this->user, $fileInfo->getPath())) {
+		if (!$mount instanceof GroupMountPoint || !$this->isAdmin($this->user, $fileInfo)) {
 			return;
 		}
 

--- a/lib/Folder/DeletedFolder.php
+++ b/lib/Folder/DeletedFolder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Folder;
+
+use OCP\Files\Cache\ICacheEntry;
+
+/**
+ * A Team folder that has been removed from users' mounts but is still within
+ * its recovery period.
+ */
+class DeletedFolder {
+	public function __construct(
+		public readonly FolderDefinition $folder,
+		public readonly ICacheEntry $rootCacheEntry,
+		public readonly int $deletedAt,
+		public readonly ?string $deletedBy,
+	) {
+	}
+}

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -1031,6 +1031,15 @@ class FolderManager {
 		$this->connection->beginTransaction();
 		try {
 			$query = $this->connection->getQueryBuilder();
+			$query->delete('gf_subfolder_quota')
+				->where(
+					$query->expr()->eq(
+						'folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT),
+					),
+				);
+			$query->executeStatement();
+
+			$query = $this->connection->getQueryBuilder();
 			$query->delete('group_folders_manage')
 				->where(
 					$query->expr()->eq(

--- a/lib/Folder/FolderManager.php
+++ b/lib/Folder/FolderManager.php
@@ -23,6 +23,7 @@ use OCA\GroupFolders\AppInfo\Application;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCA\GroupFolders\ResponseDefinitions;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AutoloadNotAllowedException;
 use OCP\Constants;
@@ -58,6 +59,7 @@ use Psr\Log\LoggerInterface;
  */
 class FolderManager {
 	public const SPACE_DEFAULT = -4;
+	public const DELETED_FOLDER_RETENTION_SECONDS = 30 * 24 * 60 * 60;
 
 	/**
 	 * Per-request cache of `acl_default_no_permission`; the value only changes on
@@ -87,6 +89,7 @@ class FolderManager {
 		private readonly IUserMappingManager $userMappingManager,
 		private readonly FolderStorageManager $folderStorageManager,
 		private readonly IAppConfig $appConfig,
+		private readonly ITimeFactory $timeFactory,
 	) {
 	}
 
@@ -101,7 +104,8 @@ class FolderManager {
 		$query = $this->connection->getQueryBuilder();
 
 		$query->select('folder_id', 'mount_point', 'quota', 'acl', 'acl_default_no_permission', 'storage_id', 'root_id', 'options')
-			->from('group_folders', 'f');
+			->from('group_folders', 'f')
+			->where($query->expr()->isNull('f.deleted_at'));
 
 		/** @var list<array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string}> $rows */
 		$rows = $query->executeQuery()->fetchAll();
@@ -120,7 +124,7 @@ class FolderManager {
 		return $folderMap;
 	}
 
-	private function selectWithFileCache(?IQueryBuilder $query = null): IQueryBuilder {
+	private function selectWithFileCache(?IQueryBuilder $query = null, bool $includeDeleted = false): IQueryBuilder {
 		if (!$query) {
 			$query = $this->connection->getQueryBuilder();
 		}
@@ -150,6 +154,11 @@ class FolderManager {
 			->selectAlias('c.permissions', 'permissions')
 			->from('group_folders', 'f')
 			->innerJoin('f', 'filecache', 'c', $query->expr()->eq('c.fileid', 'f.root_id'));
+
+		if (!$includeDeleted) {
+			$query->andWhere($query->expr()->isNull('f.deleted_at'));
+		}
+
 		return $query;
 	}
 
@@ -213,7 +222,7 @@ class FolderManager {
 			$query->expr()->eq('f.folder_id', 'a.folder_id'),
 		)
 			->selectAlias('a.permissions', 'group_permissions')
-			->where($query->expr()->in('a.group_id', $query->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));
+			->andWhere($query->expr()->in('a.group_id', $query->createNamedParameter($groups, IQueryBuilder::PARAM_STR_ARRAY)));
 
 		/** @var list<array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string}> $rows */
 		$rows = $query->executeQuery()->fetchAll();
@@ -343,7 +352,7 @@ class FolderManager {
 	public function getFolder(int $id): ?FolderWithMappingsAndCache {
 		$query = $this->selectWithFileCache();
 
-		$query->where($query->expr()->eq('f.folder_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$query->andWhere($query->expr()->eq('f.folder_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
 		$result = $query->executeQuery();
 		/** @var array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string}|false $row */
@@ -368,6 +377,136 @@ class FolderManager {
 	}
 
 	/**
+	 * @return list<DeletedFolder>
+	 * @throws Exception
+	 */
+	public function getDeletedFolders(): array {
+		$query = $this->selectWithFileCache(includeDeleted: true);
+		$query->addSelect('f.deleted_at', 'f.deleted_by')
+			->where($query->expr()->isNotNull('f.deleted_at'))
+			->orderBy('f.deleted_at', 'DESC');
+
+		/** @var list<array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string, deleted_at: int|string, deleted_by: ?string}> $rows */
+		$rows = $query->executeQuery()->fetchAll();
+
+		return array_map($this->rowToDeletedFolder(...), $rows);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function getDeletedFolder(int $id): ?DeletedFolder {
+		$query = $this->selectWithFileCache(includeDeleted: true);
+		$query->addSelect('f.deleted_at', 'f.deleted_by')
+			->where(
+				$query->expr()->andX(
+					$query->expr()->eq('f.folder_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)),
+					$query->expr()->isNotNull('f.deleted_at'),
+				),
+			);
+
+		/** @var array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string, deleted_at: int|string, deleted_by: ?string}|false $row */
+		$result = $query->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+		if ($row === false) {
+			return null;
+		}
+
+		return $this->rowToDeletedFolder($row);
+	}
+
+	/**
+	 * @return list<DeletedFolder>
+	 * @throws Exception
+	 */
+	public function getDeletedFoldersBefore(int $timestamp): array {
+		$query = $this->selectWithFileCache(includeDeleted: true);
+		$query->addSelect('f.deleted_at', 'f.deleted_by')
+			->where(
+				$query->expr()->andX(
+					$query->expr()->isNotNull('f.deleted_at'),
+					$query->expr()->lt('f.deleted_at', $query->createNamedParameter($timestamp, IQueryBuilder::PARAM_INT)),
+				),
+			)
+			->orderBy('f.deleted_at', 'ASC');
+
+		/** @var list<array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options: string, deleted_at: int|string, deleted_by: ?string}> $rows */
+		$rows = $query->executeQuery()->fetchAll();
+
+		return array_map($this->rowToDeletedFolder(...), $rows);
+	}
+
+	/**
+	 * Remove a Team folder from all user mounts while retaining its files and
+	 * configuration for the recovery period.
+	 *
+	 * @throws Exception
+	 */
+	public function archiveFolder(int $folderId, ?string $deletedBy): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->update('group_folders')
+			->set('deleted_at', $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
+			->set('deleted_by', $query->createNamedParameter($deletedBy, $deletedBy === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR))
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNull('deleted_at'));
+		$query->executeStatement();
+
+		$this->invalidateFolderAclCache($folderId);
+		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The groupfolder with id %d was moved to the recovery bin', [$folderId]));
+		$this->updateOverwriteHomeFolders();
+	}
+
+	/**
+	 * Restore a deleted Team folder. The optional mount point is needed when a
+	 * newly-created Team folder already uses the original name.
+	 *
+	 * @throws Exception
+	 * @throws \InvalidArgumentException
+	 */
+	public function restoreDeletedFolder(int $folderId, ?string $mountPoint = null): void {
+		$deletedFolder = $this->getDeletedFolder($folderId);
+		if ($deletedFolder === null) {
+			throw new \InvalidArgumentException('Deleted Team folder not found');
+		}
+
+		$mountPoint ??= $deletedFolder->folder->mountPoint;
+		if ($this->mountPointExists($mountPoint)) {
+			throw new \InvalidArgumentException('Mount point already exists');
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->update('group_folders')
+			->set('mount_point', $query->createNamedParameter($mountPoint))
+			->set('deleted_at', $query->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+			->set('deleted_by', $query->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNotNull('deleted_at'));
+		$query->executeStatement();
+
+		$this->invalidateFolderAclCache($folderId);
+		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The groupfolder with id %d was restored from the recovery bin', [$folderId]));
+		$this->updateOverwriteHomeFolders();
+	}
+
+	/**
+	 * Permanently remove an archived Team folder and all of its stored files.
+	 *
+	 * @throws Exception
+	 */
+	public function purgeDeletedFolder(int $folderId): bool {
+		$deletedFolder = $this->getDeletedFolder($folderId);
+		if ($deletedFolder === null) {
+			return false;
+		}
+
+		$this->folderStorageManager->deleteStoragesForFolder($deletedFolder->folder);
+		$this->removeFolder($folderId);
+
+		return true;
+	}
+
+	/**
 	 * Return just the ACL for the folder.
 	 *
 	 * @throws Exception
@@ -376,13 +515,14 @@ class FolderManager {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('acl')
 			->from('group_folders', 'f')
-			->where($query->expr()->eq('folder_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNull('deleted_at'));
 		$result = $query->executeQuery();
-		/** @var array{acl: int|string} $row */
+		/** @var array{acl: int|string}|false $row */
 		$row = $result->fetch();
 		$result->closeCursor();
 
-		return $row['acl'] === 1;
+		return $row !== false && $row['acl'] === 1;
 	}
 
 	public function getFolderByPath(string $path): int {
@@ -555,6 +695,7 @@ class FolderManager {
 		$query->select($query->func()->count('*'))
 			->from('group_folders')
 			->where($query->expr()->eq('mount_point', $query->createNamedParameter($mountPoint)))
+			->andWhere($query->expr()->isNull('deleted_at'))
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();
@@ -698,6 +839,18 @@ class FolderManager {
 	}
 
 	/**
+	 * @param array{folder_id: int|string, mount_point: string, quota: int|string, acl: bool, acl_default_no_permission: bool, storage_id: int|string, root_id: int|string, options?: string, deleted_at: int|string, deleted_by: ?string} $row
+	 */
+	private function rowToDeletedFolder(array $row): DeletedFolder {
+		return new DeletedFolder(
+			$this->rowToFolder($row),
+			Cache::cacheEntryFromData($row, $this->mimeTypeLoader),
+			(int)$row['deleted_at'],
+			$row['deleted_by'] === null ? null : (string)$row['deleted_by'],
+		);
+	}
+
+	/**
 	 * @param string[] $groupIds
 	 * @param list<string> $paths
 	 * @return list<FolderDefinitionWithPermissions>
@@ -716,7 +869,7 @@ class FolderManager {
 			$query->expr()->eq('f.folder_id', 'a.folder_id'),
 		)
 			->selectAlias('a.permissions', 'group_permissions')
-			->where($query->expr()->in('a.group_id', $query->createParameter('groupIds')));
+			->andWhere($query->expr()->in('a.group_id', $query->createParameter('groupIds')));
 
 		if ($folderId !== null) {
 			$query->andWhere($query->expr()->eq('f.folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
@@ -829,7 +982,7 @@ class FolderManager {
 			$query->expr()->eq('f.folder_id', 'a.folder_id'),
 		)
 			->selectAlias('a.permissions', 'group_permissions')
-			->where($query->expr()->neq('a.circle_id', $query->createNamedParameter('')));
+			->andWhere($query->expr()->neq('a.circle_id', $query->createNamedParameter('')));
 
 		if ($folderId !== null) {
 			$query->andWhere($query->expr()->eq('f.folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
@@ -1039,6 +1192,17 @@ class FolderManager {
 				);
 			$query->executeStatement();
 
+			if ($this->connection->tableExists('gf_subfolder_manager')) {
+				$query = $this->connection->getQueryBuilder();
+				$query->delete('gf_subfolder_manager')
+					->where(
+						$query->expr()->eq(
+							'folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT),
+						),
+					);
+				$query->executeStatement();
+			}
+
 			$query = $this->connection->getQueryBuilder();
 			$query->delete('group_folders_manage')
 				->where(
@@ -1079,6 +1243,8 @@ class FolderManager {
 	 * @throws Exception
 	 */
 	public function setFolderQuota(int $folderId, int $quota): void {
+		$this->validateSubfolderQuotaBounds($folderId, $this->getRealQuota($quota));
+
 		$query = $this->connection->getQueryBuilder();
 
 		$query->update('group_folders')
@@ -1121,6 +1287,14 @@ class FolderManager {
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('group')));
 		$query->executeStatement();
 
+		if ($this->connection->tableExists('gf_subfolder_manager')) {
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('gf_subfolder_manager')
+				->where($query->expr()->eq('mapping_id', $query->createNamedParameter($groupId)))
+				->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('group')));
+			$query->executeStatement();
+		}
+
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('group_folders_acl')
 			->where($query->expr()->eq('mapping_id', $query->createNamedParameter($groupId)))
@@ -1140,6 +1314,14 @@ class FolderManager {
 			->where($query->expr()->eq('mapping_id', $query->createNamedParameter($userId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('user')));
 		$query->executeStatement();
+
+		if ($this->connection->tableExists('gf_subfolder_manager')) {
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('gf_subfolder_manager')
+				->where($query->expr()->eq('mapping_id', $query->createNamedParameter($userId)))
+				->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('user')));
+			$query->executeStatement();
+		}
 
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('group_folders_acl')
@@ -1166,6 +1348,14 @@ class FolderManager {
 			->where($query->expr()->eq('mapping_id', $query->createNamedParameter($circleId)))
 			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('circle')));
 		$query->executeStatement();
+
+		if ($this->connection->tableExists('gf_subfolder_manager')) {
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('gf_subfolder_manager')
+				->where($query->expr()->eq('mapping_id', $query->createNamedParameter($circleId)))
+				->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter('circle')));
+			$query->executeStatement();
+		}
 	}
 
 
@@ -1180,12 +1370,10 @@ class FolderManager {
 			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId)));
 		$query->executeStatement();
 
-		if ($acl === false) {
-			$query = $this->connection->getQueryBuilder();
-			$query->delete('group_folders_manage')
-				->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId)));
-			$query->executeStatement();
-		}
+		// Keep Team folder and direct-subfolder manager mappings when advanced
+		// permissions are turned off. The DAV ACL plugin and subfolder manager
+		// service gate their use on this flag, so turning it off suspends the
+		// delegation; turning it back on restores the same assignments.
 
 		$this->invalidateFolderAclCache($folderId);
 
@@ -1281,6 +1469,28 @@ class FolderManager {
 		}
 	}
 
+	/**
+	 * Keep configured direct-child limits inside the effective Team folder
+	 * quota. The subfolder limits are caps, not reserved allocations, so their
+	 * sum is intentionally not constrained here.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	private function validateSubfolderQuotaBounds(int $folderId, int $quota): void {
+		if ($quota === FileInfo::SPACE_UNLIMITED || !$this->connection->tableExists('gf_subfolder_quota')) {
+			return;
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->func()->max('quota'))
+			->from('gf_subfolder_quota')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		$largestSubfolderQuota = $query->executeQuery()->fetchOne();
+		if ($largestSubfolderQuota !== false && $largestSubfolderQuota !== null && (int)$largestSubfolderQuota > $quota) {
+			throw new \InvalidArgumentException('The Team folder quota cannot be lower than an existing subfolder quota');
+		}
+	}
+
 	private function getRealQuota(int $quota): int {
 		if ($quota === self::SPACE_DEFAULT) {
 			$defaultQuota = $this->config->getSystemValueInt('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED);
@@ -1304,6 +1514,7 @@ class FolderManager {
 		$query = $builder->select('folder_id')
 			->from('group_folders')
 			->where($builder->expr()->eq('mount_point', $builder->createNamedParameter('/')))
+			->andWhere($builder->expr()->isNull('deleted_at'))
 			->setMaxResults(1);
 		$result = $query->executeQuery();
 
@@ -1336,7 +1547,8 @@ class FolderManager {
 		$query = $qb
 			->select('acl_default_no_permission')
 			->from('group_folders')
-			->where($qb->expr()->eq('folder_id', $qb->createNamedParameter($folderId)));
+			->where($qb->expr()->eq('folder_id', $qb->createNamedParameter($folderId)))
+			->andWhere($qb->expr()->isNull('deleted_at'));
 
 		$result = $query->executeQuery();
 		$hasDefaultNoPermission = (bool)$result->fetchOne();
@@ -1370,7 +1582,8 @@ class FolderManager {
 	public function countAllFolders(): int {
 		$query = $this->connection->getQueryBuilder();
 		$query->select($query->func()->count('folder_id'))
-			->from('group_folders');
+			->from('group_folders')
+			->where($query->expr()->isNull('deleted_at'));
 		$result = $query->executeQuery()->fetchOne();
 		return is_numeric($result) ? (int)$result : 0;
 	}

--- a/lib/Folder/SubfolderManagerService.php
+++ b/lib/Folder/SubfolderManagerService.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Folder;
+
+use OCA\GroupFolders\ACL\UserMapping\IUserMapping;
+use OCA\GroupFolders\ACL\UserMapping\IUserMappingManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IDBConnection;
+use OCP\IUser;
+use OCP\Log\Audit\CriticalActionPerformedEvent;
+
+/**
+ * Stores delegated administrators for direct children of Team folders.
+ *
+ * The mapping format deliberately matches Team folder ACL managers, so a
+ * delegate may be a user, group, or Circle. Being a delegate grants no file
+ * access by itself; normal Team folder and ACL permissions still apply.
+ * Delegation is available only while advanced permissions are enabled. Its
+ * mappings are retained while disabled so they can be reactivated later.
+ */
+class SubfolderManagerService {
+	public function __construct(
+		private readonly IDBConnection $connection,
+		private readonly IUserMappingManager $userMappingManager,
+		private readonly SubfolderQuotaManager $subfolderQuotaManager,
+		private readonly IEventDispatcher $eventDispatcher,
+	) {
+	}
+
+	/**
+	 * @return list<IUserMapping>
+	 * @throws \InvalidArgumentException when the file is not a direct child
+	 */
+	public function getManagers(FolderDefinition $folder, int $fileId): array {
+		if ($this->subfolderQuotaManager->getDirectSubfolder($folder, $fileId) === null) {
+			throw new \InvalidArgumentException('The subfolder manager can only be assigned to a direct child of this Team folder');
+		}
+		if (!$this->hasManagerTable()) {
+			return [];
+		}
+
+		return $this->getManagersForSubfolder($folder->id, $fileId);
+	}
+
+	public function canManageSubfolder(FolderDefinition $folder, int $fileId, IUser $user): bool {
+		if (!$folder->acl || $this->subfolderQuotaManager->getDirectSubfolder($folder, $fileId) === null) {
+			return false;
+		}
+
+		return $this->userMappingManager->userInMappings($user, $this->getManagersForSubfolder($folder->id, $fileId));
+	}
+
+	/**
+	 * Check whether a delegate may administer a path within a Team folder.
+	 * The assigned direct child and all of its descendants are covered.
+	 */
+	public function canManagePath(FolderDefinition $folder, string $path, IUser $user): bool {
+		if (!$folder->acl) {
+			return false;
+		}
+
+		$subfolder = $this->subfolderQuotaManager->getDirectSubfolderForPath($folder, $path);
+		if ($subfolder === null) {
+			return false;
+		}
+
+		return $this->userMappingManager->userInMappings($user, $this->getManagersForSubfolder($folder->id, $subfolder->fileId));
+	}
+
+	/**
+	 * @throws \InvalidArgumentException when the child or mapping is invalid
+	 */
+	public function setManager(FolderDefinition $folder, int $fileId, string $mappingType, string $mappingId, bool $manager): IUserMapping {
+		if (!$folder->acl) {
+			throw new \InvalidArgumentException('Advanced permissions must be enabled before assigning a subfolder manager');
+		}
+		if ($this->subfolderQuotaManager->getDirectSubfolder($folder, $fileId) === null) {
+			throw new \InvalidArgumentException('The subfolder manager can only be assigned to a direct child of this Team folder');
+		}
+
+		$mapping = $this->userMappingManager->mappingFromId($mappingType, $mappingId);
+		if ($mapping === null) {
+			throw new \InvalidArgumentException('The selected user, group, or team does not exist');
+		}
+		if (!$this->hasManagerTable()) {
+			throw new \InvalidArgumentException('The subfolder manager database migration has not been applied yet');
+		}
+
+		if ($manager) {
+			$this->addManager($folder->id, $fileId, $mapping);
+		} else {
+			$this->removeManager($folder->id, $fileId, $mapping);
+		}
+
+		$action = $manager ? 'given' : 'revoked';
+		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The %s "%s" was %s subfolder management rights for subfolder with id %d in groupfolder with id %d', [
+			$mapping->getType(),
+			$mapping->getId(),
+			$action,
+			$fileId,
+			$folder->id,
+		]));
+
+		return $mapping;
+	}
+
+	public function hasManagers(int $folderId, int $fileId): bool {
+		if (!$this->hasManagerTable()) {
+			return false;
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->func()->count('*'))
+			->from('gf_subfolder_manager')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+		return (int)$query->executeQuery()->fetchOne() > 0;
+	}
+
+	/**
+	 * Remove all manager mappings attached to a deleted or moved file cache entry.
+	 */
+	public function removeManagersByFileId(int $fileId): void {
+		if (!$this->hasManagerTable()) {
+			return;
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('gf_subfolder_manager')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+	}
+
+	/**
+	 * @return list<IUserMapping>
+	 */
+	private function getManagersForSubfolder(int $folderId, int $fileId): array {
+		if (!$this->hasManagerTable()) {
+			return [];
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('mapping_type', 'mapping_id')
+			->from('gf_subfolder_manager')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->orderBy('mapping_type', 'ASC')
+			->addOrderBy('mapping_id', 'ASC');
+
+		/** @var list<array{mapping_type: string, mapping_id: string}> $rows */
+		$rows = $query->executeQuery()->fetchAll();
+		$mappings = [];
+		foreach ($rows as $row) {
+			$mapping = $this->userMappingManager->mappingFromId($row['mapping_type'], $row['mapping_id']);
+			if ($mapping !== null) {
+				$mappings[] = $mapping;
+			}
+		}
+
+		return $mappings;
+	}
+
+	private function addManager(int $folderId, int $fileId, IUserMapping $mapping): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->select($query->func()->count('*'))
+			->from('gf_subfolder_manager')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter($mapping->getType())))
+			->andWhere($query->expr()->eq('mapping_id', $query->createNamedParameter($mapping->getId())));
+		if ((int)$query->executeQuery()->fetchOne() > 0) {
+			return;
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('gf_subfolder_manager')
+			->values([
+				'folder_id' => $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT),
+				'file_id' => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT),
+				'mapping_type' => $query->createNamedParameter($mapping->getType()),
+				'mapping_id' => $query->createNamedParameter($mapping->getId()),
+			]);
+		$query->executeStatement();
+	}
+
+	private function removeManager(int $folderId, int $fileId, IUserMapping $mapping): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('gf_subfolder_manager')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('mapping_type', $query->createNamedParameter($mapping->getType())))
+			->andWhere($query->expr()->eq('mapping_id', $query->createNamedParameter($mapping->getId())));
+		$query->executeStatement();
+	}
+
+	private function hasManagerTable(): bool {
+		return $this->connection->tableExists('gf_subfolder_manager');
+	}
+}

--- a/lib/Folder/SubfolderQuota.php
+++ b/lib/Folder/SubfolderQuota.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Folder;
+
+/**
+ * A direct child folder and its optional independent quota.
+ */
+class SubfolderQuota {
+	public function __construct(
+		public readonly int $fileId,
+		public readonly string $name,
+		public readonly int $size,
+		public readonly ?int $quota,
+	) {
+	}
+
+	/**
+	 * @return array{file_id: int, name: string, size: int, quota: ?int}
+	 */
+	public function toArray(): array {
+		return [
+			'file_id' => $this->fileId,
+			'name' => $this->name,
+			'size' => $this->size,
+			'quota' => $this->quota,
+		];
+	}
+}

--- a/lib/Folder/SubfolderQuotaManager.php
+++ b/lib/Folder/SubfolderQuotaManager.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Folder;
+
+use OCA\GroupFolders\Mount\FolderStorageManager;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\ICache;
+use OCP\Files\FileInfo;
+use OCP\Files\IMimeTypeLoader;
+use OCP\Files\InvalidPathException;
+use OCP\IDBConnection;
+use OCP\Log\Audit\CriticalActionPerformedEvent;
+
+/**
+ * Stores and resolves quotas assigned to direct child folders of Team folders.
+ */
+class SubfolderQuotaManager {
+	/** @var array<int, array<int, int>> */
+	private array $quotaCache = [];
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+		private readonly IMimeTypeLoader $mimeTypeLoader,
+		private readonly FolderStorageManager $folderStorageManager,
+		private readonly IEventDispatcher $eventDispatcher,
+	) {
+	}
+
+	/**
+	 * @return list<SubfolderQuota>
+	 */
+	public function getSubfolderQuotas(FolderDefinition $folder): array {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('f.fileid', 'f.name', 'f.size', 'q.quota')
+			->from('filecache', 'f')
+			->leftJoin(
+				'f',
+				'gf_subfolder_quota',
+				'q',
+				$query->expr()->andX(
+					$query->expr()->eq('q.folder_id', $query->createNamedParameter($folder->id, IQueryBuilder::PARAM_INT)),
+					$query->expr()->eq('q.file_id', 'f.fileid'),
+				),
+			)
+			->where($query->expr()->eq('f.parent', $query->createNamedParameter($folder->rootId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($folder->storageId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.mimetype', $query->createNamedParameter($this->getDirectoryMimeTypeId(), IQueryBuilder::PARAM_INT)))
+			->orderBy('f.name', 'ASC');
+
+		/** @var list<array{fileid: int|string, name: string, size: int|string, quota: int|string|null}> $rows */
+		$rows = $query->executeQuery()->fetchAll();
+
+		return array_map($this->rowToSubfolderQuota(...), $rows);
+	}
+
+	/**
+	 * Resolve the configured quota that applies to a storage path.
+	 */
+	public function getQuotaForPath(FolderDefinition $folder, ICache $cache, string $path): ?SubfolderQuota {
+		$name = $this->getDirectChildName($path);
+		if ($name === null) {
+			return null;
+		}
+
+		$entry = $cache->get($name);
+		if ($entry === false || $entry->getMimeType() !== FileInfo::MIMETYPE_FOLDER) {
+			return null;
+		}
+
+		$quota = $this->getQuotaMap($folder->id)[$entry->getId()] ?? null;
+		if ($quota === null) {
+			return null;
+		}
+
+		return new SubfolderQuota(
+			$entry->getId(),
+			$entry->getName(),
+			$entry->getSize(),
+			$quota,
+		);
+	}
+
+	/**
+	 * @throws \InvalidArgumentException when the file is not a direct child folder
+	 */
+	public function setSubfolderQuota(FolderDefinition $folder, int $fileId, int $quota): SubfolderQuota {
+		$this->validateQuota($quota);
+		$subfolder = $this->getDirectSubfolder($folder, $fileId);
+		if ($subfolder === null) {
+			throw new \InvalidArgumentException('The quota can only be assigned to a direct subfolder of this Team folder');
+		}
+
+		if ($quota === FileInfo::SPACE_UNLIMITED) {
+			$this->removeSubfolderQuota($folder->id, $fileId);
+			return new SubfolderQuota($subfolder->fileId, $subfolder->name, $subfolder->size, null);
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->update('gf_subfolder_quota')
+			->set('quota', $query->createNamedParameter($quota, IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folder->id, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+		if ($query->executeStatement() === 0) {
+			$query = $this->connection->getQueryBuilder();
+			$query->insert('gf_subfolder_quota')
+				->values([
+					'folder_id' => $query->createNamedParameter($folder->id, IQueryBuilder::PARAM_INT),
+					'file_id' => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT),
+					'quota' => $query->createNamedParameter($quota, IQueryBuilder::PARAM_INT),
+				]);
+			$query->executeStatement();
+		}
+
+		$this->invalidateQuotaCache($folder->id);
+		$this->eventDispatcher->dispatchTyped(new CriticalActionPerformedEvent('The quota for subfolder with id %d in groupfolder with id %d was set to %d bytes', [$fileId, $folder->id, $quota]));
+
+		return new SubfolderQuota($subfolder->fileId, $subfolder->name, $subfolder->size, $quota);
+	}
+
+	/**
+	 * Create a direct child folder and optionally assign a quota to it.
+	 *
+	 * @throws \InvalidArgumentException when the name or quota is invalid
+	 * @throws \RuntimeException when the folder cannot be created or scanned
+	 */
+	public function createSubfolder(FolderDefinition $folder, string $name, int $quota): SubfolderQuota {
+		$name = trim($name);
+		$this->validateSubfolderName($name);
+		$this->validateQuota($quota);
+
+		$storage = $this->folderStorageManager->getBaseStorageForFolder(
+			$folder->id,
+			$folder->useSeparateStorage(),
+			$folder,
+		);
+		try {
+			$storage->verifyPath('', $name);
+		} catch (InvalidPathException $exception) {
+			throw new \InvalidArgumentException($exception->getMessage(), previous: $exception);
+		}
+		if ($storage->file_exists($name)) {
+			throw new \InvalidArgumentException('A file or folder with this name already exists');
+		}
+		if (!$storage->mkdir($name)) {
+			throw new \RuntimeException('Unable to create the subfolder');
+		}
+
+		$cache = $storage->getCache();
+		$entry = $cache->get($name);
+		if ($entry === false) {
+			$storage->getScanner()->scan($name);
+			$entry = $cache->get($name);
+		}
+		if ($entry === false) {
+			throw new \RuntimeException('The created subfolder could not be found in the file cache');
+		}
+
+		return $this->setSubfolderQuota($folder, $entry->getId(), $quota);
+	}
+
+	public function removeSubfolderQuota(int $folderId, int $fileId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('gf_subfolder_quota')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+
+		$this->invalidateQuotaCache($folderId);
+	}
+
+	public function hasSubfolderQuota(int $folderId, int $fileId): bool {
+		return isset($this->getQuotaMap($folderId)[$fileId]);
+	}
+
+	/**
+	 * Remove any quota that refers to a deleted file cache entry.
+	 */
+	public function removeSubfolderQuotaByFileId(int $fileId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('folder_id')
+			->from('gf_subfolder_quota')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		/** @var list<int|string> $folderIds */
+		$folderIds = $query->executeQuery()->fetchFirstColumn();
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('gf_subfolder_quota')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+
+		foreach ($folderIds as $folderId) {
+			$this->invalidateQuotaCache((int)$folderId);
+		}
+	}
+
+	public function removeSubfolderQuotasForFolder(int $folderId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('gf_subfolder_quota')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+
+		$this->invalidateQuotaCache($folderId);
+	}
+
+	/**
+	 * @return array<int, int>
+	 */
+	private function getQuotaMap(int $folderId): array {
+		if (isset($this->quotaCache[$folderId])) {
+			return $this->quotaCache[$folderId];
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('file_id', 'quota')
+			->from('gf_subfolder_quota')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		/** @var list<array{file_id: int|string, quota: int|string}> $rows */
+		$rows = $query->executeQuery()->fetchAll();
+
+		$this->quotaCache[$folderId] = [];
+		foreach ($rows as $row) {
+			$this->quotaCache[$folderId][(int)$row['file_id']] = (int)$row['quota'];
+		}
+
+		return $this->quotaCache[$folderId];
+	}
+
+	private function invalidateQuotaCache(int $folderId): void {
+		unset($this->quotaCache[$folderId]);
+	}
+
+	private function getDirectoryMimeTypeId(): int {
+		return $this->mimeTypeLoader->getId(FileInfo::MIMETYPE_FOLDER);
+	}
+
+	private function getDirectChildName(string $path): ?string {
+		$path = trim($path, '/');
+		if ($path === '' || $path === '.') {
+			return null;
+		}
+
+		return explode('/', $path, 2)[0];
+	}
+
+	private function getDirectSubfolder(FolderDefinition $folder, int $fileId): ?SubfolderQuota {
+		$query = $this->connection->getQueryBuilder();
+		$query->select('f.fileid', 'f.name', 'f.size', 'q.quota')
+			->from('filecache', 'f')
+			->leftJoin(
+				'f',
+				'gf_subfolder_quota',
+				'q',
+				$query->expr()->andX(
+					$query->expr()->eq('q.folder_id', $query->createNamedParameter($folder->id, IQueryBuilder::PARAM_INT)),
+					$query->expr()->eq('q.file_id', 'f.fileid'),
+				),
+			)
+			->where($query->expr()->eq('f.fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.parent', $query->createNamedParameter($folder->rootId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($folder->storageId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.mimetype', $query->createNamedParameter($this->getDirectoryMimeTypeId(), IQueryBuilder::PARAM_INT)));
+
+		/** @var array{fileid: int|string, name: string, size: int|string, quota: int|string|null}|false $row */
+		$row = $query->executeQuery()->fetch();
+		if ($row === false) {
+			return null;
+		}
+
+		return $this->rowToSubfolderQuota($row);
+	}
+
+	/**
+	 * @param array{fileid: int|string, name: string, size: int|string, quota: int|string|null} $row
+	 */
+	private function rowToSubfolderQuota(array $row): SubfolderQuota {
+		return new SubfolderQuota(
+			(int)$row['fileid'],
+			$row['name'],
+			(int)$row['size'],
+			$row['quota'] === null ? null : (int)$row['quota'],
+		);
+	}
+
+	/**
+	 * @throws \InvalidArgumentException
+	 */
+	private function validateQuota(int $quota): void {
+		if ($quota < 0 && $quota !== FileInfo::SPACE_UNLIMITED) {
+			throw new \InvalidArgumentException('The quota must be a non-negative number of bytes or unlimited');
+		}
+	}
+
+	/**
+	 * @throws \InvalidArgumentException
+	 */
+	private function validateSubfolderName(string $name): void {
+		if ($name === '' || $name === '.' || $name === '..' || str_contains($name, '/')) {
+			throw new \InvalidArgumentException('The subfolder name must name one direct child folder');
+		}
+	}
+}

--- a/lib/Folder/SubfolderQuotaManager.php
+++ b/lib/Folder/SubfolderQuotaManager.php
@@ -89,10 +89,46 @@ class SubfolderQuotaManager {
 	}
 
 	/**
+	 * Resolve the direct Team folder child that owns a storage path. Unlike
+	 * getQuotaForPath(), this also returns children without a separate quota.
+	 */
+	public function getDirectSubfolderForPath(FolderDefinition $folder, string $path): ?SubfolderQuota {
+		$name = $this->getDirectChildName($path);
+		if ($name === null) {
+			return null;
+		}
+
+		$query = $this->connection->getQueryBuilder();
+		$query->select('f.fileid', 'f.name', 'f.size', 'q.quota')
+			->from('filecache', 'f')
+			->leftJoin(
+				'f',
+				'gf_subfolder_quota',
+				'q',
+				$query->expr()->andX(
+					$query->expr()->eq('q.folder_id', $query->createNamedParameter($folder->id, IQueryBuilder::PARAM_INT)),
+					$query->expr()->eq('q.file_id', 'f.fileid'),
+				),
+			)
+			->where($query->expr()->eq('f.name', $query->createNamedParameter($name)))
+			->andWhere($query->expr()->eq('f.parent', $query->createNamedParameter($folder->rootId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.storage', $query->createNamedParameter($folder->storageId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('f.mimetype', $query->createNamedParameter($this->getDirectoryMimeTypeId(), IQueryBuilder::PARAM_INT)));
+
+		/** @var array{fileid: int|string, name: string, size: int|string, quota: int|string|null}|false $row */
+		$row = $query->executeQuery()->fetch();
+		if ($row === false) {
+			return null;
+		}
+
+		return $this->rowToSubfolderQuota($row);
+	}
+
+	/**
 	 * @throws \InvalidArgumentException when the file is not a direct child folder
 	 */
 	public function setSubfolderQuota(FolderDefinition $folder, int $fileId, int $quota): SubfolderQuota {
-		$this->validateQuota($quota);
+		$this->validateQuotaForFolder($folder, $quota);
 		$subfolder = $this->getDirectSubfolder($folder, $fileId);
 		if ($subfolder === null) {
 			throw new \InvalidArgumentException('The quota can only be assigned to a direct subfolder of this Team folder');
@@ -135,7 +171,7 @@ class SubfolderQuotaManager {
 	public function createSubfolder(FolderDefinition $folder, string $name, int $quota): SubfolderQuota {
 		$name = trim($name);
 		$this->validateSubfolderName($name);
-		$this->validateQuota($quota);
+		$this->validateQuotaForFolder($folder, $quota);
 
 		$storage = $this->folderStorageManager->getBaseStorageForFolder(
 			$folder->id,
@@ -251,7 +287,7 @@ class SubfolderQuotaManager {
 		return explode('/', $path, 2)[0];
 	}
 
-	private function getDirectSubfolder(FolderDefinition $folder, int $fileId): ?SubfolderQuota {
+	public function getDirectSubfolder(FolderDefinition $folder, int $fileId): ?SubfolderQuota {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('f.fileid', 'f.name', 'f.size', 'q.quota')
 			->from('filecache', 'f')
@@ -296,6 +332,25 @@ class SubfolderQuotaManager {
 	private function validateQuota(int $quota): void {
 		if ($quota < 0 && $quota !== FileInfo::SPACE_UNLIMITED) {
 			throw new \InvalidArgumentException('The quota must be a non-negative number of bytes or unlimited');
+		}
+	}
+
+	/**
+	 * A child quota is a limit within the Team folder quota, never a separate
+	 * allocation outside it. A finite child limit therefore cannot exceed a
+	 * finite Team folder limit.
+	 *
+	 * @throws \InvalidArgumentException
+	 */
+	private function validateQuotaForFolder(FolderDefinition $folder, int $quota): void {
+		$this->validateQuota($quota);
+
+		if ($quota === FileInfo::SPACE_UNLIMITED || $folder->quota === FileInfo::SPACE_UNLIMITED) {
+			return;
+		}
+
+		if ($quota > $folder->quota) {
+			throw new \InvalidArgumentException('The subfolder quota cannot exceed the Team folder quota');
 		}
 	}
 

--- a/lib/Listeners/SubfolderQuotaListener.php
+++ b/lib/Listeners/SubfolderQuotaListener.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Listeners;
+
+use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
+use OCA\GroupFolders\Mount\GroupFolderStorage;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Exceptions\AbortedEventException;
+use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Events\Node\NodeRenamedEvent;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+
+/**
+ * Keeps subfolder quota assignments attached to direct Team folder children.
+ *
+ * @template-implements IEventListener<Event>
+ */
+class SubfolderQuotaListener implements IEventListener {
+	/**
+	 * The source node in NodeRenamedEvent may no longer exist. Keep the source
+	 * file id from the corresponding before event so a cross-storage move can
+	 * remove the original assignment safely.
+	 *
+	 * @var array<string, array{folderId: int, fileId: int}>
+	 */
+	private array $pendingMoves = [];
+
+	public function __construct(
+		private readonly SubfolderQuotaManager $subfolderQuotaManager,
+	) {
+	}
+
+	#[\Override]
+	public function handle(Event $event): void {
+		if ($event instanceof BeforeNodeRenamedEvent) {
+			$this->preventNestedConfiguredSubfolder($event);
+			return;
+		}
+
+		if ($event instanceof NodeRenamedEvent) {
+			$this->removeQuotaAfterMoveOutsideDirectChildren($event);
+			return;
+		}
+
+		if (!$event instanceof NodeDeletedEvent) {
+			return;
+		}
+
+		$this->removeQuotaAfterDeletion($event);
+	}
+
+	private function preventNestedConfiguredSubfolder(BeforeNodeRenamedEvent $event): void {
+		$source = $event->getSource();
+		$sourceStorage = $source->getStorage();
+		if (!$sourceStorage->instanceOfStorage(GroupFolderStorage::class)) {
+			return;
+		}
+
+		/** @var GroupFolderStorage $sourceStorage */
+		$sourceFolder = $sourceStorage->getFolder();
+		if (!$this->subfolderQuotaManager->hasSubfolderQuota($sourceFolder->id, $source->getId())) {
+			return;
+		}
+
+		$target = $event->getTarget();
+		$targetStorage = $target->getStorage();
+		if ($targetStorage->instanceOfStorage(GroupFolderStorage::class)
+			&& $targetStorage->getFolderId() === $sourceFolder->id
+			&& $targetStorage->appliesSubfolderQuotas()
+			&& !$this->isDirectChildOf($target, $sourceFolder)) {
+			throw new AbortedEventException('A subfolder with a quota must remain a direct child of its Team folder');
+		}
+
+		$this->pendingMoves[$this->getMoveKey($source, $target)] = [
+			'folderId' => $sourceFolder->id,
+			'fileId' => $source->getId(),
+		];
+	}
+
+	private function removeQuotaAfterMoveOutsideDirectChildren(NodeRenamedEvent $event): void {
+		$source = $event->getSource();
+		$target = $event->getTarget();
+		$pendingMoveKey = $this->getMoveKey($source, $target);
+		$pendingMove = $this->pendingMoves[$pendingMoveKey] ?? null;
+		unset($this->pendingMoves[$pendingMoveKey]);
+
+		if ($pendingMove === null) {
+			return;
+		}
+
+		$targetStorage = $target->getStorage();
+		$remainsDirectChild = $targetStorage->instanceOfStorage(GroupFolderStorage::class)
+			&& $targetStorage->getFolderId() === $pendingMove['folderId']
+			&& $targetStorage->appliesSubfolderQuotas()
+			&& $this->isDirectChildOf($target, $targetStorage->getFolder());
+		if (!$remainsDirectChild) {
+			$this->subfolderQuotaManager->removeSubfolderQuota($pendingMove['folderId'], $pendingMove['fileId']);
+		}
+	}
+
+	private function removeQuotaAfterDeletion(NodeDeletedEvent $event): void {
+		$node = $event->getNode();
+		$storage = $node->getStorage();
+		if (!$storage->instanceOfStorage(GroupFolderStorage::class)) {
+			return;
+		}
+
+		/** @var GroupFolderStorage $storage */
+		$this->subfolderQuotaManager->removeSubfolderQuota($storage->getFolderId(), $node->getId());
+	}
+
+	private function isDirectChildOf(Node $node, FolderDefinition $folder): bool {
+		try {
+			return $node->getParent()->getId() === $folder->rootId;
+		} catch (NotFoundException) {
+			return false;
+		}
+	}
+
+	private function getMoveKey(Node $source, Node $target): string {
+		return $source->getPath() . "\0" . $target->getPath();
+	}
+}

--- a/lib/Listeners/SubfolderQuotaListener.php
+++ b/lib/Listeners/SubfolderQuotaListener.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\Listeners;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\SubfolderManagerService;
 use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
 use OCP\EventDispatcher\Event;
@@ -38,6 +39,7 @@ class SubfolderQuotaListener implements IEventListener {
 
 	public function __construct(
 		private readonly SubfolderQuotaManager $subfolderQuotaManager,
+		private readonly SubfolderManagerService $subfolderManagerService,
 	) {
 	}
 
@@ -69,7 +71,8 @@ class SubfolderQuotaListener implements IEventListener {
 
 		/** @var GroupFolderStorage $sourceStorage */
 		$sourceFolder = $sourceStorage->getFolder();
-		if (!$this->subfolderQuotaManager->hasSubfolderQuota($sourceFolder->id, $source->getId())) {
+		if (!$this->subfolderQuotaManager->hasSubfolderQuota($sourceFolder->id, $source->getId())
+			&& !$this->subfolderManagerService->hasManagers($sourceFolder->id, $source->getId())) {
 			return;
 		}
 
@@ -79,7 +82,7 @@ class SubfolderQuotaListener implements IEventListener {
 			&& $targetStorage->getFolderId() === $sourceFolder->id
 			&& $targetStorage->appliesSubfolderQuotas()
 			&& !$this->isDirectChildOf($target, $sourceFolder)) {
-			throw new AbortedEventException('A subfolder with a quota must remain a direct child of its Team folder');
+			throw new AbortedEventException('A configured subfolder must remain a direct child of its Team folder');
 		}
 
 		$this->pendingMoves[$this->getMoveKey($source, $target)] = [
@@ -106,6 +109,7 @@ class SubfolderQuotaListener implements IEventListener {
 			&& $this->isDirectChildOf($target, $targetStorage->getFolder());
 		if (!$remainsDirectChild) {
 			$this->subfolderQuotaManager->removeSubfolderQuota($pendingMove['folderId'], $pendingMove['fileId']);
+			$this->subfolderManagerService->removeManagersByFileId($pendingMove['fileId']);
 		}
 	}
 
@@ -118,6 +122,7 @@ class SubfolderQuotaListener implements IEventListener {
 
 		/** @var GroupFolderStorage $storage */
 		$this->subfolderQuotaManager->removeSubfolderQuota($storage->getFolderId(), $node->getId());
+		$this->subfolderManagerService->removeManagersByFileId($node->getId());
 	}
 
 	private function isDirectChildOf(Node $node, FolderDefinition $folder): bool {

--- a/lib/Migration/Version2400000Date20260827000000.php
+++ b/lib/Migration/Version2400000Date20260827000000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds quotas for direct subfolders of Team folders.
+ */
+class Version2400000Date20260827000000 extends SimpleMigrationStep {
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('gf_subfolder_quota')) {
+			return null;
+		}
+
+		$table = $schema->createTable('gf_subfolder_quota');
+		$table->addColumn('folder_id', Types::INTEGER, [
+			'notnull' => true,
+		]);
+		$table->addColumn('file_id', Types::BIGINT, [
+			'notnull' => true,
+		]);
+		$table->addColumn('quota', Types::BIGINT, [
+			'notnull' => true,
+		]);
+		$table->setPrimaryKey(['folder_id', 'file_id']);
+		$table->addIndex(['file_id'], 'gf_subfolder_quota_file');
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version2400000Date20260827100000.php
+++ b/lib/Migration/Version2400000Date20260827100000.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds delegated administrators for direct Team folder children.
+ */
+class Version2400000Date20260827100000 extends SimpleMigrationStep {
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('gf_subfolder_manager')) {
+			return null;
+		}
+
+		$table = $schema->createTable('gf_subfolder_manager');
+		$table->addColumn('folder_id', Types::INTEGER, [
+			'notnull' => true,
+		]);
+		$table->addColumn('file_id', Types::BIGINT, [
+			'notnull' => true,
+		]);
+		$table->addColumn('mapping_type', Types::STRING, [
+			'notnull' => true,
+			'length' => 16,
+		]);
+		$table->addColumn('mapping_id', Types::STRING, [
+			'notnull' => true,
+			// Keep this in sync with group_folders_manage. Apart from being
+			// sufficient for user, group, and Circle ids, this keeps the
+			// composite primary key portable to older MySQL installations.
+			'length' => 64,
+		]);
+		$table->setPrimaryKey(['folder_id', 'file_id', 'mapping_type', 'mapping_id']);
+		$table->addIndex(['file_id'], 'gf_subfolder_manager_file');
+		$table->addIndex(['mapping_type', 'mapping_id'], 'gf_subfolder_manager_mapping');
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version2400000Date20260827110000.php
+++ b/lib/Migration/Version2400000Date20260827110000.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Adds the recovery state for deleted Team folders.
+ */
+class Version2400000Date20260827110000 extends SimpleMigrationStep {
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('group_folders')) {
+			return null;
+		}
+
+		$table = $schema->getTable('group_folders');
+		$changed = false;
+
+		if (!$table->hasColumn('deleted_at')) {
+			$table->addColumn('deleted_at', Types::BIGINT, [
+				'notnull' => false,
+			]);
+			$changed = true;
+		}
+
+		if (!$table->hasColumn('deleted_by')) {
+			$table->addColumn('deleted_by', Types::STRING, [
+				'notnull' => false,
+				'length' => 64,
+			]);
+			$changed = true;
+		}
+
+		if (!$table->hasIndex('group_folders_deleted_at')) {
+			$table->addIndex(['deleted_at'], 'group_folders_deleted_at');
+			$changed = true;
+		}
+
+		return $changed ? $schema : null;
+	}
+}

--- a/lib/Mount/GroupFolderStorage.php
+++ b/lib/Mount/GroupFolderStorage.php
@@ -13,9 +13,14 @@ use OC\Files\ObjectStore\ObjectStoreScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Storage\Wrapper\Quota;
 use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\SubfolderQuota;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IScanner;
+use OCP\Files\FileInfo;
+use OCP\Files\GenericFileException;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\Storage\IConstructableStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
@@ -26,9 +31,18 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 	private readonly ?ICacheEntry $rootEntry;
 	private readonly IUserSession $userSession;
 	private readonly ?IUser $mountOwner;
+	private readonly ?SubfolderQuotaManager $subfolderQuotaManager;
+	private readonly bool $applySubfolderQuotas;
 
 	/**
-	 * @param array{folder: FolderDefinition, rootCacheEntry: ?ICacheEntry, userSession: IUserSession, mountOwner: ?IUser} $parameters
+	 * @param array{
+	 *     folder: FolderDefinition,
+	 *     rootCacheEntry: ?ICacheEntry,
+	 *     userSession: IUserSession,
+	 *     mountOwner: ?IUser,
+	 *     subfolderQuotaManager?: ?SubfolderQuotaManager,
+	 *     applySubfolderQuotas?: bool,
+	 * } $parameters
 	 */
 	public function __construct(array $parameters) {
 		parent::__construct($parameters);
@@ -36,6 +50,8 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 		$this->rootEntry = $parameters['rootCacheEntry'];
 		$this->userSession = $parameters['userSession'];
 		$this->mountOwner = $parameters['mountOwner'];
+		$this->subfolderQuotaManager = $parameters['subfolderQuotaManager'] ?? null;
+		$this->applySubfolderQuotas = $parameters['applySubfolderQuotas'] ?? false;
 	}
 
 	public function getFolderId(): int {
@@ -44,6 +60,10 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 
 	public function getFolder(): FolderDefinition {
 		return $this->folder;
+	}
+
+	public function appliesSubfolderQuotas(): bool {
+		return $this->applySubfolderQuotas;
 	}
 
 	#[\Override]
@@ -111,5 +131,233 @@ class GroupFolderStorage extends Quota implements IConstructableStorage {
 	#[\Override]
 	protected function shouldApplyQuota(string $path): bool {
 		return true;
+	}
+
+	/**
+	 * Return the most restrictive amount of free space from the Team folder and
+	 * the configured direct subfolder, if this path belongs to one.
+	 */
+	#[\Override]
+	public function free_space(string $path): int|float|false {
+		$freeSpace = parent::free_space($path);
+		$subfolderFreeSpace = $this->getSubfolderFreeSpace($path);
+		if ($subfolderFreeSpace === null || $subfolderFreeSpace < 0) {
+			return $freeSpace;
+		}
+		if ($freeSpace === false) {
+			return false;
+		}
+
+		return $freeSpace >= 0 ? min($freeSpace, $subfolderFreeSpace) : $subfolderFreeSpace;
+	}
+
+	/**
+	 * The core Quota wrapper does not execute its checks when the Team folder
+	 * itself is unlimited. Apply the same checks explicitly for a path that is
+	 * covered by a subfolder quota in that case.
+	 */
+	#[\Override]
+	public function file_put_contents(string $path, mixed $data): int|float|false {
+		if (!$this->needsStandaloneSubfolderQuota($path) || !is_string($data)) {
+			return parent::file_put_contents($path, $data);
+		}
+
+		$free = $this->free_space($path);
+		if ($free === false) {
+			return false;
+		}
+		if ($free < 0 || strlen($data) < $free) {
+			return $this->getWrapperStorage()->file_put_contents($path, $data);
+		}
+
+		return false;
+	}
+
+	#[\Override]
+	public function copy(string $source, string $target): bool {
+		if (!$this->needsStandaloneSubfolderQuota($target)) {
+			return parent::copy($source, $target);
+		}
+
+		$free = $this->free_space($target);
+		if ($free === false) {
+			return false;
+		}
+		if ($free < 0 || $this->getSize($source) < $free) {
+			return $this->getWrapperStorage()->copy($source, $target);
+		}
+
+		return false;
+	}
+
+	#[\Override]
+	public function fopen(string $path, string $mode) {
+		if (!$this->needsStandaloneSubfolderQuota($path) || $this->isPartFile($path)) {
+			return parent::fopen($path, $mode);
+		}
+		if ($mode === 'r' || $mode === 'rb') {
+			return $this->getWrapperStorage()->fopen($path, $mode);
+		}
+
+		$free = $this->free_space($path);
+		if ($free === false || $free === 0) {
+			return false;
+		}
+
+		$source = $this->getWrapperStorage()->fopen($path, $mode);
+		if (!is_resource($source)) {
+			return false;
+		}
+		if ($free >= 0) {
+			return \OC\Files\Stream\Quota::wrap($source, $free);
+		}
+
+		return $source;
+	}
+
+	#[\Override]
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
+		if (!$this->needsStandaloneSubfolderQuota($targetInternalPath)) {
+			return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
+		$free = $this->free_space($targetInternalPath);
+		if ($free === false) {
+			return false;
+		}
+		if ($free < 0 || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
+			return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
+		return false;
+	}
+
+	#[\Override]
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
+		if ($sourceStorage === $this) {
+			return $this->rename($sourceInternalPath, $targetInternalPath);
+		}
+
+		if (!$this->needsStandaloneSubfolderQuota($targetInternalPath)) {
+			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
+		$free = $this->free_space($targetInternalPath);
+		if ($free === false) {
+			return false;
+		}
+		if ($free < 0 || $this->getSize($sourceInternalPath, $sourceStorage) < $free) {
+			return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+
+		return false;
+	}
+
+	#[\Override]
+	public function mkdir(string $path): bool {
+		if (!$this->needsStandaloneSubfolderQuota($path)) {
+			return parent::mkdir($path);
+		}
+
+		$free = $this->free_space($path);
+		return $free !== false && $free !== 0 && $this->getWrapperStorage()->mkdir($path);
+	}
+
+	#[\Override]
+	public function touch(string $path, ?int $mtime = null): bool {
+		if (!$this->needsStandaloneSubfolderQuota($path)) {
+			return parent::touch($path, $mtime);
+		}
+
+		$free = $this->free_space($path);
+		return $free !== false && $free !== 0 && $this->getWrapperStorage()->touch($path, $mtime);
+	}
+
+	#[\Override]
+	public function writeStream(string $path, $stream, ?int $size = null): int {
+		if (!$this->needsStandaloneSubfolderQuota($path)) {
+			return parent::writeStream($path, $stream, $size);
+		}
+
+		$free = $this->free_space($path);
+		if ($free === 0 || $free === false) {
+			throw new NotEnoughSpaceException();
+		}
+
+		if ($size !== null) {
+			if ($free < 0 || $size < $free) {
+				return parent::writeStream($path, $stream, $size);
+			}
+			throw new NotEnoughSpaceException();
+		}
+
+		try {
+			return parent::writeStreamFallback($path, $stream);
+		} catch (GenericFileException) {
+			throw new NotEnoughSpaceException();
+		}
+	}
+
+	#[\Override]
+	public function rename(string $source, string $target): bool {
+		if (!$this->applySubfolderQuotas || $this->subfolderQuotaManager === null) {
+			return parent::rename($source, $target);
+		}
+
+		$sourceQuota = $this->getSubfolderQuota($source);
+		if ($sourceQuota !== null && $this->isDirectChildPath($source) && !$this->isDirectChildPath($target)) {
+			return false;
+		}
+
+		$targetQuota = $this->getSubfolderQuota($target);
+		if ($targetQuota === null || $targetQuota->fileId === $sourceQuota?->fileId) {
+			return parent::rename($source, $target);
+		}
+
+		$sourceSize = $this->getSize($source);
+		$targetFreeSpace = $this->getFreeSpaceForQuota($targetQuota);
+		if ($sourceSize < 0 || $targetFreeSpace < 0 || $sourceSize < $targetFreeSpace) {
+			return parent::rename($source, $target);
+		}
+
+		return false;
+	}
+
+	private function needsStandaloneSubfolderQuota(string $path): bool {
+		return $this->getQuota() === FileInfo::SPACE_UNLIMITED && $this->getSubfolderQuota($path) !== null;
+	}
+
+	private function getSubfolderQuota(string $path): ?SubfolderQuota {
+		if (!$this->applySubfolderQuotas || $this->subfolderQuotaManager === null) {
+			return null;
+		}
+
+		return $this->subfolderQuotaManager->getQuotaForPath($this->folder, $this->getCache(), $path);
+	}
+
+	private function getSubfolderFreeSpace(string $path): ?int {
+		$quota = $this->getSubfolderQuota($path);
+		if ($quota === null) {
+			return null;
+		}
+
+		return $this->getFreeSpaceForQuota($quota);
+	}
+
+	private function getFreeSpaceForQuota(SubfolderQuota $quota): int {
+		if ($quota->size < 0) {
+			return FileInfo::SPACE_NOT_COMPUTED;
+		}
+
+		return max($quota->quota - $quota->size, 0);
+	}
+
+	private function isDirectChildPath(string $path): bool {
+		$path = trim($path, '/');
+		return $path !== '' && !str_contains($path, '/');
+	}
+
+	private function isPartFile(string $path): bool {
+		return pathinfo($path, PATHINFO_EXTENSION) === 'part';
 	}
 }

--- a/lib/Mount/MountProvider.php
+++ b/lib/Mount/MountProvider.php
@@ -17,6 +17,7 @@ use OCA\GroupFolders\ACL\Rule;
 use OCA\GroupFolders\Folder\FolderDefinition;
 use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCP\Constants;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -45,6 +46,7 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 		private readonly IMountProviderCollection $mountProviderCollection,
 		private readonly IDBConnection $connection,
 		private readonly FolderStorageManager $folderStorageManager,
+		private readonly SubfolderQuotaManager $subfolderQuotaManager,
 		private readonly bool $allowRootShare,
 		private readonly bool $enableEncryption,
 	) {
@@ -248,6 +250,8 @@ class MountProvider implements IMountProvider, IPartialMountProvider {
 			'rootCacheEntry' => $rootCacheEntry,
 			'userSession' => $this->userSession,
 			'mountOwner' => $user,
+			'subfolderQuotaManager' => $this->subfolderQuotaManager,
+			'applySubfolderQuotas' => $type === 'files',
 		]);
 	}
 

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -59,11 +59,30 @@ namespace OCA\GroupFolders;
  *     sortIndex?: non-negative-int,
  * }
  *
+ * @phpstan-type GroupFoldersDeletedFolder = array{
+ *     id: int,
+ *     mount_point: string,
+ *     quota: int,
+ *     size: int,
+ *     deleted_at: int,
+ *     deleted_by: ?string,
+ * }
+ *
  * @phpstan-type GroupFoldersSubfolderQuota = array{
  *     file_id: int,
  *     name: string,
  *     size: int,
  *     quota: ?int,
+ * }
+ *
+ * @phpstan-type GroupFoldersSubfolderManagement = array{
+ *     file_id: int,
+ *     name: string,
+ *     size: int,
+ *     quota: ?int,
+ *     managers: list<GroupFoldersAclManage>,
+ *     can_manage: bool,
+ *     can_assign: bool,
  * }
  */
 class ResponseDefinitions {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -58,6 +58,13 @@ namespace OCA\GroupFolders;
  *     manage: list<GroupFoldersAclManage>,
  *     sortIndex?: non-negative-int,
  * }
+ *
+ * @phpstan-type GroupFoldersSubfolderQuota = array{
+ *     file_id: int,
+ *     name: string,
+ *     size: int,
+ *     quota: ?int,
+ * }
  */
 class ResponseDefinitions {
 }

--- a/openapi.json
+++ b/openapi.json
@@ -133,6 +133,42 @@
                     }
                 }
             },
+            "DeletedFolder": {
+                "type": "object",
+                "required": [
+                    "id",
+                    "mount_point",
+                    "quota",
+                    "size",
+                    "deleted_at",
+                    "deleted_by"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "mount_point": {
+                        "type": "string"
+                    },
+                    "quota": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "deleted_at": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "deleted_by": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                }
+            },
             "Folder": {
                 "type": "object",
                 "required": [
@@ -230,6 +266,48 @@
                     },
                     "itemsperpage": {
                         "type": "string"
+                    }
+                }
+            },
+            "SubfolderManagement": {
+                "type": "object",
+                "required": [
+                    "file_id",
+                    "name",
+                    "size",
+                    "quota",
+                    "managers",
+                    "can_manage",
+                    "can_assign"
+                ],
+                "properties": {
+                    "file_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "quota": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    },
+                    "managers": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AclManage"
+                        }
+                    },
+                    "can_manage": {
+                        "type": "boolean"
+                    },
+                    "can_assign": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -1073,7 +1151,7 @@
             },
             "delete": {
                 "operationId": "folder-remove-folder",
-                "summary": "Remove a Groupfolder",
+                "summary": "Move a Groupfolder to the recovery bin",
                 "description": "This endpoint requires password confirmation",
                 "tags": [
                     "folder"
@@ -1110,7 +1188,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Groupfolder removed successfully",
+                        "description": "Groupfolder moved to the recovery bin successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1340,6 +1418,510 @@
                     },
                     "400": {
                         "description": "Mount point already exists",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/deleted": {
+            "get": {
+                "operationId": "folder-get-deleted-folders",
+                "summary": "Get Team folders that are still recoverable.",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Deleted Team folders returned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/DeletedFolder"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not a global administrator",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/{id}/restore": {
+            "post": {
+                "operationId": "folder-restore-deleted-folder",
+                "summary": "Restore a Team folder from the recovery bin.",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mountpoint": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "default": null,
+                                        "description": "Replacement mount point when its original name is in use"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the deleted Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Team folder restored successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "success",
+                                                        "folder"
+                                                    ],
+                                                    "properties": {
+                                                        "success": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                true
+                                                            ]
+                                                        },
+                                                        "folder": {
+                                                            "$ref": "#/components/schemas/Folder"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "A replacement mount point is invalid or already in use",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not a global administrator",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Deleted Team folder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/{id}/permanent": {
+            "delete": {
+                "operationId": "folder-purge-deleted-folder",
+                "summary": "Permanently remove a Team folder and all of its stored data.",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the deleted Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Team folder permanently removed successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "success"
+                                                    ],
+                                                    "properties": {
+                                                        "success": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                true
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not a global administrator",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Deleted Team folder not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2831,6 +3413,393 @@
                     },
                     "404": {
                         "description": "Team folder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas/{fileId}/management": {
+            "get": {
+                "operationId": "folder-get-subfolder-management",
+                "summary": "Get the delegated administrators for one direct Team folder child.",
+                "description": "A Team folder administrator may assign managers. A delegated subfolder administrator may view the configuration of the subfolder they manage.",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "File ID of the direct subfolder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subfolder management returned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/SubfolderManagement"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not allowed to manage this subfolder",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder or direct subfolder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "folder-set-subfolder-manager",
+                "summary": "Add or remove a delegated administrator for one direct Team folder child. Only a Team folder administrator can change this assignment.",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "mappingType",
+                                    "mappingId",
+                                    "manager"
+                                ],
+                                "properties": {
+                                    "mappingType": {
+                                        "type": "string",
+                                        "description": "Type of mapping: user, group, or circle"
+                                    },
+                                    "mappingId": {
+                                        "type": "string",
+                                        "description": "ID of the selected user, group, or team"
+                                    },
+                                    "manager": {
+                                        "type": "boolean",
+                                        "description": "Whether to grant or revoke subfolder management"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "File ID of the direct subfolder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subfolder manager assignment updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/SubfolderManagement"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid child or mapping",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Not allowed to assign subfolder managers",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder or direct subfolder not found",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -233,6 +233,33 @@
                     }
                 }
             },
+            "SubfolderQuota": {
+                "type": "object",
+                "required": [
+                    "file_id",
+                    "name",
+                    "size",
+                    "quota"
+                ],
+                "properties": {
+                    "file_id": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    "quota": {
+                        "type": "integer",
+                        "format": "int64",
+                        "nullable": true
+                    }
+                }
+            },
             "User": {
                 "type": "object",
                 "required": [
@@ -2162,6 +2189,648 @@
                     },
                     "404": {
                         "description": "Groupfolder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas": {
+            "get": {
+                "operationId": "folder-get-subfolder-quotas",
+                "summary": "List the direct subfolders of a Team folder and their optional quotas",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Direct subfolders returned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/SubfolderQuota"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "operationId": "folder-create-subfolder-quota",
+                "summary": "Create a direct subfolder and assign its quota",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "name",
+                                    "quota"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "description": "Name for the new direct subfolder"
+                                    },
+                                    "quota": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Quota in bytes, or -3 for unlimited"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subfolder created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/SubfolderQuota"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid subfolder name or quota",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas/{fileId}": {
+            "post": {
+                "operationId": "folder-set-subfolder-quota",
+                "summary": "Set a quota for a direct subfolder of a Team folder",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "quota"
+                                ],
+                                "properties": {
+                                    "quota": {
+                                        "type": "integer",
+                                        "format": "int64",
+                                        "description": "Quota in bytes, or -3 to remove the independent limit"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "File ID of the direct subfolder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subfolder quota set successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "$ref": "#/components/schemas/SubfolderQuota"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "The target is not a direct subfolder or the quota is invalid",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Current user is not logged in",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "folder-remove-subfolder-quota",
+                "summary": "Remove the independent quota from a direct subfolder",
+                "description": "This endpoint requires password confirmation",
+                "tags": [
+                    "folder"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID of the Team folder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "fileId",
+                        "in": "path",
+                        "description": "File ID of the direct subfolder",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Subfolder quota removed successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "success"
+                                                    ],
+                                                    "properties": {
+                                                        "success": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                true
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Team folder not found",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "groupfolders",
-  "version": "22.0.6",
+  "version": "22.0.7-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "groupfolders",
-      "version": "22.0.6",
+      "version": "22.0.7-dev.0",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@mdi/svg": "^7.4.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "groupfolders",
-  "version": "22.0.6",
+  "version": "22.0.7-dev.0",
   "type": "module",
   "scripts": {
     "build": "NODE_ENV=production vite --mode production build",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,6 +38,7 @@ parameters:
 		- tests/stubs/oc_files_cache_wrapper_cachewrapper.php
 		- tests/stubs/oc_files_fileinfo.php
 		- tests/stubs/oc_files_filesystem.php
+		- tests/stubs/oc_files_stream_quota.php
 		- tests/stubs/oc_files_mount_mountpoint.php
 		- tests/stubs/oc_files_node_lazyfolder.php
 		- tests/stubs/oc_files_node_node.php

--- a/src/components/SubfolderManagementSidebarView.vue
+++ b/src/components/SubfolderManagementSidebarView.vue
@@ -1,0 +1,274 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import type { INode } from '@nextcloud/files'
+import type { Group, User, Circle } from '../types'
+import type { SubfolderManager } from '../services/subfolderManagement'
+
+import { mdiPlus, mdiTrashCanOutline } from '@mdi/js'
+import axios, { isCancel, isAxiosError } from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
+import { formatFileSize } from '@nextcloud/files'
+import { t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
+import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import NcAvatar from '@nextcloud/vue/components/NcAvatar'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcIconSvgWrapper from '@nextcloud/vue/components/NcIconSvgWrapper'
+import NcSelectUsers from '@nextcloud/vue/components/NcSelectUsers'
+import { useDebounceFn } from '@vueuse/core'
+import svgGroup from '@mdi/svg/svg/account-multiple-outline.svg?raw'
+import svgTeam from '@mdi/svg/svg/account-group-outline.svg?raw'
+import { getAcls } from '../services/acl'
+import { logger } from '../services/logger'
+import { getSubfolderManagement, setSubfolderManager, type SubfolderManagement } from '../services/subfolderManagement'
+
+type IUserData = InstanceType<typeof NcSelectUsers>['$props']['options'][number]
+
+interface MappingOption extends IUserData, SubfolderManager {
+	unique: string
+}
+
+const props = defineProps<{
+	node: INode
+}>()
+
+const select = useTemplateRef('select')
+const management = ref<SubfolderManagement>()
+const folderId = ref<number>()
+const loading = ref(false)
+const searching = ref(false)
+const showManagerSelect = ref(false)
+const options = ref<MappingOption[]>([])
+const selected = ref<MappingOption>()
+
+const quotaText = computed(() => {
+	if (!management.value || management.value.quota === null) {
+		return t('groupfolders', 'No separate limit')
+	}
+
+	return formatFileSize(management.value.quota)
+})
+
+const usageText = computed(() => {
+	if (!management.value) {
+		return ''
+	}
+
+	return t('groupfolders', '{used} used of {quota}', {
+		used: formatFileSize(management.value.size),
+		quota: quotaText.value,
+	})
+})
+
+watch(() => props.node, () => {
+	void loadManagement()
+}, { immediate: true })
+
+watch(selected, (value) => {
+	if (value) {
+		void updateManager(value, true)
+	}
+})
+
+async function loadManagement() {
+	management.value = undefined
+	folderId.value = undefined
+	showManagerSelect.value = false
+	selected.value = undefined
+
+	if (props.node.type !== 'folder') {
+		return
+	}
+
+	try {
+		const acls = await getAcls(props.node.path)
+		if (!acls?.groupFolderId) {
+			return
+		}
+
+		folderId.value = acls.groupFolderId
+		management.value = await getSubfolderManagement(acls.groupFolderId, Number(props.node.id))
+	} catch (error) {
+		// A regular folder, an unassigned child, or a user without management
+		// rights intentionally has no section to display.
+		if (isAxiosError(error) && [403, 404].includes(error.response?.status ?? 0)) {
+			return
+		}
+
+		logger.error('Failed to load subfolder management', { error })
+	}
+}
+
+function getFullDisplayName(manager: SubfolderManager): string {
+	if (manager.type === 'group') {
+		return `${manager.displayname} (${t('groupfolders', 'Group')})`
+	}
+	if (manager.type === 'circle') {
+		return `${manager.displayname} (${t('groupfolders', 'Team')})`
+	}
+
+	return manager.displayname
+}
+
+function toggleManagerSelect() {
+	showManagerSelect.value = !showManagerSelect.value
+	if (showManagerSelect.value) {
+		nextTick(() => {
+			const input = (select.value?.$el as HTMLElement | undefined)?.querySelector('input')
+			input?.focus()
+		})
+	}
+}
+
+const debouncedSearch = useDebounceFn(searchMappings, 300)
+let abortController: AbortController | undefined
+
+async function searchMappings(query: string) {
+	if (!folderId.value) {
+		return
+	}
+
+	if (abortController) {
+		abortController.abort('A newer search was requested')
+	}
+	abortController = new AbortController()
+	searching.value = true
+
+	try {
+		const url = generateUrl('apps/groupfolders/folders/{id}/search?format=json&search={search}', {
+			id: folderId.value,
+			search: encodeURIComponent(query),
+		})
+		type SearchResponse = { ocs: { data: { groups: Record<string, Group>, users: Record<string, User>, circles: Record<string, Circle> } } }
+		const { data } = await axios.get<SearchResponse>(url, { signal: abortController.signal })
+
+		const groups = Object.values(data.ocs.data.groups).map((group) => ({
+			unique: 'group:' + group.gid,
+			isNoUser: true,
+			type: 'group' as const,
+			id: group.gid,
+			iconSvg: svgGroup,
+			displayname: group.displayname,
+			displayName: group.displayname,
+		}))
+		const users = Object.values(data.ocs.data.users).map((user) => ({
+			unique: 'user:' + user.uid,
+			type: 'user' as const,
+			id: user.uid,
+			user: user.uid,
+			displayname: user.displayname,
+			displayName: user.displayname,
+		}))
+		const circles = Object.values(data.ocs.data.circles).map((circle) => ({
+			unique: 'circle:' + circle.sid,
+			isNoUser: true,
+			type: 'circle' as const,
+			id: circle.sid,
+			iconSvg: svgTeam,
+			displayname: circle.displayname,
+			displayName: circle.displayname,
+		}))
+		options.value = [...groups, ...users, ...circles]
+			.filter((option) => management.value?.managers.every((manager) => manager.type !== option.type || manager.id !== option.id)) as MappingOption[]
+	} catch (error) {
+		if (!isCancel(error)) {
+			logger.error('Failed to search subfolder manager candidates', { error })
+		}
+	} finally {
+		searching.value = false
+	}
+}
+
+async function updateManager(manager: SubfolderManager, enabled: boolean) {
+	if (!folderId.value || !management.value) {
+		return
+	}
+
+	selected.value = undefined
+	loading.value = true
+	try {
+		management.value = await setSubfolderManager(folderId.value, management.value.file_id, manager, enabled)
+		showManagerSelect.value = false
+	} catch (error) {
+		logger.error('Failed to update subfolder manager', { error })
+		showError(t('groupfolders', 'Could not update subfolder administrators'))
+	} finally {
+		loading.value = false
+	}
+}
+</script>
+
+<template>
+	<div v-if="management && !loading" class="subfolder-management">
+		<h4 class="section-header">{{ t('groupfolders', 'Subfolder administration') }}</h4>
+		<p>{{ usageText }}</p>
+		<p v-if="management.quota === null" class="subfolder-management__hint">
+			{{ t('groupfolders', 'This subfolder has no separate limit, but its contents still count towards the Team folder quota.') }}
+		</p>
+
+		<p v-if="management.can_assign" class="subfolder-management__hint">
+			{{ t('groupfolders', 'Assign administrators who may manage permissions only in this subfolder and its contents.') }}
+		</p>
+		<p v-else class="subfolder-management__hint">
+			{{ t('groupfolders', 'You can manage permissions in this subfolder and its contents.') }}
+		</p>
+
+		<ul class="subfolder-management__managers">
+			<li v-for="manager in management.managers" :key="manager.type + ':' + manager.id">
+				<NcAvatar :user="manager.id" :is-no-user="manager.type !== 'user'" :size="24" />
+				<span>{{ getFullDisplayName(manager) }}</span>
+				<NcButton v-if="management.can_assign"
+					:aria-label="t('groupfolders', 'Remove subfolder administrator')"
+					:title="t('groupfolders', 'Remove subfolder administrator')"
+					variant="tertiary"
+					@click="updateManager(manager, false)">
+					<template #icon>
+						<NcIconSvgWrapper :path="mdiTrashCanOutline" />
+					</template>
+				</NcButton>
+			</li>
+		</ul>
+
+		<NcButton v-if="management.can_assign && !showManagerSelect" @click="toggleManagerSelect">
+			<template #icon>
+				<NcIconSvgWrapper :path="mdiPlus" />
+			</template>
+			{{ t('groupfolders', 'Add subfolder administrator') }}
+		</NcButton>
+
+		<NcSelectUsers v-if="management.can_assign && showManagerSelect"
+			ref="select"
+			v-model="selected"
+			:options="options"
+			:loading="searching"
+			:placeholder="t('groupfolders', 'Select a user or team')"
+			@search="debouncedSearch" />
+	</div>
+</template>
+
+<style scoped>
+.subfolder-management__hint {
+	color: var(--color-text-maxcontrast);
+}
+
+.subfolder-management__managers {
+	margin: 0 0 8px;
+	padding: 0;
+	list-style: none;
+}
+
+.subfolder-management__managers li {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-height: 32px;
+}
+
+.subfolder-management__managers li span {
+	flex: 1;
+}
+</style>

--- a/src/init-files.ts
+++ b/src/init-files.ts
@@ -16,6 +16,7 @@ import 'vite/modulepreload-polyfill'
 registerFilesView()
 registerFileAction(openGroupfolderAction)
 registerSharingSidebarSection()
+registerSubfolderManagementSidebarSection()
 
 /**
  * Registers the Groupfolders view in the Nextcloud Files app navigation.
@@ -54,6 +55,27 @@ function registerSharingSidebarSection() {
 		element: tagName,
 		enabled(node) {
 			return node.attributes['mount-type'] === 'group'
+		},
+	})
+}
+
+/**
+ * Registers the direct-subfolder administration panel. The server decides
+ * whether the selected folder is a managed direct child and whether the user
+ * may see or change its manager assignments.
+ */
+function registerSubfolderManagementSidebarSection() {
+	const tagName = 'oca_groupfolders-subfolder_management_sidebar_section'
+	const VueComponent = defineAsyncComponent(() => import('./components/SubfolderManagementSidebarView.vue'))
+	const WebComponent = defineCustomElement(VueComponent, { shadowRoot: false })
+	window.customElements.define(tagName, WebComponent)
+
+	registerSidebarSection({
+		id: 'groupfolders-subfolder-management',
+		order: 21,
+		element: tagName,
+		enabled(node) {
+			return node.attributes['mount-type'] === 'group' && node.type === 'folder'
 		},
 	})
 }

--- a/src/services/subfolderManagement.ts
+++ b/src/services/subfolderManagement.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { confirmPassword } from '@nextcloud/password-confirmation'
+import { generateUrl } from '@nextcloud/router'
+// eslint-disable-next-line n/no-unpublished-import
+import type { OCSResponse } from '@nextcloud/typings/ocs'
+
+export interface SubfolderManager {
+	displayname: string
+	id: string
+	type: 'user' | 'group' | 'circle'
+}
+
+export interface SubfolderManagement {
+	file_id: number
+	name: string
+	size: number
+	quota: number | null
+	managers: SubfolderManager[]
+	can_manage: boolean
+	can_assign: boolean
+}
+
+function managementUrl(folderId: number, fileId: number): string {
+	return generateUrl('apps/groupfolders/folders/{folderId}/subfolder-quotas/{fileId}/management', {
+		folderId,
+		fileId,
+	})
+}
+
+export async function getSubfolderManagement(folderId: number, fileId: number): Promise<SubfolderManagement> {
+	const response = await axios.get<OCSResponse<SubfolderManagement>>(managementUrl(folderId, fileId))
+	return response.data.ocs.data
+}
+
+export async function setSubfolderManager(folderId: number, fileId: number, mapping: SubfolderManager, manager: boolean): Promise<SubfolderManagement> {
+	await confirmPassword()
+
+	const response = await axios.post<OCSResponse<SubfolderManagement>>(managementUrl(folderId, fileId), {
+		mappingType: mapping.type,
+		mappingId: mapping.id,
+		manager: manager ? 1 : 0,
+	})
+	return response.data.ocs.data
+}

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -7,7 +7,7 @@ import axios from '@nextcloud/axios'
 import { confirmPassword, addPasswordConfirmationInterceptors, PwdConfirmationMode } from '@nextcloud/password-confirmation'
 // eslint-disable-next-line n/no-unpublished-import
 import type { OCSResponse } from '@nextcloud/typings/ocs'
-import type { Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle, SubfolderQuota } from '../types'
+import type { Folder, DeletedFolder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle, SubfolderQuota } from '../types'
 
 addPasswordConfirmationInterceptors(axios)
 
@@ -76,6 +76,24 @@ export class Api {
 		await axios.delete(this.getUrl(`folders/${id}`))
 	}
 
+	async listDeletedFolders(): Promise<DeletedFolder[]> {
+		const response = await axios.get<OCSResponse<DeletedFolder[]>>(this.getUrl('folders/deleted'))
+		return response.data.ocs.data
+	}
+
+	async restoreDeletedFolder(id: number, mountpoint?: string): Promise<Folder> {
+		await confirmPassword()
+
+		const response = await axios.post<OCSResponse<{success: true, folder: Folder}>>(this.getUrl(`folders/${id}/restore`), { mountpoint })
+		return response.data.ocs.data.folder
+	}
+
+	async purgeDeletedFolder(id: number): Promise<void> {
+		await confirmPassword()
+
+		await axios.delete(this.getUrl(`folders/${id}/permanent`))
+	}
+
 	async addGroup(folderId: number, group: string): Promise<void> {
 		await confirmPassword()
 
@@ -104,10 +122,11 @@ export class Api {
 		})
 	}
 
-	async setQuota(folderId: number, quota: number): Promise<void> {
+	async setQuota(folderId: number, quota: number): Promise<Folder> {
 		await confirmPassword()
 
-		await axios.post(this.getUrl(`folders/${folderId}/quota`), { quota })
+		const response = await axios.post<OCSResponse<{success: true, folder: Folder}>>(this.getUrl(`folders/${folderId}/quota`), { quota })
+		return response.data.ocs.data.folder
 	}
 
 	async listSubfolderQuotas(folderId: number): Promise<SubfolderQuota[]> {

--- a/src/settings/Api.ts
+++ b/src/settings/Api.ts
@@ -6,8 +6,8 @@ import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import { confirmPassword, addPasswordConfirmationInterceptors, PwdConfirmationMode } from '@nextcloud/password-confirmation'
 // eslint-disable-next-line n/no-unpublished-import
-import type { OCSResponse } from '@nextcloud/typings/lib/ocs'
-import type { Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle } from '../types'
+import type { OCSResponse } from '@nextcloud/typings/ocs'
+import type { Folder, Group, User, AclManage, DelegationCircle, DelegationGroup, Circle, SubfolderQuota } from '../types'
 
 addPasswordConfirmationInterceptors(axios)
 
@@ -108,6 +108,31 @@ export class Api {
 		await confirmPassword()
 
 		await axios.post(this.getUrl(`folders/${folderId}/quota`), { quota })
+	}
+
+	async listSubfolderQuotas(folderId: number): Promise<SubfolderQuota[]> {
+		const response = await axios.get<OCSResponse<SubfolderQuota[]>>(this.getUrl(`folders/${folderId}/subfolder-quotas`))
+		return response.data.ocs.data
+	}
+
+	async createSubfolderQuota(folderId: number, name: string, quota: number): Promise<SubfolderQuota> {
+		await confirmPassword()
+
+		const response = await axios.post<OCSResponse<SubfolderQuota>>(this.getUrl(`folders/${folderId}/subfolder-quotas`), { name, quota })
+		return response.data.ocs.data
+	}
+
+	async setSubfolderQuota(folderId: number, fileId: number, quota: number): Promise<SubfolderQuota> {
+		await confirmPassword()
+
+		const response = await axios.post<OCSResponse<SubfolderQuota>>(this.getUrl(`folders/${folderId}/subfolder-quotas/${fileId}`), { quota })
+		return response.data.ocs.data
+	}
+
+	async removeSubfolderQuota(folderId: number, fileId: number): Promise<void> {
+		await confirmPassword()
+
+		await axios.delete(this.getUrl(`folders/${folderId}/subfolder-quotas/${fileId}`))
 	}
 
 	async setACL(folderId: number, acl: boolean): Promise<void> {

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -183,6 +183,32 @@
 		padding: calc(var(--default-grid-baseline) * 2);
 	}
 
+	.deleted-folders {
+		margin: calc(var(--default-grid-baseline) * 5) 0;
+		padding: calc(var(--default-grid-baseline) * 3);
+		border: 1px solid var(--color-border);
+		border-radius: var(--border-radius-element, var(--border-radius));
+		background: var(--color-background-dark);
+
+		h3,
+		p {
+			margin-top: 0;
+		}
+
+		&__table {
+			width: 100%;
+			margin-top: calc(var(--default-grid-baseline) * 2);
+		}
+
+		&__actions {
+			white-space: nowrap;
+
+			button + button {
+				margin-inline-start: calc(var(--default-grid-baseline) * 2);
+			}
+		}
+	}
+
 	.subfolder-quotas-action {
 		margin-inline-start: auto;
 		white-space: nowrap;

--- a/src/settings/App.scss
+++ b/src/settings/App.scss
@@ -183,6 +183,54 @@
 		padding: calc(var(--default-grid-baseline) * 2);
 	}
 
+	.subfolder-quotas-action {
+		margin-inline-start: auto;
+		white-space: nowrap;
+	}
+
+	tr.subfolder-quotas-row {
+		height: auto;
+
+		& > td {
+			padding: 0;
+		}
+	}
+
+	.subfolder-quotas {
+		padding: calc(var(--default-grid-baseline) * 3);
+		background: var(--color-background-dark);
+
+		h4 {
+			margin: 0 0 calc(var(--default-grid-baseline) * 2);
+		}
+
+		p {
+			margin: 0 0 calc(var(--default-grid-baseline) * 3);
+		}
+
+		&__create {
+			display: flex;
+			align-items: center;
+			gap: calc(var(--default-grid-baseline) * 2);
+			margin-bottom: calc(var(--default-grid-baseline) * 3);
+
+			input {
+				min-width: 200px;
+			}
+		}
+
+		&__table {
+			width: 100%;
+			border-collapse: collapse;
+
+			th,
+			td {
+				padding: calc(var(--default-grid-baseline) * 2);
+				text-align: start;
+			}
+		}
+	}
+
 	thead {
 		tr {
 			th {

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 import { Component, FormEvent } from 'react'
 
 import { Api } from './Api'
-import type { Folder, AclManage, DelegationGroup, DelegationCircle, SubfolderQuota } from '../types'
+import type { Folder, DeletedFolder, AclManage, DelegationGroup, DelegationCircle, SubfolderQuota } from '../types'
 import { FolderGroups } from './FolderGroups'
 import { QuotaSelect } from './QuotaSelect'
 import { SubfolderQuotas } from './SubfolderQuotas'
@@ -19,8 +19,8 @@ import AdminGroupSelect from './AdminGroupSelect'
 import SubAdminGroupSelect from './SubAdminGroupSelect'
 import { loadState } from '@nextcloud/initial-state'
 import { t } from '@nextcloud/l10n'
-import { isAxiosError } from "@nextcloud/axios";
-import { showError } from "@nextcloud/dialogs";
+import { isAxiosError } from '@nextcloud/axios'
+import { showError } from '@nextcloud/dialogs'
 import { getLoggerBuilder } from '@nextcloud/logger'
 
 const logger = getLoggerBuilder()
@@ -56,6 +56,8 @@ export interface AppState {
 	sort: SortKey;
 	sortOrder: number;
 	isAdminNextcloud: boolean;
+	deletedFolders: DeletedFolder[];
+	loadingDeletedFolders: boolean;
 	checkAppsInstalled: boolean;
 	currentPage: number;
 	loading: boolean;
@@ -84,6 +86,8 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		sort: 'mount_point',
 		sortOrder: 1,
 		isAdminNextcloud: false,
+		deletedFolders: [],
+		loadingDeletedFolders: false,
 		checkAppsInstalled: false,
 		currentPage: 0,
 		loading: false,
@@ -108,7 +112,11 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 			this.setState({ totalFolders })
 		})
 
-		this.setState({ isAdminNextcloud: loadState('groupfolders', 'isAdminNextcloud') })
+		const isAdminNextcloud = loadState<boolean>('groupfolders', 'isAdminNextcloud', false)
+		this.setState({ isAdminNextcloud })
+		if (isAdminNextcloud) {
+			this.loadDeletedFolders()
+		}
 		this.setState({ checkAppsInstalled: loadState('groupfolders', 'checkAppsInstalled') })
 
 		OC.Plugins.register('OCA.Search.Core', this)
@@ -121,10 +129,10 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 			return
 		}
 		try {
-			const folder = await this.api.createFolder(mountPoint, this.state.newACLDefaultNoPermission);
+			const folder = await this.api.createFolder(mountPoint, this.state.newACLDefaultNoPermission)
 			const folders = this.state.folders
 			folders.push(folder)
-			this.setState({folders, newMountPoint: ''})
+			this.setState({ folders, newMountPoint: '' })
 		} catch (error) {
 			logger.error('Error while creating new folder', { error })
 
@@ -143,14 +151,94 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		})
 	}
 
+	async loadDeletedFolders() {
+		this.setState({ loadingDeletedFolders: true })
+		try {
+			const deletedFolders = await this.api.listDeletedFolders()
+			this.setState({ deletedFolders })
+		} catch (error) {
+			logger.error('Error while loading the Team folder recovery bin', { error })
+		} finally {
+			this.setState({ loadingDeletedFolders: false })
+		}
+	}
+
+	async reloadActiveFolders() {
+		const [folders, totalFolders] = await Promise.all([
+			this.api.listFolders(0, pageSize + 1, this.state.sort, this.state.sortOrder === 1 ? 'asc' : 'desc'),
+			this.api.countFolders(),
+		])
+		this.setState({ folders, totalFolders, currentPage: 0 })
+	}
+
 	deleteFolder(folder: Folder) {
 		OC.dialogs.confirm(
-			t('groupfolders', 'Are you sure you want to delete "{folderName}" and all files inside? This operation cannot be undone', { folderName: folder.mount_point }),
-			t('groupfolders', 'Delete "{folderName}"?', { folderName: folder.mount_point }),
+			t('groupfolders', 'Move "{folderName}" to the recovery bin? A global administrator can restore it for 30 days.', { folderName: folder.mount_point }),
+			t('groupfolders', 'Move "{folderName}" to recovery bin?', { folderName: folder.mount_point }),
 			async (confirmed) => {
 				if (confirmed) {
-					await this.api.deleteFolder(folder.id)
-					this.setState({ folders: this.state.folders.filter(item => item.id !== folder.id) })
+					try {
+						await this.api.deleteFolder(folder.id)
+						this.setState({
+							folders: this.state.folders.filter(item => item.id !== folder.id),
+							totalFolders: Math.max(0, this.state.totalFolders - 1),
+						})
+						if (this.state.isAdminNextcloud) {
+							await this.loadDeletedFolders()
+						}
+					} catch (error) {
+						logger.error('Error while moving Team folder to the recovery bin', { error })
+						const message = isAxiosError(error) ? error.response?.data?.message : undefined
+						showError(typeof message === 'string' ? message : t('groupfolders', 'Folder could not be moved to the recovery bin'))
+					}
+				}
+			},
+			true,
+		)
+	}
+
+	async restoreDeletedFolder(folder: DeletedFolder, mountpoint?: string) {
+		try {
+			await this.api.restoreDeletedFolder(folder.id, mountpoint)
+			await Promise.all([this.reloadActiveFolders(), this.loadDeletedFolders()])
+		} catch (error) {
+			const status = isAxiosError(error) ? error.response?.status : undefined
+			if (status === 400 && mountpoint === undefined) {
+				OC.dialogs.prompt(
+					t('groupfolders', 'The original name "{folderName}" is already in use. Enter a different name to restore this Team folder.', { folderName: folder.mount_point }),
+					t('groupfolders', 'Choose a name to restore "{folderName}"', { folderName: folder.mount_point }),
+					(confirmed, replacementMountpoint) => {
+						if (confirmed && replacementMountpoint.trim()) {
+							this.restoreDeletedFolder(folder, replacementMountpoint)
+						}
+					},
+					true,
+				)
+				return
+			}
+
+			logger.error('Error while restoring Team folder from the recovery bin', { error })
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			showError(typeof message === 'string' ? message : t('groupfolders', 'Folder could not be restored'))
+		}
+	}
+
+	purgeDeletedFolder(folder: DeletedFolder) {
+		OC.dialogs.confirm(
+			t('groupfolders', 'Permanently delete "{folderName}" and all its files? This operation cannot be undone.', { folderName: folder.mount_point }),
+			t('groupfolders', 'Permanently delete "{folderName}"?', { folderName: folder.mount_point }),
+			async (confirmed) => {
+				if (!confirmed) {
+					return
+				}
+
+				try {
+					await this.api.purgeDeletedFolder(folder.id)
+					await this.loadDeletedFolders()
+				} catch (error) {
+					logger.error('Error while permanently deleting Team folder', { error })
+					const message = isAxiosError(error) ? error.response?.data?.message : undefined
+					showError(typeof message === 'string' ? message : t('groupfolders', 'Folder could not be permanently deleted'))
 				}
 			},
 			true,
@@ -187,10 +275,23 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 	}
 
 	async setQuota(folder: Folder, quota: number) {
-		await this.api.setQuota(folder.id, quota)
-		const folders = this.state.folders
-		folder.quota = quota
-		this.setState({ folders })
+		try {
+			const updatedFolder = await this.api.setQuota(folder.id, quota)
+			const folders = this.state.folders
+			folder.quota = updatedFolder.quota
+			this.setState({ folders })
+		} catch (error) {
+			logger.error('Error while setting Team folder quota', { error })
+			// Re-render the controlled selector with the persisted quota after a
+			// rejected lower limit.
+			this.setState({ folders: [...this.state.folders] })
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			if (typeof message === 'string') {
+				showError(message)
+			} else {
+				showError(t('groupfolders', 'Team folder quota could not be updated'))
+			}
+		}
 	}
 
 	async toggleSubfolderQuotas(folder: Folder) {
@@ -270,10 +371,10 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 
 	async renameFolder(folder: Folder, newName: string) {
 		try {
-			await this.api.renameFolder(folder.id, newName);
+			await this.api.renameFolder(folder.id, newName)
 			const folders = this.state.folders
 			folder.mount_point = newName
-			this.setState({folders, editingMountPoint: 0})
+			this.setState({ folders, editingMountPoint: 0 })
 		} catch (error) {
 			logger.error('Error while renaming folder', { error })
 
@@ -367,6 +468,43 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		}
 	}
 
+	renderDeletedFolders() {
+		if (!this.state.isAdminNextcloud) {
+			return null
+		}
+
+		return <section className="deleted-folders" aria-labelledby="deleted-folders-title">
+			<h3 id="deleted-folders-title">{t('groupfolders', 'Team folder recovery bin')}</h3>
+			<p>{t('groupfolders', 'Deleted Team folders can be restored for 30 days. After that, their files are permanently removed.')}</p>
+			{this.state.loadingDeletedFolders
+				? <p>{t('groupfolders', 'Loading recovery bin …')}</p>
+				: this.state.deletedFolders.length === 0
+					? <p>{t('groupfolders', 'The recovery bin is empty.')}</p>
+					: <table className="deleted-folders__table">
+						<thead>
+							<tr>
+								<th>{t('groupfolders', 'Folder name')}</th>
+								<th>{t('groupfolders', 'Deleted')}</th>
+								<th>{t('groupfolders', 'Deleted by')}</th>
+								<th><span className="hidden-visually">{t('groupfolders', 'Actions')}</span></th>
+							</tr>
+						</thead>
+						<tbody>
+							{this.state.deletedFolders.map((folder) => <tr key={folder.id}>
+								<td>{folder.mount_point}</td>
+								<td>{new Date(folder.deleted_at * 1000).toLocaleString()}</td>
+								<td>{folder.deleted_by ?? '—'}</td>
+								<td className="deleted-folders__actions">
+									<button type="button" onClick={() => this.restoreDeletedFolder(folder)}>{t('groupfolders', 'Restore')}</button>
+									<button type="button" className="error" onClick={() => this.purgeDeletedFolder(folder)}>{t('groupfolders', 'Permanently delete')}</button>
+								</td>
+							</tr>)}
+						</tbody>
+					</table>
+			}
+		</section>
+	}
+
 	render() {
 		const isCirclesEnabled = loadState('groupfolders', 'isCirclesEnabled', false)
 		const lastPage = Math.max(0, Math.ceil(this.state.totalFolders / pageSize) - 1)
@@ -377,8 +515,6 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		const groupHeaderSort = isCirclesEnabled
 			? t('groupfolders', 'Sort by number of groups or teams that have access to this folder')
 			: t('groupfolders', 'Sort by number of groups that have access to this folder')
-
-		console.log('totalFolders:', this.state.totalFolders, 'lastPage:', lastPage, 'currentPage:', this.state.currentPage)
 
 		const rows
 			= this.state.folders
@@ -468,9 +604,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 						<td className="remove">
 							<button type="button"
 								className="icon icon-delete icon-visible"
-								aria-label={t('groupfolders', 'Delete')}
+								aria-label={t('groupfolders', 'Move to recovery bin')}
 								onClick={this.deleteFolder.bind(this, folder)}
-								title={t('groupfolders', 'Delete')}/>
+								title={t('groupfolders', 'Move to recovery bin')}/>
 						</td>
 					</tr>)
 					if (this.state.editingSubfolderQuotas === id) {
@@ -481,6 +617,7 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 									: <SubfolderQuotas
 										subfolders={this.state.subfolderQuotas[id] ?? []}
 										quotaOptions={defaultQuotaOptions}
+										parentQuota={folder.quota}
 										onCreate={this.createSubfolderQuota.bind(this, folder)}
 										onSetQuota={this.setSubfolderQuota.bind(this, folder)}/>}
 							</td>
@@ -520,6 +657,8 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 					>{t('groupfolders', 'Do not grant any advanced permissions by default')}</span>
 				</label>
 			</form>
+
+			{this.renderDeletedFolders()}
 
 			<table>
 				<thead>

--- a/src/settings/App.tsx
+++ b/src/settings/App.tsx
@@ -6,9 +6,10 @@ import * as React from 'react'
 import { Component, FormEvent } from 'react'
 
 import { Api } from './Api'
-import type { Folder, AclManage, DelegationGroup, DelegationCircle } from '../types'
+import type { Folder, AclManage, DelegationGroup, DelegationCircle, SubfolderQuota } from '../types'
 import { FolderGroups } from './FolderGroups'
 import { QuotaSelect } from './QuotaSelect'
+import { SubfolderQuotas } from './SubfolderQuotas'
 import './App.scss'
 import { SubmitInput } from './SubmitInput'
 import { SortArrow } from './SortArrow'
@@ -59,6 +60,9 @@ export interface AppState {
 	currentPage: number;
 	loading: boolean;
 	totalFolders: number;
+	editingSubfolderQuotas: number;
+	loadingSubfolderQuotas: number;
+	subfolderQuotas: Record<number, SubfolderQuota[]>;
 }
 
 export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Search.Core> {
@@ -84,6 +88,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		currentPage: 0,
 		loading: false,
 		totalFolders: 0,
+		editingSubfolderQuotas: 0,
+		loadingSubfolderQuotas: 0,
+		subfolderQuotas: {},
 	}
 
 	componentDidMount() {
@@ -121,8 +128,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		} catch (error) {
 			logger.error('Error while creating new folder', { error })
 
-			if (isAxiosError(error) && error.response.data.message) {
-				showError(error.response.data.message)
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			if (typeof message === 'string') {
+				showError(message)
 			} else {
 				showError(t('groupfolders', 'Folder could not be created'))
 			}
@@ -185,6 +193,81 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		this.setState({ folders })
 	}
 
+	async toggleSubfolderQuotas(folder: Folder) {
+		if (this.state.editingSubfolderQuotas === folder.id) {
+			this.setState({ editingSubfolderQuotas: 0 })
+			return
+		}
+
+		this.setState({ editingSubfolderQuotas: folder.id, loadingSubfolderQuotas: folder.id })
+		try {
+			const subfolderQuotas = await this.api.listSubfolderQuotas(folder.id)
+			this.setState({
+				subfolderQuotas: {
+					...this.state.subfolderQuotas,
+					[folder.id]: subfolderQuotas,
+				},
+			})
+		} catch (error) {
+			logger.error('Error while listing subfolder quotas', { error })
+			showError(t('groupfolders', 'Subfolder quotas could not be loaded'))
+		} finally {
+			this.setState({ loadingSubfolderQuotas: 0 })
+		}
+	}
+
+	async createSubfolderQuota(folder: Folder, name: string, quota: number | null): Promise<boolean> {
+		try {
+			const subfolderQuota = await this.api.createSubfolderQuota(folder.id, name, quota ?? -3)
+			const subfolderQuotas = this.state.subfolderQuotas[folder.id] ?? []
+			this.setState({
+				subfolderQuotas: {
+					...this.state.subfolderQuotas,
+					[folder.id]: [...subfolderQuotas, subfolderQuota].sort((left, right) => left.name.localeCompare(right.name)),
+				},
+			})
+			return true
+		} catch (error) {
+			logger.error('Error while creating subfolder quota', { error })
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			if (typeof message === 'string') {
+				showError(message)
+			} else {
+				showError(t('groupfolders', 'Subfolder could not be created'))
+			}
+			return false
+		}
+	}
+
+	async setSubfolderQuota(folder: Folder, subfolder: SubfolderQuota, quota: number | null) {
+		try {
+			const updated = quota === null
+				? { ...subfolder, quota: null }
+				: await this.api.setSubfolderQuota(folder.id, subfolder.file_id, quota)
+			if (quota === null) {
+				await this.api.removeSubfolderQuota(folder.id, subfolder.file_id)
+			}
+
+			const subfolderQuotas = (this.state.subfolderQuotas[folder.id] ?? []).map((item) => (
+				item.file_id === updated.file_id ? updated : item
+			))
+			this.setState({
+				subfolderQuotas: {
+					...this.state.subfolderQuotas,
+					[folder.id]: subfolderQuotas,
+				},
+			})
+		} catch (error) {
+			logger.error('Error while setting subfolder quota', { error })
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			if (typeof message === 'string') {
+				showError(message)
+			} else {
+				showError(t('groupfolders', 'Subfolder quota could not be updated'))
+			}
+		}
+	}
+
 	async renameFolder(folder: Folder, newName: string) {
 		try {
 			await this.api.renameFolder(folder.id, newName);
@@ -194,8 +277,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 		} catch (error) {
 			logger.error('Error while renaming folder', { error })
 
-			if (isAxiosError(error) && error.response.data.message) {
-				showError(error.response.data.message)
+			const message = isAxiosError(error) ? error.response?.data?.message : undefined
+			if (typeof message === 'string') {
+				showError(message)
 			} else {
 				showError(t('groupfolders', 'Folder could not be renamed'))
 			}
@@ -306,9 +390,9 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 				})
 				.sort((a, b) => a.sortIndex! - b.sortIndex!)
 				.slice(this.state.currentPage * pageSize, this.state.currentPage * pageSize + pageSize)
-				.map(folder => {
+				.reduce<React.ReactElement[]>((rows, folder) => {
 					const id = folder.id
-					return <tr key={id}>
+					rows.push(<tr key={id}>
 						<td className="mountpoint">
 							{this.state.editingMountPoint === id
 								? <SubmitInput
@@ -368,6 +452,18 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 								onSearch={this.searchMappings.bind(this, folder)}
 							/>
 							}
+							<button
+								type="button"
+								className="subfolder-quotas-action"
+								onClick={(event) => {
+									event.stopPropagation()
+									this.toggleSubfolderQuotas(folder)
+								}}
+							>
+								{this.state.editingSubfolderQuotas === id
+									? t('groupfolders', 'Hide subfolder quotas')
+									: t('groupfolders', 'Subfolder quotas')}
+							</button>
 						</td>
 						<td className="remove">
 							<button type="button"
@@ -376,8 +472,23 @@ export class App extends Component<unknown, AppState> implements OC.Plugin<OC.Se
 								onClick={this.deleteFolder.bind(this, folder)}
 								title={t('groupfolders', 'Delete')}/>
 						</td>
-					</tr>
-				})
+					</tr>)
+					if (this.state.editingSubfolderQuotas === id) {
+						rows.push(<tr key={`${id}-subfolder-quotas`} className="subfolder-quotas-row">
+							<td colSpan={5}>
+								{this.state.loadingSubfolderQuotas === id
+									? t('groupfolders', 'Loading subfolder quotas …')
+									: <SubfolderQuotas
+										subfolders={this.state.subfolderQuotas[id] ?? []}
+										quotaOptions={defaultQuotaOptions}
+										onCreate={this.createSubfolderQuota.bind(this, folder)}
+										onSetQuota={this.setSubfolderQuota.bind(this, folder)}/>}
+							</td>
+						</tr>)
+					}
+
+					return rows
+				}, [])
 
 		return <div id="groupfolders-react-root"
 			onClick={() => {

--- a/src/settings/QuotaSelect.tsx
+++ b/src/settings/QuotaSelect.tsx
@@ -9,9 +9,10 @@ import './EditSelect.scss'
 
 export interface QuotaSelectProps {
 	options: { [name: string]: number };
-	value: number;
+	value: number | null;
 	size: number;
-	onChange: (quota: number) => void;
+	onChange: (quota: number | null) => void;
+	noneLabel?: string;
 }
 
 export interface QuotaSelectState {
@@ -31,7 +32,7 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 	constructor(props) {
 		super(props)
 		this.state.options = props.options
-		if (props.value >= 0) {
+		if (props.value !== null && props.value >= 0) {
 			const valueText = formatFileSize(props.value)
 			this.state.options[valueText] = props.value
 		}
@@ -39,16 +40,18 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 
 	onSelect = event => {
 		const value = event.target.value
-		if (value === 'other') {
+		if (value === '') {
+			this.props.onChange(null)
+		} else if (value === 'other') {
 			this.setState({ isEditing: true })
 		} else {
-			this.props.onChange(value)
+			this.props.onChange(Number(value))
 		}
 	}
 
 	onEditedValue = (value) => {
 		const size = parseFileSize(value, true)
-		if (!size) {
+		if (size === null || size < 0) {
 			this.setState({ isValidInput: false })
 		} else {
 			this.setState({ isValidInput: true, isEditing: false })
@@ -59,7 +62,11 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 	}
 
 	getUsedPercentage() {
-		if (this.props.value >= 0) {
+		if (this.props.value === null) {
+			return 0
+		}
+
+		if (this.props.value !== null && this.props.value >= 0) {
 			return Math.min((this.props.size / this.props.value) * 100, 100)
 		} else {
 			const usedInGB = this.props.size / (10 * Math.pow(2, 30))
@@ -95,7 +102,8 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 					onChange={this.onSelect}
 					aria-label={t('groupfolders', 'Quota')}
 					title={t('settings', '{size} used', { size: humanSize }, 0, { escape: false }).replace('&lt;', '<')}
-					value={this.props.value}>
+					value={this.props.value ?? ''}>
+					{this.props.noneLabel && <option value="">{this.props.noneLabel}</option>}
 					{options}
 					<option value="other">
 						{t('groupfolders', 'Other …')}

--- a/src/settings/QuotaSelect.tsx
+++ b/src/settings/QuotaSelect.tsx
@@ -13,6 +13,7 @@ export interface QuotaSelectProps {
 	size: number;
 	onChange: (quota: number | null) => void;
 	noneLabel?: string;
+	maxSize?: number | null;
 }
 
 export interface QuotaSelectState {
@@ -51,7 +52,12 @@ export class QuotaSelect extends Component<QuotaSelectProps, QuotaSelectState> {
 
 	onEditedValue = (value) => {
 		const size = parseFileSize(value, true)
-		if (size === null || size < 0) {
+		const exceedsMaximum = this.props.maxSize !== null
+			&& this.props.maxSize !== undefined
+			&& this.props.maxSize >= 0
+			&& size !== null
+			&& size > this.props.maxSize
+		if (size === null || size < 0 || exceedsMaximum) {
 			this.setState({ isValidInput: false })
 		} else {
 			this.setState({ isValidInput: true, isEditing: false })

--- a/src/settings/SubfolderQuotas.tsx
+++ b/src/settings/SubfolderQuotas.tsx
@@ -12,6 +12,7 @@ import { QuotaSelect } from './QuotaSelect'
 interface SubfolderQuotasProps {
 	subfolders: SubfolderQuota[];
 	quotaOptions: { [name: string]: number };
+	parentQuota: number;
 	onCreate: (name: string, quota: number | null) => Promise<boolean>;
 	onSetQuota: (subfolder: SubfolderQuota, quota: number | null) => Promise<void>;
 }
@@ -39,7 +40,14 @@ export class SubfolderQuotas extends Component<SubfolderQuotasProps, SubfolderQu
 		}
 	}
 
+	getQuotaOptions(): { [name: string]: number } {
+		return Object.fromEntries(Object.entries(this.props.quotaOptions).filter(([, quota]) => (
+			quota >= 0 && (this.props.parentQuota < 0 || quota <= this.props.parentQuota)
+		)))
+	}
+
 	render() {
+		const quotaOptions = this.getQuotaOptions()
 		return <div className="subfolder-quotas">
 			<h4>{t('groupfolders', 'Subfolder quotas')}</h4>
 			<p>{t('groupfolders', 'A subfolder limit applies to all of its contents and also counts towards the Team folder quota.')}</p>
@@ -50,9 +58,10 @@ export class SubfolderQuotas extends Component<SubfolderQuotasProps, SubfolderQu
 					aria-label={t('groupfolders', 'Subfolder name')}
 					onChange={(event) => this.setState({ name: event.target.value })}/>
 				<QuotaSelect
-					options={this.props.quotaOptions}
+					options={quotaOptions}
 					value={this.state.quota}
 					size={0}
+					maxSize={this.props.parentQuota}
 					noneLabel={t('groupfolders', 'No separate limit')}
 					onChange={(quota) => this.setState({ quota })}/>
 				<button type="submit">{t('groupfolders', 'Create subfolder')}</button>
@@ -73,9 +82,10 @@ export class SubfolderQuotas extends Component<SubfolderQuotasProps, SubfolderQu
 							<td>{formatFileSize(subfolder.size)}</td>
 							<td className="quota">
 								<QuotaSelect
-									options={this.props.quotaOptions}
+									options={quotaOptions}
 									value={subfolder.quota}
 									size={subfolder.size}
+									maxSize={this.props.parentQuota}
 									noneLabel={t('groupfolders', 'No separate limit')}
 									onChange={(quota) => this.props.onSetQuota(subfolder, quota)}/>
 							</td>

--- a/src/settings/SubfolderQuotas.tsx
+++ b/src/settings/SubfolderQuotas.tsx
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import * as React from 'react'
+import { Component, FormEvent } from 'react'
+import { formatFileSize } from '@nextcloud/files'
+import { t } from '@nextcloud/l10n'
+import type { SubfolderQuota } from '../types'
+import { QuotaSelect } from './QuotaSelect'
+
+interface SubfolderQuotasProps {
+	subfolders: SubfolderQuota[];
+	quotaOptions: { [name: string]: number };
+	onCreate: (name: string, quota: number | null) => Promise<boolean>;
+	onSetQuota: (subfolder: SubfolderQuota, quota: number | null) => Promise<void>;
+}
+
+interface SubfolderQuotasState {
+	name: string;
+	quota: number | null;
+}
+
+export class SubfolderQuotas extends Component<SubfolderQuotasProps, SubfolderQuotasState> {
+
+	state: SubfolderQuotasState = {
+		name: '',
+		quota: null,
+	}
+
+	createSubfolder = async (event: FormEvent) => {
+		event.preventDefault()
+		if (this.state.name === '') {
+			return
+		}
+
+		if (await this.props.onCreate(this.state.name, this.state.quota)) {
+			this.setState({ name: '', quota: null })
+		}
+	}
+
+	render() {
+		return <div className="subfolder-quotas">
+			<h4>{t('groupfolders', 'Subfolder quotas')}</h4>
+			<p>{t('groupfolders', 'A subfolder limit applies to all of its contents and also counts towards the Team folder quota.')}</p>
+			<form onSubmit={this.createSubfolder} className="subfolder-quotas__create">
+				<input
+					value={this.state.name}
+					placeholder={t('groupfolders', 'Subfolder name')}
+					aria-label={t('groupfolders', 'Subfolder name')}
+					onChange={(event) => this.setState({ name: event.target.value })}/>
+				<QuotaSelect
+					options={this.props.quotaOptions}
+					value={this.state.quota}
+					size={0}
+					noneLabel={t('groupfolders', 'No separate limit')}
+					onChange={(quota) => this.setState({ quota })}/>
+				<button type="submit">{t('groupfolders', 'Create subfolder')}</button>
+			</form>
+			<table className="subfolder-quotas__table">
+				<thead>
+					<tr>
+						<th>{t('groupfolders', 'Subfolder')}</th>
+						<th>{t('groupfolders', 'Used')}</th>
+						<th>{t('groupfolders', 'Quota')}</th>
+					</tr>
+				</thead>
+				<tbody>
+					{this.props.subfolders.length === 0
+						? <tr><td colSpan={3}>{t('groupfolders', 'No direct subfolders yet')}</td></tr>
+						: this.props.subfolders.map((subfolder) => <tr key={subfolder.file_id}>
+							<td>{subfolder.name}</td>
+							<td>{formatFileSize(subfolder.size)}</td>
+							<td className="quota">
+								<QuotaSelect
+									options={this.props.quotaOptions}
+									value={subfolder.quota}
+									size={subfolder.size}
+									noneLabel={t('groupfolders', 'No separate limit')}
+									onChange={(quota) => this.props.onSetQuota(subfolder, quota)}/>
+							</td>
+						</tr>)}
+				</tbody>
+			</table>
+		</div>
+	}
+
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,4 @@ export type User = components['schemas']['User'];
 export type Circle = components['schemas']['Circle'];
 export type AclManage = components['schemas']['AclManage'];
 export type Applicable = components['schemas']['Applicable'];
+export type SubfolderQuota = components['schemas']['SubfolderQuota'];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ import type { components } from './openapi/openapi.ts'
 export type DelegationGroup = components['schemas']['DelegationGroup'];
 export type DelegationCircle = components['schemas']['DelegationCircle'];
 export type Folder = components['schemas']['Folder'];
+export type DeletedFolder = components['schemas']['DeletedFolder'];
 export type Group = components['schemas']['Group'];
 export type User = components['schemas']['User'];
 export type Circle = components['schemas']['Circle'];

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -185,6 +185,51 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the direct subfolders of a Team folder and their optional quotas */
+        get: operations["folder-get-subfolder-quotas"];
+        put?: never;
+        /**
+         * Create a direct subfolder and assign its quota
+         * @description This endpoint requires password confirmation
+         */
+        post: operations["folder-create-subfolder-quota"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas/{fileId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set a quota for a direct subfolder of a Team folder
+         * @description This endpoint requires password confirmation
+         */
+        post: operations["folder-set-subfolder-quota"];
+        /**
+         * Remove the independent quota from a direct subfolder
+         * @description This endpoint requires password confirmation
+         */
+        delete: operations["folder-remove-subfolder-quota"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/index.php/apps/groupfolders/folders/{id}/acl": {
         parameters: {
             query?: never;
@@ -324,6 +369,15 @@ export type components = {
             message?: string;
             totalitems?: string;
             itemsperpage?: string;
+        };
+        SubfolderQuota: {
+            /** Format: int64 */
+            file_id: number;
+            name: string;
+            /** Format: int64 */
+            size: number;
+            /** Format: int64 */
+            quota: number | null;
         };
         User: {
             uid: string;
@@ -1198,6 +1252,299 @@ export interface operations {
                 };
             };
             /** @description Groupfolder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-get-subfolder-quotas": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Direct subfolders returned successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["SubfolderQuota"][];
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-create-subfolder-quota": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Name for the new direct subfolder */
+                    name: string;
+                    /**
+                     * Format: int64
+                     * @description Quota in bytes, or -3 for unlimited
+                     */
+                    quota: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Subfolder created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["SubfolderQuota"];
+                        };
+                    };
+                };
+            };
+            /** @description Invalid subfolder name or quota */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-set-subfolder-quota": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+                /** @description File ID of the direct subfolder */
+                fileId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: int64
+                     * @description Quota in bytes, or -3 to remove the independent limit
+                     */
+                    quota: number;
+                };
+            };
+        };
+        responses: {
+            /** @description Subfolder quota set successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["SubfolderQuota"];
+                        };
+                    };
+                };
+            };
+            /** @description The target is not a direct subfolder or the quota is invalid */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-remove-subfolder-quota": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+                /** @description File ID of the direct subfolder */
+                fileId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subfolder quota removed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {boolean} */
+                                success: true;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/src/types/openapi/openapi.ts
+++ b/src/types/openapi/openapi.ts
@@ -92,10 +92,67 @@ export type paths = {
         put: operations["folder-set-mount-point"];
         post?: never;
         /**
-         * Remove a Groupfolder
+         * Move a Groupfolder to the recovery bin
          * @description This endpoint requires password confirmation
          */
         delete: operations["folder-remove-folder"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/index.php/apps/groupfolders/folders/deleted": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Team folders that are still recoverable. */
+        get: operations["folder-get-deleted-folders"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/index.php/apps/groupfolders/folders/{id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore a Team folder from the recovery bin.
+         * @description This endpoint requires password confirmation
+         */
+        post: operations["folder-restore-deleted-folder"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/index.php/apps/groupfolders/folders/{id}/permanent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently remove a Team folder and all of its stored data.
+         * @description This endpoint requires password confirmation
+         */
+        delete: operations["folder-purge-deleted-folder"];
         options?: never;
         head?: never;
         patch?: never;
@@ -230,6 +287,30 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/index.php/apps/groupfolders/folders/{id}/subfolder-quotas/{fileId}/management": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the delegated administrators for one direct Team folder child.
+         * @description A Team folder administrator may assign managers. A delegated subfolder administrator may view the configuration of the subfolder they manage.
+         */
+        get: operations["folder-get-subfolder-management"];
+        put?: never;
+        /**
+         * Add or remove a delegated administrator for one direct Team folder child. Only a Team folder administrator can change this assignment.
+         * @description This endpoint requires password confirmation
+         */
+        post: operations["folder-set-subfolder-manager"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/index.php/apps/groupfolders/folders/{id}/acl": {
         parameters: {
             query?: never;
@@ -339,6 +420,18 @@ export type components = {
             gid: string;
             displayName: string;
         };
+        DeletedFolder: {
+            /** Format: int64 */
+            id: number;
+            mount_point: string;
+            /** Format: int64 */
+            quota: number;
+            /** Format: int64 */
+            size: number;
+            /** Format: int64 */
+            deleted_at: number;
+            deleted_by: string | null;
+        };
         Folder: {
             /** Format: int64 */
             id: number;
@@ -369,6 +462,18 @@ export type components = {
             message?: string;
             totalitems?: string;
             itemsperpage?: string;
+        };
+        SubfolderManagement: {
+            /** Format: int64 */
+            file_id: number;
+            name: string;
+            /** Format: int64 */
+            size: number;
+            /** Format: int64 */
+            quota: number | null;
+            managers: components["schemas"]["AclManage"][];
+            can_manage: boolean;
+            can_assign: boolean;
         };
         SubfolderQuota: {
             /** Format: int64 */
@@ -849,7 +954,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Groupfolder removed successfully */
+            /** @description Groupfolder moved to the recovery bin successfully */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -881,6 +986,239 @@ export interface operations {
                 };
             };
             /** @description Groupfolder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-get-deleted-folders": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted Team folders returned successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["DeletedFolder"][];
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not a global administrator */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-restore-deleted-folder": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the deleted Team folder */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description Replacement mount point when its original name is in use
+                     * @default null
+                     */
+                    mountpoint?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Team folder restored successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {boolean} */
+                                success: true;
+                                folder: components["schemas"]["Folder"];
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description A replacement mount point is invalid or already in use */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not a global administrator */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Deleted Team folder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-purge-deleted-folder": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the deleted Team folder */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Team folder permanently removed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: {
+                                /** @enum {boolean} */
+                                success: true;
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not a global administrator */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Deleted Team folder not found */
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -1545,6 +1883,181 @@ export interface operations {
                 };
             };
             /** @description Team folder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-get-subfolder-management": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+                /** @description File ID of the direct subfolder */
+                fileId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subfolder management returned successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["SubfolderManagement"];
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not allowed to manage this subfolder */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder or direct subfolder not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    "folder-set-subfolder-manager": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Required to be true for the API request to pass */
+                "OCS-APIRequest": boolean;
+            };
+            path: {
+                /** @description ID of the Team folder */
+                id: number;
+                /** @description File ID of the direct subfolder */
+                fileId: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Type of mapping: user, group, or circle */
+                    mappingType: string;
+                    /** @description ID of the selected user, group, or team */
+                    mappingId: string;
+                    /** @description Whether to grant or revoke subfolder management */
+                    manager: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Subfolder manager assignment updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: components["schemas"]["SubfolderManagement"];
+                        };
+                    };
+                };
+            };
+            /** @description Invalid child or mapping */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Current user is not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Not allowed to assign subfolder managers */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ocs: {
+                            meta: components["schemas"]["OCSMeta"];
+                            data: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Team folder or direct subfolder not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/tests/Folder/FolderManagerTest.php
+++ b/tests/Folder/FolderManagerTest.php
@@ -15,6 +15,7 @@ use OCA\GroupFolders\Folder\FolderDefinitionWithPermissions;
 use OCA\GroupFolders\Folder\FolderManager;
 use OCA\GroupFolders\Mount\FolderStorageManager;
 use OCA\GroupFolders\ResponseDefinitions;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -45,6 +46,7 @@ class FolderManagerTest extends TestCase {
 	private IUserMappingManager&MockObject $userMappingManager;
 	private FolderStorageManager $folderStorageManager;
 	private IAppConfig $appConfig;
+	private ITimeFactory&MockObject $timeFactory;
 
 	#[\Override]
 	protected function setUp(): void {
@@ -58,6 +60,7 @@ class FolderManagerTest extends TestCase {
 		$this->userMappingManager = $this->createMock(IUserMappingManager::class);
 		$this->folderStorageManager = Server::get(FolderStorageManager::class);
 		$this->appConfig = Server::get(IAppConfig::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->manager = new FolderManager(
 			Server::get(IDBConnection::class),
@@ -69,6 +72,7 @@ class FolderManagerTest extends TestCase {
 			$this->userMappingManager,
 			$this->folderStorageManager,
 			$this->appConfig,
+			$this->timeFactory,
 		);
 		$this->clean();
 	}
@@ -286,6 +290,91 @@ class FolderManagerTest extends TestCase {
 		]);
 	}
 
+	public function testArchiveHidesFolderAndRestoreKeepsItsConfiguration(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+		$this->timeFactory->method('getTime')->willReturn(1_000_000);
+
+		$folderId = $this->manager->createFolder('recoverable');
+		$this->manager->addApplicableGroup($folderId, 'g1');
+		$this->manager->setFolderQuota($folderId, 1024);
+
+		$this->manager->archiveFolder($folderId, 'admin');
+
+		self::assertNull($this->manager->getFolder($folderId));
+		self::assertFalse($this->manager->mountPointExists('recoverable'));
+		self::assertSame(0, $this->manager->countAllFolders());
+		self::assertSame([], $this->manager->getAllFolders());
+
+		$deletedFolder = $this->manager->getDeletedFolder($folderId);
+		self::assertNotNull($deletedFolder);
+		self::assertSame('recoverable', $deletedFolder->folder->mountPoint);
+		self::assertSame(1024, $deletedFolder->folder->quota);
+		self::assertSame(1_000_000, $deletedFolder->deletedAt);
+		self::assertSame('admin', $deletedFolder->deletedBy);
+		self::assertCount(1, $this->manager->getDeletedFoldersBefore(1_000_001));
+
+		$this->manager->restoreDeletedFolder($folderId);
+
+		$restoredFolder = $this->manager->getFolder($folderId);
+		self::assertNotNull($restoredFolder);
+		self::assertSame('recoverable', $restoredFolder->mountPoint);
+		self::assertSame(1024, $restoredFolder->quota);
+		self::assertArrayHasKey('g1', $restoredFolder->groups);
+		self::assertSame([], $this->manager->getDeletedFolders());
+	}
+
+	public function testRestoreRequiresAnotherNameWhenOriginalMountPointIsInUse(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+		$this->timeFactory->method('getTime')->willReturn(1_000_000);
+
+		$deletedFolderId = $this->manager->createFolder('same-name');
+		$this->manager->archiveFolder($deletedFolderId, 'admin');
+		$this->manager->createFolder('same-name');
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->manager->restoreDeletedFolder($deletedFolderId);
+	}
+
+	public function testRestoreAcceptsReplacementMountPoint(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+		$this->timeFactory->method('getTime')->willReturn(1_000_000);
+
+		$deletedFolderId = $this->manager->createFolder('same-name');
+		$this->manager->archiveFolder($deletedFolderId, 'admin');
+		$this->manager->createFolder('same-name');
+
+		$this->manager->restoreDeletedFolder($deletedFolderId, 'same-name-restored');
+
+		$restoredFolder = $this->manager->getFolder($deletedFolderId);
+		self::assertNotNull($restoredFolder);
+		self::assertSame('same-name-restored', $restoredFolder->mountPoint);
+	}
+
+	public function testPurgeOnlyRemovesArchivedFolders(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValueInt')
+			->with('groupfolders.quota.default', FileInfo::SPACE_UNLIMITED)
+			->willReturn(FileInfo::SPACE_UNLIMITED);
+		$this->timeFactory->method('getTime')->willReturn(1_000_000);
+
+		$folderId = $this->manager->createFolder('purgeable');
+		self::assertFalse($this->manager->purgeDeletedFolder($folderId));
+		self::assertNotNull($this->manager->getFolder($folderId));
+
+		$this->manager->archiveFolder($folderId, 'admin');
+		self::assertTrue($this->manager->purgeDeletedFolder($folderId));
+		self::assertNull($this->manager->getDeletedFolder($folderId));
+	}
+
 	public function testRenameFolder(): void {
 		$this->config->expects($this->any())
 			->method('getSystemValueInt')
@@ -325,6 +414,27 @@ class FolderManagerTest extends TestCase {
 			['mount_point' => 'foo', 'groups' => []],
 			['mount_point' => 'other', 'groups' => []],
 		]);
+	}
+
+	public function testDisablingAclRetainsManagerAssignments(): void {
+		$folderId = $this->manager->createFolder('retain-acl-managers');
+		$this->manager->setManageACL($folderId, 'group', 'somegroup', true);
+
+		$this->manager->setFolderACL($folderId, false);
+
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->select($query->func()->count('*'))
+			->from('group_folders_manage')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		self::assertSame(1, (int)$query->executeQuery()->fetchOne());
+
+		$this->manager->setFolderACL($folderId, true);
+
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
+		$query->select($query->func()->count('*'))
+			->from('group_folders_manage')
+			->where($query->expr()->eq('folder_id', $query->createNamedParameter($folderId, IQueryBuilder::PARAM_INT)));
+		self::assertSame(1, (int)$query->executeQuery()->fetchOne());
 	}
 
 	public function testGetFoldersForGroups(): void {
@@ -369,7 +479,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserSimple(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig, $this->timeFactory])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -399,7 +509,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFoldersForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig, $this->timeFactory])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 
@@ -453,7 +563,7 @@ class FolderManagerTest extends TestCase {
 	public function testGetFolderPermissionsForUserMerge(): void {
 		$db = $this->createMock(IDBConnection::class);
 		$manager = $this->getMockBuilder(FolderManager::class)
-			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig])
+			->setConstructorArgs([$db, $this->groupManager, $this->mimeLoader, $this->logger, $this->eventDispatcher, $this->config, $this->userMappingManager, $this->folderStorageManager, $this->appConfig, $this->timeFactory])
 			->onlyMethods(['getFoldersForGroups'])
 			->getMock();
 

--- a/tests/Folder/SubfolderManagerServiceTest.php
+++ b/tests/Folder/SubfolderManagerServiceTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Tests\Folder;
+
+use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\SubfolderManagerService;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
+use OCP\IUser;
+use OCP\Server;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * @group DB
+ */
+class SubfolderManagerServiceTest extends TestCase {
+	use UserTrait;
+
+	private FolderManager $folderManager;
+	private SubfolderQuotaManager $subfolderQuotaManager;
+	private SubfolderManagerService $subfolderManagerService;
+	private int $folderId;
+	private IUser $managerUser;
+	private IUser $otherUser;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->folderManager = Server::get(FolderManager::class);
+		$this->subfolderQuotaManager = Server::get(SubfolderQuotaManager::class);
+		$this->subfolderManagerService = Server::get(SubfolderManagerService::class);
+		$this->folderId = $this->folderManager->createFolder('subfolder-manager-' . bin2hex(random_bytes(8)));
+		$this->folderManager->setFolderACL($this->folderId, true);
+		$this->managerUser = $this->createUser('subfolder-manager-' . bin2hex(random_bytes(4)), 'test');
+		$this->otherUser = $this->createUser('subfolder-other-' . bin2hex(random_bytes(4)), 'test');
+	}
+
+	#[\Override]
+	protected function tearDown(): void {
+		if ($this->folderManager->getFolder($this->folderId) !== null) {
+			$this->folderManager->removeFolder($this->folderId);
+		}
+
+		parent::tearDown();
+	}
+
+	public function testDelegateOnlyManagesItsAssignedSubfolder(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+		$first = $this->subfolderQuotaManager->createSubfolder($folder, 'first', 1024);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'second', 1024);
+
+		$this->subfolderManagerService->setManager($folder, $first->fileId, 'user', $this->managerUser->getUID(), true);
+
+		$managers = $this->subfolderManagerService->getManagers($folder, $first->fileId);
+		self::assertCount(1, $managers);
+		self::assertSame($this->managerUser->getUID(), $managers[0]->getId());
+		self::assertTrue($this->subfolderManagerService->canManageSubfolder($folder, $first->fileId, $this->managerUser));
+		self::assertTrue($this->subfolderManagerService->canManagePath($folder, 'first/nested/file.txt', $this->managerUser));
+		self::assertFalse($this->subfolderManagerService->canManagePath($folder, 'second/file.txt', $this->managerUser));
+		self::assertFalse($this->subfolderManagerService->canManageSubfolder($folder, $first->fileId, $this->otherUser));
+
+		$this->subfolderManagerService->setManager($folder, $first->fileId, 'user', $this->managerUser->getUID(), false);
+		self::assertFalse($this->subfolderManagerService->canManageSubfolder($folder, $first->fileId, $this->managerUser));
+	}
+
+	public function testManagerMustBeAssignedToADirectChild(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->subfolderManagerService->setManager($folder, $folder->rootId, 'user', $this->managerUser->getUID(), true);
+	}
+
+	public function testDisablingAdvancedPermissionsSuspendsSubfolderManagers(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+		$subfolder = $this->subfolderQuotaManager->createSubfolder($folder, 'first', 1024);
+		$this->subfolderManagerService->setManager($folder, $subfolder->fileId, 'user', $this->managerUser->getUID(), true);
+
+		$this->folderManager->setFolderACL($folder->id, false);
+		$inactiveFolder = $this->folderManager->getFolder($folder->id);
+		self::assertNotNull($inactiveFolder);
+		self::assertFalse($this->subfolderManagerService->canManageSubfolder($inactiveFolder, $subfolder->fileId, $this->managerUser));
+
+		$this->folderManager->setFolderACL($folder->id, true);
+		$reactivatedFolder = $this->folderManager->getFolder($folder->id);
+		self::assertNotNull($reactivatedFolder);
+
+		self::assertTrue($this->subfolderManagerService->canManageSubfolder($reactivatedFolder, $subfolder->fileId, $this->managerUser));
+	}
+}

--- a/tests/Folder/SubfolderQuotaManagerTest.php
+++ b/tests/Folder/SubfolderQuotaManagerTest.php
@@ -85,6 +85,67 @@ class SubfolderQuotaManagerTest extends TestCase {
 		$this->subfolderQuotaManager->setSubfolderQuota($folder, $folder->rootId, 1024);
 	}
 
+	public function testSubfolderQuotaCannotExceedTeamFolderQuota(): void {
+		$this->folderManager->setFolderQuota($this->folderId, 1024);
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'too-large', 1025);
+	}
+
+	public function testTeamFolderQuotaCannotBeLoweredBelowConfiguredSubfolderQuota(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'limited', 1024);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->folderManager->setFolderQuota($this->folderId, 1023);
+	}
+
+	public function testSubfolderQuotaCapsAreNotReservedAllocations(): void {
+		$this->folderManager->setFolderQuota($this->folderId, 10 * 1024);
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$first = $this->subfolderQuotaManager->createSubfolder($folder, 'first', 8 * 1024);
+		$second = $this->subfolderQuotaManager->createSubfolder($folder, 'second', 8 * 1024);
+
+		self::assertSame(8 * 1024, $first->quota);
+		self::assertSame(8 * 1024, $second->quota);
+	}
+
+	public function testSubfoldersContinueToShareTheTeamFolderQuota(): void {
+		$this->folderManager->setFolderQuota($this->folderId, 10);
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'first', 8);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'second', 8);
+
+		/** @var FolderStorageManager $folderStorageManager */
+		$folderStorageManager = Server::get(FolderStorageManager::class);
+		/** @var IUserSession $userSession */
+		$userSession = Server::get(IUserSession::class);
+		$storage = new GroupFolderStorage([
+			'storage' => $folderStorageManager->getBaseStorageForFolder(
+				$folder->id,
+				$folder->useSeparateStorage(),
+				$folder,
+			),
+			'quota' => $folder->quota,
+			'folder' => $folder,
+			'rootCacheEntry' => $folder->rootCacheEntry,
+			'userSession' => $userSession,
+			'mountOwner' => null,
+			'subfolderQuotaManager' => $this->subfolderQuotaManager,
+			'applySubfolderQuotas' => true,
+		]);
+
+		self::assertSame(6, $storage->file_put_contents('first/first.txt', '123456'));
+		self::assertSame(4, $storage->free_space('second/second.txt'));
+		self::assertFalse($storage->file_put_contents('second/second.txt', '12345'));
+	}
+
 	public function testSubfolderQuotaIsAppliedWhenTeamFolderIsUnlimited(): void {
 		$folder = $this->folderManager->getFolder($this->folderId);
 		self::assertNotNull($folder);

--- a/tests/Folder/SubfolderQuotaManagerTest.php
+++ b/tests/Folder/SubfolderQuotaManagerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Tests\Folder;
+
+use OCA\GroupFolders\Folder\FolderManager;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
+use OCA\GroupFolders\Mount\FolderStorageManager;
+use OCA\GroupFolders\Mount\GroupFolderStorage;
+use OCP\Files\FileInfo;
+use OCP\IUserSession;
+use OCP\Server;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class SubfolderQuotaManagerTest extends TestCase {
+	private FolderManager $folderManager;
+	private SubfolderQuotaManager $subfolderQuotaManager;
+	private int $folderId;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->folderManager = Server::get(FolderManager::class);
+		$this->subfolderQuotaManager = Server::get(SubfolderQuotaManager::class);
+		$this->folderId = $this->folderManager->createFolder('subfolder-quota-' . bin2hex(random_bytes(8)));
+	}
+
+	#[\Override]
+	protected function tearDown(): void {
+		if ($this->folderManager->getFolder($this->folderId) !== null) {
+			$this->folderManager->removeFolder($this->folderId);
+		}
+
+		parent::tearDown();
+	}
+
+	public function testCreateSubfolderWithQuota(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$created = $this->subfolderQuotaManager->createSubfolder($folder, 'first', 1024);
+
+		self::assertSame('first', $created->name);
+		self::assertSame(1024, $created->quota);
+		self::assertGreaterThan(0, $created->fileId);
+
+		$subfolders = $this->subfolderQuotaManager->getSubfolderQuotas($folder);
+		self::assertCount(1, $subfolders);
+		self::assertSame($created->fileId, $subfolders[0]->fileId);
+		self::assertSame(1024, $subfolders[0]->quota);
+	}
+
+	public function testUnlimitedRemovesIndependentQuota(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$created = $this->subfolderQuotaManager->createSubfolder($folder, 'first', 1024);
+		$updated = $this->subfolderQuotaManager->setSubfolderQuota(
+			$folder,
+			$created->fileId,
+			FileInfo::SPACE_UNLIMITED,
+		);
+
+		self::assertNull($updated->quota);
+		$subfolders = $this->subfolderQuotaManager->getSubfolderQuotas($folder);
+		self::assertCount(1, $subfolders);
+		self::assertNull($subfolders[0]->quota);
+	}
+
+	public function testQuotaCanOnlyBeSetOnDirectChildFolders(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+
+		$this->expectException(\InvalidArgumentException::class);
+		$this->subfolderQuotaManager->setSubfolderQuota($folder, $folder->rootId, 1024);
+	}
+
+	public function testSubfolderQuotaIsAppliedWhenTeamFolderIsUnlimited(): void {
+		$folder = $this->folderManager->getFolder($this->folderId);
+		self::assertNotNull($folder);
+		$this->subfolderQuotaManager->createSubfolder($folder, 'limited', 10);
+
+		/** @var FolderStorageManager $folderStorageManager */
+		$folderStorageManager = Server::get(FolderStorageManager::class);
+		/** @var IUserSession $userSession */
+		$userSession = Server::get(IUserSession::class);
+		$storage = new GroupFolderStorage([
+			'storage' => $folderStorageManager->getBaseStorageForFolder(
+				$folder->id,
+				$folder->useSeparateStorage(),
+				$folder,
+			),
+			'quota' => FileInfo::SPACE_UNLIMITED,
+			'folder' => $folder,
+			'rootCacheEntry' => $folder->rootCacheEntry,
+			'userSession' => $userSession,
+			'mountOwner' => null,
+			'subfolderQuotaManager' => $this->subfolderQuotaManager,
+			'applySubfolderQuotas' => true,
+		]);
+
+		self::assertSame(3, $storage->file_put_contents('limited/first.txt', 'abc'));
+		self::assertSame(7, $storage->free_space('limited/second.txt'));
+		self::assertFalse($storage->file_put_contents('limited/second.txt', '12345678'));
+		self::assertFalse($storage->rename('limited', 'nested/limited'));
+	}
+}

--- a/tests/Listeners/SubfolderQuotaListenerTest.php
+++ b/tests/Listeners/SubfolderQuotaListenerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\GroupFolders\Tests\Listeners;
 
 use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\SubfolderManagerService;
 use OCA\GroupFolders\Folder\SubfolderQuotaManager;
 use OCA\GroupFolders\Listeners\SubfolderQuotaListener;
 use OCA\GroupFolders\Mount\GroupFolderStorage;
@@ -24,6 +25,7 @@ use Test\TestCase;
 
 class SubfolderQuotaListenerTest extends TestCase {
 	private SubfolderQuotaManager&MockObject $subfolderQuotaManager;
+	private SubfolderManagerService&MockObject $subfolderManagerService;
 	private SubfolderQuotaListener $listener;
 	private GroupFolderStorage&MockObject $sourceStorage;
 	private GroupFolderStorage&MockObject $targetStorage;
@@ -36,7 +38,8 @@ class SubfolderQuotaListenerTest extends TestCase {
 		parent::setUp();
 
 		$this->subfolderQuotaManager = $this->createMock(SubfolderQuotaManager::class);
-		$this->listener = new SubfolderQuotaListener($this->subfolderQuotaManager);
+		$this->subfolderManagerService = $this->createMock(SubfolderManagerService::class);
+		$this->listener = new SubfolderQuotaListener($this->subfolderQuotaManager, $this->subfolderManagerService);
 
 		$this->sourceStorage = $this->createMock(GroupFolderStorage::class);
 		$this->sourceStorage
@@ -115,6 +118,41 @@ class SubfolderQuotaListenerTest extends TestCase {
 		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
 	}
 
+	public function testKeepsManagerAssignmentWhenRenamingADirectChild(): void {
+		$targetParent = $this->createMock(Folder::class);
+		$targetParent
+			->method('getId')
+			->willReturn(10);
+		$this->target
+			->method('getStorage')
+			->willReturn($this->targetStorage);
+		$this->target
+			->method('getParent')
+			->willReturn($targetParent);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(false);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('hasManagers')
+			->with(1, 42)
+			->willReturn(true);
+		$this->subfolderManagerService
+			->expects($this->never())
+			->method('removeManagersByFileId');
+
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+
+		$sourceAfterRename = $this->createMock(Folder::class);
+		$sourceAfterRename
+			->method('getPath')
+			->willReturn('/team/source');
+		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
+	}
+
 	public function testRemovesQuotaWhenAConfiguredSubfolderLeavesTheTeamFolder(): void {
 		$externalStorage = $this->createMock(IStorage::class);
 		$externalStorage
@@ -134,6 +172,10 @@ class SubfolderQuotaListenerTest extends TestCase {
 			->expects($this->once())
 			->method('removeSubfolderQuota')
 			->with(1, 42);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('removeManagersByFileId')
+			->with(42);
 
 		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
 
@@ -144,6 +186,44 @@ class SubfolderQuotaListenerTest extends TestCase {
 		$sourceAfterRename
 			->expects($this->never())
 			->method('getId');
+		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
+	}
+
+	public function testRemovesManagerWhenManagerOnlySubfolderLeavesTheTeamFolder(): void {
+		$externalStorage = $this->createMock(IStorage::class);
+		$externalStorage
+			->method('instanceOfStorage')
+			->with(GroupFolderStorage::class)
+			->willReturn(false);
+		$this->target
+			->method('getStorage')
+			->willReturn($externalStorage);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(false);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('hasManagers')
+			->with(1, 42)
+			->willReturn(true);
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('removeSubfolderQuota')
+			->with(1, 42);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('removeManagersByFileId')
+			->with(42);
+
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+
+		$sourceAfterRename = $this->createMock(Folder::class);
+		$sourceAfterRename
+			->method('getPath')
+			->willReturn('/team/source');
 		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
 	}
 
@@ -184,6 +264,10 @@ class SubfolderQuotaListenerTest extends TestCase {
 			->expects($this->once())
 			->method('removeSubfolderQuota')
 			->with(1, 42);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('removeManagersByFileId')
+			->with(42);
 
 		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
 
@@ -199,6 +283,10 @@ class SubfolderQuotaListenerTest extends TestCase {
 			->expects($this->once())
 			->method('removeSubfolderQuota')
 			->with(1, 42);
+		$this->subfolderManagerService
+			->expects($this->once())
+			->method('removeManagersByFileId')
+			->with(42);
 
 		$event = $this->createMock(NodeDeletedEvent::class);
 		$event

--- a/tests/Listeners/SubfolderQuotaListenerTest.php
+++ b/tests/Listeners/SubfolderQuotaListenerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\GroupFolders\Tests\Listeners;
+
+use OCA\GroupFolders\Folder\FolderDefinition;
+use OCA\GroupFolders\Folder\SubfolderQuotaManager;
+use OCA\GroupFolders\Listeners\SubfolderQuotaListener;
+use OCA\GroupFolders\Mount\GroupFolderStorage;
+use OCP\Exceptions\AbortedEventException;
+use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Events\Node\NodeRenamedEvent;
+use OCP\Files\Folder;
+use OCP\Files\Storage\IStorage;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class SubfolderQuotaListenerTest extends TestCase {
+	private SubfolderQuotaManager&MockObject $subfolderQuotaManager;
+	private SubfolderQuotaListener $listener;
+	private GroupFolderStorage&MockObject $sourceStorage;
+	private GroupFolderStorage&MockObject $targetStorage;
+	private Folder&MockObject $source;
+	private Folder&MockObject $target;
+	private bool $targetAppliesSubfolderQuotas = true;
+
+	#[\Override]
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->subfolderQuotaManager = $this->createMock(SubfolderQuotaManager::class);
+		$this->listener = new SubfolderQuotaListener($this->subfolderQuotaManager);
+
+		$this->sourceStorage = $this->createMock(GroupFolderStorage::class);
+		$this->sourceStorage
+			->method('instanceOfStorage')
+			->with(GroupFolderStorage::class)
+			->willReturn(true);
+		$this->sourceStorage
+			->method('getFolder')
+			->willReturn($this->getFolderDefinition());
+		$this->sourceStorage
+			->method('getFolderId')
+			->willReturn(1);
+
+		$this->targetStorage = $this->createMock(GroupFolderStorage::class);
+		$this->targetStorage
+			->method('instanceOfStorage')
+			->with(GroupFolderStorage::class)
+			->willReturn(true);
+		$this->targetStorage
+			->method('getFolderId')
+			->willReturn(1);
+		$this->targetStorage
+			->method('getFolder')
+			->willReturn($this->getFolderDefinition());
+		$this->targetStorage
+			->method('appliesSubfolderQuotas')
+			->willReturnCallback(fn (): bool => $this->targetAppliesSubfolderQuotas);
+
+		$this->source = $this->createMock(Folder::class);
+		$this->source
+			->method('getStorage')
+			->willReturn($this->sourceStorage);
+		$this->source
+			->method('getId')
+			->willReturn(42);
+		$this->source
+			->method('getPath')
+			->willReturn('/team/source');
+
+		$this->target = $this->createMock(Folder::class);
+		$this->target
+			->method('getPath')
+			->willReturn('/team/renamed');
+	}
+
+	public function testKeepsQuotaWhenRenamingAConfiguredDirectChild(): void {
+		$targetParent = $this->createMock(Folder::class);
+		$targetParent
+			->method('getId')
+			->willReturn(10);
+		$this->target
+			->method('getStorage')
+			->willReturn($this->targetStorage);
+		$this->target
+			->method('getParent')
+			->willReturn($targetParent);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(true);
+		$this->subfolderQuotaManager
+			->expects($this->never())
+			->method('removeSubfolderQuota');
+
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+
+		$sourceAfterRename = $this->createMock(Folder::class);
+		$sourceAfterRename
+			->method('getPath')
+			->willReturn('/team/source');
+		$sourceAfterRename
+			->expects($this->never())
+			->method('getId');
+		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
+	}
+
+	public function testRemovesQuotaWhenAConfiguredSubfolderLeavesTheTeamFolder(): void {
+		$externalStorage = $this->createMock(IStorage::class);
+		$externalStorage
+			->method('instanceOfStorage')
+			->with(GroupFolderStorage::class)
+			->willReturn(false);
+		$this->target
+			->method('getStorage')
+			->willReturn($externalStorage);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(true);
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('removeSubfolderQuota')
+			->with(1, 42);
+
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+
+		$sourceAfterRename = $this->createMock(Folder::class);
+		$sourceAfterRename
+			->method('getPath')
+			->willReturn('/team/source');
+		$sourceAfterRename
+			->expects($this->never())
+			->method('getId');
+		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
+	}
+
+	public function testPreventsMovingAConfiguredSubfolderIntoANestedPath(): void {
+		$targetParent = $this->createMock(Folder::class);
+		$targetParent
+			->method('getId')
+			->willReturn(99);
+		$this->target
+			->method('getStorage')
+			->willReturn($this->targetStorage);
+		$this->target
+			->method('getParent')
+			->willReturn($targetParent);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(true);
+
+		$this->expectException(AbortedEventException::class);
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+	}
+
+	public function testAllowsMovingAConfiguredSubfolderToTrashStorage(): void {
+		$this->targetAppliesSubfolderQuotas = false;
+		$this->target
+			->method('getStorage')
+			->willReturn($this->targetStorage);
+
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('hasSubfolderQuota')
+			->with(1, 42)
+			->willReturn(true);
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('removeSubfolderQuota')
+			->with(1, 42);
+
+		$this->listener->handle($this->getBeforeRenameEvent($this->source, $this->target));
+
+		$sourceAfterRename = $this->createMock(Folder::class);
+		$sourceAfterRename
+			->method('getPath')
+			->willReturn('/team/source');
+		$this->listener->handle($this->getRenameEvent($sourceAfterRename, $this->target));
+	}
+
+	public function testRemovesQuotaWhenConfiguredSubfolderIsDeleted(): void {
+		$this->subfolderQuotaManager
+			->expects($this->once())
+			->method('removeSubfolderQuota')
+			->with(1, 42);
+
+		$event = $this->createMock(NodeDeletedEvent::class);
+		$event
+			->method('getNode')
+			->willReturn($this->source);
+
+		$this->listener->handle($event);
+	}
+
+	private function getFolderDefinition(): FolderDefinition {
+		return new FolderDefinition(1, 'team', 0, false, false, 1, 10, []);
+	}
+
+	private function getBeforeRenameEvent(Folder $source, Folder $target): BeforeNodeRenamedEvent {
+		$event = $this->createMock(BeforeNodeRenamedEvent::class);
+		$event
+			->method('getSource')
+			->willReturn($source);
+		$event
+			->method('getTarget')
+			->willReturn($target);
+
+		return $event;
+	}
+
+	private function getRenameEvent(Folder $source, Folder $target): NodeRenamedEvent {
+		$event = $this->createMock(NodeRenamedEvent::class);
+		$event
+			->method('getSource')
+			->willReturn($source);
+		$event
+			->method('getTarget')
+			->willReturn($target);
+
+		return $event;
+	}
+}

--- a/tests/stubs/oc_files_stream_quota.php
+++ b/tests/stubs/oc_files_stream_quota.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\Files\Stream;
+
+class Quota {
+	/**
+	 * @param resource $stream
+	 * @return resource|false
+	 */
+	public static function wrap($stream, int|float $limit) {
+	}
+}


### PR DESCRIPTION
## Summary

Compatibility port of #5057 for Nextcloud 34.

- add optional quotas for direct Team Folder subfolders; their actual usage also counts towards the parent Team Folder quota
- allow Team Folder administrators to assign scoped managers for direct subfolders from the Files sidebar
- retain delegated-manager assignments when advanced permissions are disabled, while suspending their effect until advanced permissions are enabled again
- add a recoverable Team Folder deletion flow with global-admin restore and permanent-purge actions
- permanently expire archived Team Folders after 30 days through a background job
- expose the API surface in the OpenAPI specification and generated TypeScript types

## Safety notes

- subfolder quota caps are not reserved allocations: configured caps may add up to more than the parent quota, but stored data cannot exceed the parent quota
- normal deletion of a child folder in Files still uses the regular Nextcloud trash; the recovery bin applies to deletion of the Team Folder itself

## Compatibility

This PR targets `stable34` and Nextcloud 34. The upstream feature proposal is #5057 against `master`.

## Validation

- manual validation on Nextcloud 34.0.3 in Docker: direct subfolder quotas, quota enforcement, Team Folder archive, and restore
- `npm run lint -- src/settings/App.tsx src/settings/Api.ts src/types/index.ts`
- `npm run stylelint -- src/settings/App.scss`
- `npm run build`
- `git diff --check`