### PR TITLE
fix(TeamSpace): include quota in TeamFolder instantiation and update …

### DIFF
--- a/lib/TeamSpace/TeamSpaceService.php
+++ b/lib/TeamSpace/TeamSpaceService.php
@@ -233,7 +233,7 @@ class TeamSpaceService {
 
 		$this->createAppDirectory($folderId);
 
-		return new TeamFolder($folder->id, $folder->mountPoint);
+		return new TeamFolder($folder->id, $folder->mountPoint, $folder->quota);
 	}
 
 	/**
@@ -257,7 +257,7 @@ class TeamSpaceService {
 			throw new \RuntimeException('Team space could not be found after updating quota');
 		}
 
-		return new TeamFolder($folder->id, $folder->mountPoint);
+		return new TeamFolder($folder->id, $folder->mountPoint, $quota);
 	}
 
 	/**

--- a/tests/TeamSpace/TeamSpaceServiceTest.php
+++ b/tests/TeamSpace/TeamSpaceServiceTest.php
@@ -121,7 +121,10 @@ class TeamSpaceServiceTest extends TestCase {
 		$storage->expects($this->never())->method('mkdir');
 		$storage->expects($this->never())->method('getScanner');
 
-		$this->assertSame(42, $this->service->getTeamSpaceForCircle('team-1')?->getId());
+		$folder = $this->service->getTeamSpaceForCircle('team-1');
+
+		$this->assertSame(42, $folder?->getId());
+		$this->assertSame(0, $folder?->getQuota());
 	}
 
 	public function testUnlinkKeepsFolderAndClearsTeamLink(): void {
@@ -150,6 +153,7 @@ class TeamSpaceServiceTest extends TestCase {
 
 		$this->assertSame(42, $folder->getId());
 		$this->assertSame('Engineering', $folder->getMountPoint());
+		$this->assertSame(1024, $folder->getQuota());
 	}
 
 	public function testGetGroupFoldersForCircleReturnsAllAssignedFolders(): void {

--- a/tests/TeamSpace/TeamSpaceServiceTest.php
+++ b/tests/TeamSpace/TeamSpaceServiceTest.php
@@ -18,6 +18,7 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\Storage\IStorage;
 use OCP\Teams\Team;
+use OCP\Teams\TeamFolder;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -123,8 +124,9 @@ class TeamSpaceServiceTest extends TestCase {
 
 		$folder = $this->service->getTeamSpaceForCircle('team-1');
 
-		$this->assertSame(42, $folder?->getId());
-		$this->assertSame(0, $folder?->getQuota());
+		$this->assertInstanceOf(TeamFolder::class, $folder);
+		$this->assertSame(42, $folder->getId());
+		$this->assertSame(0, $folder->getQuota());
 	}
 
 	public function testUnlinkKeepsFolderAndClearsTeamLink(): void {


### PR DESCRIPTION
…tests

Fix the links returned for team resources managed by Groupfolders.

The team's primary team space now links to its Circles team page, while additional group folders assigned to the team continue to link directly to their respective Files views.

 GPT-5.6 Terra



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
