### PR TITLE
fix(trash): share the local storage instance of a separate-storage folder

### DIFF
--- a/lib/Mount/FolderStorageManager.php
+++ b/lib/Mount/FolderStorageManager.php
@@ -31,6 +31,8 @@ class FolderStorageManager {
 	private readonly bool $enableEncryption;
 	/** @var array<string, Folder> */
 	private array $cachedFolders = [];
+	/** @var array<int, Local> */
+	private array $separateLocalStorages = [];
 
 	public function __construct(
 		private readonly IRootFolder $rootFolder,
@@ -138,6 +140,10 @@ class FolderStorageManager {
 		int $folderId,
 		bool $init = false,
 	): IStorage {
+		if (isset($this->separateLocalStorages[$folderId])) {
+			return $this->separateLocalStorages[$folderId];
+		}
+
 		$dataDirectory = $this->config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data');
 		$rootPath = $dataDirectory . '/__groupfolders/' . $folderId;
 		if ($init) {
@@ -150,7 +156,8 @@ class FolderStorageManager {
 			}
 		}
 
-		$storage = new Local([
+		// moves between the files, trash and versions storages are only renames when they share this instance
+		$storage = $this->separateLocalStorages[$folderId] = new Local([
 			'datadir' => $rootPath,
 		]);
 

--- a/tests/Trash/TrashBackendTest.php
+++ b/tests/Trash/TrashBackendTest.php
@@ -25,6 +25,7 @@ use OCA\GroupFolders\Trash\TrashManager;
 use OCP\Constants;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -166,6 +167,27 @@ class TrashBackendTest extends TestCase {
 		$this->assertCount(2, $this->trashBackend->listTrashFolder($managerTrashFolder));
 		$this->assertCount(1, $this->trashBackend->listTrashFolder($normalTrashFolder));
 
+		$this->logout();
+	}
+
+	public function testTrashAndRestoreKeepChildHiddenFromUser(): void {
+		$this->loginAsUser('manager');
+		$folder = $this->managerUserFolder->newFolder("{$this->folderName}/folder");
+		$restrictedChild = $folder->newFile('restricted.txt', 'content');
+		$this->ruleManager->saveRule($this->createNoReadRule('normal', $restrictedChild->getId()));
+
+		$this->loginAsUser('normal');
+		$this->assertFalse($this->normalUserFolder->nodeExists("{$this->folderName}/folder/restricted.txt"));
+		$folder = $this->normalUserFolder->get("{$this->folderName}/folder");
+		$this->trashBackend->moveToTrash($folder->getStorage(), $folder->getInternalPath());
+		$trashItems = $this->trashBackend->listTrashRoot($this->normalUser);
+		$this->assertCount(1, $trashItems);
+		$this->trashBackend->restoreItem($trashItems[0]);
+
+		$this->loginAsUser('manager');
+		$restored = $this->managerUserFolder->get("{$this->folderName}/folder/restricted.txt");
+		$this->assertInstanceOf(File::class, $restored);
+		$this->assertSame('content', $restored->getContent());
 		$this->logout();
 	}
 


### PR DESCRIPTION
For a team folder with its own storage, `getBaseStorageForFolderSeparateStorageLocal()` builds a new `Local` on every call, so the files, trash and versions storages of that folder are different objects. `Common::moveFromStorage()` only turns a move into a rename when both sides unwrap to the same instance, and `Local::canDoCrossStorageMove()` refuses ACL wrapped sources.

So, with ACL enabled, every move to or from the trash ends up as a recursive copy in PHP followed by a recursive delete of the source.

That has two effects:

- **It's slow.** Every file costs an ACL lookup plus a full copy, so restoring a big tree keeps the database busy for minutes.
- **It loses data.** The copy only sees what the acting user can read, but the delete removes everything, so files hidden from that user by ACL are gone once they trash or restore the parent folder.

Reusing one `Local` per folder makes these moves renames again, the same as for folders in the root storage. Object storage isn't affected, it already only moves the metadata.

Restoring a trashed folder as a user who can't read one of its files (MariaDB 11.8, local storage, median of 5 runs):

| | before | after |
|---|---|---|
| 5,000 files, 221 folders | 3,071 ms, 5,297 queries | 112 ms, 54 queries |

Before the change 5,243 of those 5,297 queries went to `oc_group_folders_acl`, after it **there are none**.

The new test fails without the change on MariaDB and PostgreSQL with local storage, and passes with it with both local storage and S3, along with the rest of `TrashBackendTest`.

Fix https://github.com/nextcloud/groupfolders/issues/1574
