### PR TITLE
fix(ci): split Cypress specs per runner instead of Cypress Cloud parallelization

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -118,25 +118,21 @@ jobs:
       - name: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }} cypress tests
         uses: cypress-io/github-action@6c143abc292aa835d827652c2ea025d098311070 # v6.10.1
         with:
-          record: ${{ secrets.CYPRESS_RECORD_KEY && true }}
-          parallel: ${{ secrets.CYPRESS_RECORD_KEY && true }}
+          # Cypress Cloud parallelization rejects runs whose runners report different OS versions,
+          # which happens when ubuntu-latest jobs land on different runner pools
+          record: false
+          parallel: false
           # cypress run type
           component: ${{ matrix.containers == 'component' }}
-          group: ${{ secrets.CYPRESS_RECORD_KEY && env.CYPRESS_GROUP }}
-          # cypress env
-          ci-build-id: ${{ secrets.CYPRESS_RECORD_KEY && env.CYPRESS_BUILD_ID }}
-          tag: ${{ secrets.CYPRESS_RECORD_KEY && github.event_name }}
         env:
           # Needs to be prefixed with CYPRESS_
           CYPRESS_BRANCH: ${{ env.BRANCH }}
-          # https://github.com/cypress-io/github-action/issues/124
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
           # Needed for some specific code workarounds
           TESTING: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          CYPRESS_BUILD_ID: ${{ github.sha }}-${{ github.run_number }}
-          CYPRESS_GROUP: Run ${{ matrix.containers == 'component' && 'component' || 'E2E' }}
+          # cypress-split picks this runner's share of the specs
+          SPLIT: ${{ strategy.job-total }}
+          SPLIT_INDEX: ${{ strategy.job-index }}
 
       - name: Upload snapshots
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -147,7 +143,7 @@ jobs:
 
       - name: Extract NC logs
         if: failure() && matrix.containers != 'component'
-        run: docker logs nextcloud-cypress-tests_${{ env.APP_NAME }} > nextcloud.log
+        run: docker logs nextcloud-e2e-test-server_${{ env.APP_NAME }} > nextcloud.log
 
       - name: Upload NC logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
`ubuntu-latest` jobs here land on both GitHub-hosted runners and the self-hosted `garm-*` runners, and those currently run different Ubuntu point releases (24.04.5 vs 24.04.4). Cypress Cloud refuses to parallelize a run whose machines report different OS versions (`parallel-group-params-mismatch`), so the mismatched runners stop before running any spec and the job fails with "Could not find Cypress test run results". See runners 1 and 3 in https://github.com/nextcloud/groupfolders/actions/runs/34579398382.

`cypress.config.ts` already registers `cypress-split`, so each runner now picks its share of the specs from `SPLIT`/`SPLIT_INDEX`, the same way deck and text do. The trade-off is that runs are no longer recorded to Cypress Cloud (no dashboard or Test Replay).

The "Extract NC logs" step also looked for `nextcloud-cypress-tests_groupfolders`, but `@nextcloud/e2e-test-server` 0.4.0 names the container `nextcloud-e2e-test-server_groupfolders`, so logs were never uploaded on failure.

Unrelated to this change: "Correctly moves versions when user moves the containing folder out of the groupfolder" is currently flaky on master and stable34 as well.
